### PR TITLE
fix 'capnp id' version string

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -106,8 +106,7 @@ public:
   }
 
   kj::MainFunc getGenIdMain() {
-    return kj::MainBuilder(
-          context, "Cap'n Proto multi-tool 0.2",
+    return kj::MainBuilder(context, VERSION_STRING,
           "Generates a new 64-bit unique ID for use in a Cap'n Proto schema.")
         .callAfterParsing(KJ_BIND_METHOD(*this, generateId))
         .build();


### PR DESCRIPTION
Before this patch, `capnp id` reports its version as "0.2":
```
$ capnp id --version
Cap'n Proto multi-tool 0.2
```