### PR TITLE
MSVS 2015 CTP5 Win64 warning fixes - explicit casts, remove unused list....

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -6,7 +6,6 @@ set(capnp_sources_lite
   blob.c++
   arena.c++
   layout.c++
-  list.c++
   any.c++
   message.c++
   schema.capnp.c++

--- a/c++/src/capnp/any-test.c++
+++ b/c++/src/capnp/any-test.c++
@@ -148,7 +148,7 @@ TEST(Any, AnyStruct) {
     MallocMessageBuilder b2;
     auto root2 = b2.getRoot<test::TestAnyPointer>();
     auto sb = root2.getAnyPointerField().initAsAnyStruct(
-        r.getDataSection().size() / 8, r.getPointerSection().size());
+        static_cast<uint>(r.getDataSection().size() / 8), static_cast<uint>(r.getPointerSection().size()));
 
     EXPECT_EQ(48, sb.getDataSection().size());
     EXPECT_EQ(20, sb.getPointerSection().size());

--- a/c++/src/capnp/arena.c++
+++ b/c++/src/capnp/arena.c++
@@ -224,7 +224,7 @@ SegmentBuilder* BuilderArena::addSegmentInternal(kj::ArrayPtr<T> content) {
   }
 
   kj::Own<SegmentBuilder> newBuilder = kj::heap<SegmentBuilder>(
-      this, SegmentId(segmentState->builders.size() + 1), content, &this->dummyLimiter);
+      this, SegmentId(static_cast<int>(segmentState->builders.size()) + 1), content, &this->dummyLimiter);
   SegmentBuilder* result = newBuilder.get();
   segmentState->builders.add(kj::mv(newBuilder));
 

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -373,7 +373,7 @@ inline const word* SegmentReader::getStartPtr() { return ptr.begin(); }
 inline WordCount SegmentReader::getOffsetTo(const word* ptr) {
   return intervalLength(this->ptr.begin(), ptr);
 }
-inline WordCount SegmentReader::getSize() { return ptr.size() * WORDS; }
+inline WordCount SegmentReader::getSize() { return static_cast<WordCount>(ptr.size()) * WORDS; }
 inline kj::ArrayPtr<const word> SegmentReader::getArray() { return ptr; }
 inline void SegmentReader::unread(WordCount64 amount) { readLimiter->unread(amount); }
 

--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -1595,7 +1595,7 @@ TEST(Encoding, NameAnnotation) {
   EXPECT_EQ(true, root.getGoodFieldName());
   EXPECT_TRUE(root.isGoodFieldName());
 
-  root.setBar(0xff);
+  root.setBar(static_cast<int8_t>(0xff));
   EXPECT_FALSE(root.isGoodFieldName());
 
   root.setAnotherGoodFieldName(test::RenamedStruct::RenamedEnum::QUX);

--- a/c++/src/capnp/endian.h
+++ b/c++/src/capnp/endian.h
@@ -215,8 +215,8 @@ public:
   KJ_ALWAYS_INLINE(void set(T newValue)) {
     uint16_t raw;
     memcpy(&raw, &newValue, sizeof(T));
-    bytes[0] = raw;
-    bytes[1] = raw >> 8;
+    bytes[0] = static_cast<uint8_t>(raw);
+    bytes[1] = static_cast<uint8_t>(raw >> 8);
   }
 
 private:
@@ -273,14 +273,14 @@ public:
   KJ_ALWAYS_INLINE(void set(T newValue)) {
     uint64_t raw;
     memcpy(&raw, &newValue, sizeof(T));
-    bytes[0] = raw;
-    bytes[1] = raw >> 8;
-    bytes[2] = raw >> 16;
-    bytes[3] = raw >> 24;
-    bytes[4] = raw >> 32;
-    bytes[5] = raw >> 40;
-    bytes[6] = raw >> 48;
-    bytes[7] = raw >> 56;
+    bytes[0] = static_cast<uint8_t>(raw);
+    bytes[1] = static_cast<uint8_t>(raw >> 8);
+    bytes[2] = static_cast<uint8_t>(raw >> 16);
+    bytes[3] = static_cast<uint8_t>(raw >> 24);
+    bytes[4] = static_cast<uint8_t>(raw >> 32);
+    bytes[5] = static_cast<uint8_t>(raw >> 40);
+    bytes[6] = static_cast<uint8_t>(raw >> 48);
+    bytes[7] = static_cast<uint8_t>(raw >> 56);
   }
 
 private:

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -123,7 +123,7 @@ struct WirePointer {
     KJ_DREQUIRE(segment->containsInterval(
         reinterpret_cast<word*>(this), reinterpret_cast<word*>(this + 1)));
     KJ_DREQUIRE(segment->containsInterval(target, target));
-    offsetAndKind.set(((target - reinterpret_cast<word*>(this) - 1) << 2) | kind);
+    offsetAndKind.set(static_cast<uint32_t>(((target - reinterpret_cast<word*>(this) - 1) << 2) | kind));
   }
   KJ_ALWAYS_INLINE(void setKindWithZeroOffset(Kind kind)) {
     offsetAndKind.set(kind);
@@ -772,9 +772,9 @@ struct WireHelpers {
           case ElementSize::TWO_BYTES:
           case ElementSize::FOUR_BYTES:
           case ElementSize::EIGHT_BYTES: {
-            WordCount wordCount = roundBitsUpToWords(
+            WordCount wordCount = static_cast<WordCount>(roundBitsUpToWords(
                 ElementCount64(src->listRef.elementCount()) *
-                dataBitsPerElement(src->listRef.elementSize()));
+                dataBitsPerElement(src->listRef.elementSize())));
             const word* srcPtr = src->target();
             word* dstPtr = allocate(dst, segment, wordCount, WirePointer::LIST, nullptr);
             memcpy(dstPtr, srcPtr, wordCount * BYTES_PER_WORD / BYTES);
@@ -1006,7 +1006,7 @@ struct WireHelpers {
     auto step = (dataSize + pointerCount * BITS_PER_POINTER) / ELEMENTS;
 
     // Calculate size of the list.
-    WordCount wordCount = roundBitsUpToWords(ElementCount64(elementCount) * step);
+    WordCount wordCount = static_cast<WordCount>(roundBitsUpToWords(ElementCount64(elementCount) * step));
 
     // Allocate the list.
     word* ptr = allocate(ref, segment, wordCount, WirePointer::LIST, orphanArena);
@@ -1414,7 +1414,7 @@ struct WireHelpers {
   static KJ_ALWAYS_INLINE(SegmentAnd<Text::Builder> setTextPointer(
       WirePointer* ref, SegmentBuilder* segment, Text::Reader value,
       BuilderArena* orphanArena = nullptr)) {
-    auto allocation = initTextPointer(ref, segment, value.size() * BYTES, orphanArena);
+    auto allocation = initTextPointer(ref, segment, static_cast<ByteCount>(value.size()) * BYTES, orphanArena);
     memcpy(allocation.value.begin(), value.begin(), value.size());
     return allocation;
   }
@@ -1465,7 +1465,7 @@ struct WireHelpers {
   static KJ_ALWAYS_INLINE(SegmentAnd<Data::Builder> setDataPointer(
       WirePointer* ref, SegmentBuilder* segment, Data::Reader value,
       BuilderArena* orphanArena = nullptr)) {
-    auto allocation = initDataPointer(ref, segment, value.size() * BYTES, orphanArena);
+    auto allocation = initDataPointer(ref, segment, static_cast<ByteCount>(value.size()) * BYTES, orphanArena);
     memcpy(allocation.value.begin(), value.begin(), value.size());
     return allocation;
   }
@@ -1502,7 +1502,7 @@ struct WireHelpers {
   static SegmentAnd<word*> setStructPointer(
       SegmentBuilder* segment, WirePointer* ref, StructReader value,
       BuilderArena* orphanArena = nullptr) {
-    WordCount dataSize = roundBitsUpToWords(value.dataSize);
+    WordCount dataSize = static_cast<WordCount>(roundBitsUpToWords(value.dataSize));
     WordCount totalSize = dataSize + value.pointerCount * WORDS_PER_POINTER;
 
     word* ptr = allocate(ref, segment, totalSize, WirePointer::STRUCT, orphanArena);
@@ -1538,7 +1538,7 @@ struct WireHelpers {
   static SegmentAnd<word*> setListPointer(
       SegmentBuilder* segment, WirePointer* ref, ListReader value,
       BuilderArena* orphanArena = nullptr) {
-    WordCount totalSize = roundBitsUpToWords(value.elementCount * value.step);
+    WordCount totalSize = static_cast<WordCount>(roundBitsUpToWords(value.elementCount * value.step));
 
     if (value.elementSize != ElementSize::INLINE_COMPOSITE) {
       // List of non-structs.
@@ -1565,7 +1565,7 @@ struct WireHelpers {
                            orphanArena);
       ref->listRef.setInlineComposite(totalSize);
 
-      WordCount dataSize = roundBitsUpToWords(value.structDataSize);
+      WordCount dataSize = static_cast<WordCount>(roundBitsUpToWords(value.structDataSize));
       WirePointerCount pointerCount = value.structPointerCount;
 
       WirePointer* tag = reinterpret_cast<WirePointer*>(ptr);
@@ -2668,12 +2668,12 @@ OrphanBuilder OrphanBuilder::referenceExternalData(BuilderArena* arena, Data::Re
   KJ_REQUIRE(reinterpret_cast<uintptr_t>(data.begin()) % sizeof(void*) == 0,
              "Cannot referenceExternalData() that is not aligned.");
 
-  auto wordCount = WireHelpers::roundBytesUpToWords(data.size() * BYTES);
+  auto wordCount = WireHelpers::roundBytesUpToWords(static_cast<ByteCount>(data.size()) * BYTES);
   kj::ArrayPtr<const word> words(reinterpret_cast<const word*>(data.begin()), wordCount / WORDS);
 
   OrphanBuilder result;
   result.tagAsPtr()->setKindForOrphan(WirePointer::LIST);
-  result.tagAsPtr()->listRef.set(ElementSize::BYTE, data.size() * ELEMENTS);
+  result.tagAsPtr()->listRef.set(ElementSize::BYTE, static_cast<ElementCount>(data.size()) * ELEMENTS);
   result.segment = arena->addExternalSegment(words);
 
   // const_cast OK here because we will check whether the segment is writable when we try to get

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -378,7 +378,7 @@ struct List<List<T>, Kind::LIST> {
     }
     void set(uint index, std::initializer_list<ReaderFor<T>> value) {
       KJ_IREQUIRE(index < size());
-      auto l = init(index, value.size());
+      auto l = init(index, static_cast<uint>(value.size()));
       uint i = 0;
       for (auto& element: value) {
         l.set(i++, element);

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -155,7 +155,7 @@ MallocMessageBuilder::MallocMessageBuilder(
 
 MallocMessageBuilder::MallocMessageBuilder(
     kj::ArrayPtr<word> firstSegment, AllocationStrategy allocationStrategy)
-    : nextSize(firstSegment.size()), allocationStrategy(allocationStrategy),
+    : nextSize(static_cast<uint>(firstSegment.size())), allocationStrategy(allocationStrategy),
       ownFirstSegment(false), returnedFirstSegment(false), firstSegment(firstSegment.begin()) {
   KJ_REQUIRE(firstSegment.size() > 0, "First segment size must be non-zero.");
 

--- a/c++/src/capnp/pointer-helpers.h
+++ b/c++/src/capnp/pointer-helpers.h
@@ -79,7 +79,7 @@ struct PointerHelpers<List<T>, Kind::LIST> {
     builder.setList(value.reader);
   }
   static void set(PointerBuilder builder, kj::ArrayPtr<const ReaderFor<T>> value) {
-    auto l = init(builder, value.size());
+    auto l = init(builder, static_cast<uint>(value.size()));
     uint i = 0;
     for (auto& element: value) {
       l.set(i++, element);

--- a/c++/src/capnp/serialize-packed.c++
+++ b/c++/src/capnp/serialize-packed.c++
@@ -140,7 +140,7 @@ size_t PackedInputStream::tryRead(void* dst, size_t minBytes, size_t maxBytes) {
         return out - reinterpret_cast<uint8_t*>(dst);
       }
 
-      uint inRemaining = BUFFER_REMAINING;
+      uint inRemaining = static_cast<uint>(BUFFER_REMAINING);
       if (inRemaining >= runLength) {
         // Fast path.
         memcpy(out, in, runLength);
@@ -266,7 +266,7 @@ void PackedInputStream::skip(size_t bytes) {
 
       bytes -= runLength;
 
-      uint inRemaining = BUFFER_REMAINING;
+      uint inRemaining = static_cast<uint>(BUFFER_REMAINING);
       if (inRemaining > runLength) {
         // Fast path.
         in += runLength;
@@ -365,7 +365,7 @@ void PackedOutputStream::write(const void* src, size_t size) {
       }
 
       // Write the count.
-      *out++ = inWord - reinterpret_cast<const uint64_t*>(in);
+      *out++ = static_cast<uint8_t>(inWord - reinterpret_cast<const uint64_t*>(in));
 
       // Advance input.
       in = reinterpret_cast<const uint8_t*>(inWord);
@@ -405,8 +405,8 @@ void PackedOutputStream::write(const void* src, size_t size) {
       }
 
       // Write the count.
-      uint count = in - runStart;
-      *out++ = count / sizeof(word);
+      uint count = static_cast<uint>(in - runStart);
+      *out++ = static_cast<uint8_t>(count / sizeof(word));
 
       if (count <= reinterpret_cast<uint8_t*>(buffer.end()) - out) {
         // There's enough space to memcpy.

--- a/c++/src/capnp/serialize-test.c++
+++ b/c++/src/capnp/serialize-test.c++
@@ -324,10 +324,14 @@ int mkstemp(char *tpl) {
   char* end = tpl + strlen(tpl);
   while (end > tpl && *(end-1) == 'X') --end;
 
-  for (;;) {
-    KJ_ASSERT(_mktemp(tpl) == tpl);
+#pragma warning(push)
+#pragma warning(disable: 4996)	// avoid microsoft crt warning of unsafe functions
 
-    int fd = open(tpl, O_RDWR | O_CREAT | O_EXCL | O_TEMPORARY | O_BINARY, 0700);
+  for (;;) {
+    KJ_ASSERT(mktemp(tpl) == tpl);
+
+	int fd = _open(tpl, O_RDWR | O_CREAT | O_EXCL | O_TEMPORARY | O_BINARY, 0700);
+
     if (fd >= 0) {
       return fd;
     }
@@ -339,6 +343,7 @@ int mkstemp(char *tpl) {
 
     memset(end, 'X', strlen(end));
   }
+#pragma warning(pop)
 }
 #endif
 
@@ -370,7 +375,7 @@ TEST(Serialize, FileDescriptors) {
     writeMessageToFd(tmpfile.get(), builder);
   }
 
-  lseek(tmpfile, 0, SEEK_SET);
+  _lseek(tmpfile, 0, SEEK_SET);
 
   {
     StreamFdMessageReader reader(tmpfile.get());

--- a/c++/src/capnp/serialize.c++
+++ b/c++/src/capnp/serialize.c++
@@ -106,10 +106,10 @@ kj::Array<word> messageToFlatArray(kj::ArrayPtr<const kj::ArrayPtr<const word>> 
   // We write the segment count - 1 because this makes the first word zero for single-segment
   // messages, improving compression.  We don't bother doing this with segment sizes because
   // one-word segments are rare anyway.
-  table[0].set(segments.size() - 1);
+  table[0].set(static_cast<uint32_t>(segments.size()) - 1);
 
   for (uint i = 0; i < segments.size(); i++) {
-    table[i + 1].set(segments[i].size());
+    table[i + 1].set(static_cast<uint32_t>(segments[i].size()));
   }
 
   if (segments.size() % 2 == 0) {
@@ -259,9 +259,9 @@ void writeMessage(kj::OutputStream& output, kj::ArrayPtr<const kj::ArrayPtr<cons
   // We write the segment count - 1 because this makes the first word zero for single-segment
   // messages, improving compression.  We don't bother doing this with segment sizes because
   // one-word segments are rare anyway.
-  table[0].set(segments.size() - 1);
+  table[0].set(static_cast<uint32_t>(segments.size()) - 1);
   for (uint i = 0; i < segments.size(); i++) {
-    table[i + 1].set(segments[i].size());
+    table[i + 1].set(static_cast<uint32_t>(segments[i].size()));
   }
   if (segments.size() % 2 == 0) {
     // Set padding byte.

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -275,7 +275,7 @@ TEST(Common, MinMaxValue) {
   EXPECT_EQ(0, uint8_t(minValue));
   EXPECT_EQ(-0x8000, int16_t(minValue));
   EXPECT_EQ(0, uint16_t(minValue));
-  EXPECT_EQ(-0x80000000, int32_t(minValue));
+  EXPECT_EQ(static_cast<int32_t>(-0x80000000ll), int32_t(minValue));
   EXPECT_EQ(0, uint32_t(minValue));
   EXPECT_EQ(-0x8000000000000000ll, int64_t(minValue));
   EXPECT_EQ(0, uint64_t(minValue));

--- a/c++/src/kj/miniposix.h
+++ b/c++/src/kj/miniposix.h
@@ -49,10 +49,10 @@ namespace miniposix {
 typedef int ssize_t;
 
 inline ssize_t read(int fd, void* buffer, size_t size) {
-  return ::_read(fd, buffer, size);
+  return ::_read(fd, buffer, static_cast<unsigned int>(size));
 }
 inline ssize_t write(int fd, const void* buffer, size_t size) {
-  return ::_write(fd, buffer, size);
+  return ::_write(fd, buffer, static_cast<unsigned int>(size));
 }
 inline int close(int fd) {
   return ::_close(fd);

--- a/c++/src/kj/mutex.c++
+++ b/c++/src/kj/mutex.c++
@@ -286,7 +286,7 @@ void Once::runOnce(Initializer& init) {
 
 bool Once::isInitialized() noexcept {
   BOOL junk;
-  return InitOnceBeginInitialize(&coercedInitOnce, INIT_ONCE_CHECK_ONLY, &junk, nullptr);
+  return 0 != InitOnceBeginInitialize(&coercedInitOnce, INIT_ONCE_CHECK_ONLY, &junk, nullptr);
 }
 
 void Once::reset() {


### PR DESCRIPTION
Fixes for Visual studio warnings on x64
- One outstanding warning in capnp\encoding-test.c++ line 1598 - truncated value trying to fit 0xFF into an int8_t - not sure how to appropriately tweak the test parameter to avoid truncation