### PR TITLE
Add abortRead to AyncIoStream

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -180,6 +180,12 @@ public:
     KJ_SYSCALL(shutdown(fd, SHUT_WR));
   }
 
+  void abortRead() override {
+    // There's no legitimate way to get an AsyncStreamFd that isn't a socket through the
+    // UnixAsyncIoProvider interface.
+    KJ_SYSCALL(shutdown(fd, SHUT_RD));
+  }
+
   void getsockopt(int level, int option, void* value, uint* length) override {
     socklen_t socklen = *length;
     KJ_SYSCALL(::getsockopt(fd, level, option, value, &socklen));

--- a/c++/src/kj/async-io.h
+++ b/c++/src/kj/async-io.h
@@ -64,6 +64,10 @@ public:
   virtual void shutdownWrite() = 0;
   // Cleanly shut down just the write end of the stream, while keeping the read end open.
 
+  virtual void abortRead() {}
+  // Similar to shutdownWrite, but this will shut down the read end of the stream, and should only
+  // be called when an error has occurred.
+
   virtual void getsockopt(int level, int option, void* value, uint* length);
   virtual void setsockopt(int level, int option, const void* value, uint length);
   // Corresponds to getsockopt() and setsockopt() syscalls. Will throw an "unimplemented" exception


### PR DESCRIPTION
This is analogous to shutdownWrite, but for the read end of the stream

Should the default implementation raise a KJ_UNIMPLEMENTED instead of doing nothing? Making it pure virtual breaks anyone who has already inherited from AsynIoStream (ie. node-capnp).