### PR TITLE
zero warnings: use KJ_UNUSED for unused constexpr & local vars

### DIFF
--- a/c++/src/kj/arena.c++
+++ b/c++/src/kj/arena.c++
@@ -66,7 +66,7 @@ void Arena::cleanup() {
 
 namespace {
 
-constexpr bool isPowerOfTwo(size_t value) {
+constexpr bool KJ_UNUSED isPowerOfTwo(size_t value) {
   return (value & (value - 1)) == 0;
 }
 

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -252,7 +252,7 @@ char* DoubleToBuffer(double value, char* buffer) {
     return buffer;
   }
 
-  int snprintf_result =
+  int snprintf_result KJ_UNUSED =
     snprintf(buffer, kDoubleToBufferSize, "%.*g", DBL_DIG, value);
 
   // The snprintf should never overflow because the buffer is significantly
@@ -267,7 +267,7 @@ char* DoubleToBuffer(double value, char* buffer) {
   // truncated to a double.
   volatile double parsed_value = strtod(buffer, NULL);
   if (parsed_value != value) {
-    int snprintf_result2 =
+    int snprintf_result2 KJ_UNUSED =
       snprintf(buffer, kDoubleToBufferSize, "%.*g", DBL_DIG+2, value);
 
     // Should never overflow; see above.
@@ -311,7 +311,7 @@ char* FloatToBuffer(float value, char* buffer) {
     return buffer;
   }
 
-  int snprintf_result =
+  int snprintf_result KJ_UNUSED =
     snprintf(buffer, kFloatToBufferSize, "%.*g", FLT_DIG, value);
 
   // The snprintf should never overflow because the buffer is significantly
@@ -320,7 +320,7 @@ char* FloatToBuffer(float value, char* buffer) {
 
   float parsed_value;
   if (!safe_strtof(buffer, &parsed_value) || parsed_value != value) {
-    int snprintf_result2 =
+    int snprintf_result2 KJ_UNUSED =
       snprintf(buffer, kFloatToBufferSize, "%.*g", FLT_DIG+2, value);
 
     // Should never overflow; see above.


### PR DESCRIPTION
one function in arena.c++ and several snprintf_result local vars
in string.c++ get optimized away because they're only used in
KJ_DASSERT() invocations.

tthis patch thus identifies those unused declarations with KJ_UNUSED