### PR TITLE
Hardcode /bin/cat output option for `capnp compile`.

### DIFF
--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -242,10 +242,12 @@ public:
     builder.addOptionWithArg({'o', "output"}, KJ_BIND_METHOD(*this, addOutput), "<lang>[:<dir>]",
                              "Generate source code for language <lang> in directory <dir> "
                              "(default: current directory).  <lang> actually specifies a plugin "
-                             "to use.  If <lang> is a simple word, the compiler for a plugin "
+                             "to use.  If <lang> is a simple word, the compiler searches for a plugin "
                              "called 'capnpc-<lang>' in $PATH.  If <lang> is a file path "
                              "containing slashes, it is interpreted as the exact plugin "
-                             "executable file name, and $PATH is not searched.")
+                             "executable file name, and $PATH is not searched.  The special case of "
+                             "'/bin/cat' is hardcoded to dump the request to standard output, as "
+                             "this is a common operation and /bin/cat is not available on all systems.")
            .addOptionWithArg({"src-prefix"}, KJ_BIND_METHOD(*this, addSourcePrefix), "<prefix>",
                              "If a file specified for compilation starts with <prefix>, remove "
                              "the prefix for the purpose of deciding the names of output files.  "
@@ -440,6 +442,11 @@ public:
     }
 
     for (auto& output: outputs) {
+      if (kj::str(output.name) == "/bin/cat") {
+        writeMessageToFd(STDOUT_FILENO, message);
+        continue;
+      }
+
       int pipeFds[2];
       KJ_SYSCALL(pipe(pipeFds));
 

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -245,9 +245,8 @@ public:
                              "to use.  If <lang> is a simple word, the compiler searches for a plugin "
                              "called 'capnpc-<lang>' in $PATH.  If <lang> is a file path "
                              "containing slashes, it is interpreted as the exact plugin "
-                             "executable file name, and $PATH is not searched.  The special case of "
-                             "'/bin/cat' is hardcoded to dump the request to standard output, as "
-                             "this is a common operation and /bin/cat is not available on all systems.")
+                             "executable file name, and $PATH is not searched.  If <lang> is '-', "
+                             "the compiler dumps the request to standard output.")
            .addOptionWithArg({"src-prefix"}, KJ_BIND_METHOD(*this, addSourcePrefix), "<prefix>",
                              "If a file specified for compilation starts with <prefix>, remove "
                              "the prefix for the purpose of deciding the names of output files.  "
@@ -442,7 +441,7 @@ public:
     }
 
     for (auto& output: outputs) {
-      if (kj::str(output.name) == "/bin/cat") {
+      if (kj::str(output.name) == "-") {
         writeMessageToFd(STDOUT_FILENO, message);
         continue;
       }


### PR DESCRIPTION
In the typical build process for a Rust project that uses Cap'n Proto code generation, we have access to capnpc-rust as a library, but not as an executable. (See [this thread](https://github.com/rust-lang/cargo/issues/872) for some discussion.)  The `compile()` function, defined [here](https://github.com/dwrensha/capnpc-rust/blob/master/src/lib.rs), is designed to handle this case. It spawns a child that runs `capnp compile -o/bin/cat`, and forwards the child's stdout to the usual codegen procedure. Things get more complicated when `/bin/cat` is not present, like on Windows, or even when it is not in its usual location (https://github.com/dwrensha/capnpc-rust/issues/9). Adding an option for `capnp compile` to directly write to stdout should make things simpler.

I had thought that "-o -" would be a nice way to specify this option, but I've found that that would interact weirdly with option parsing. For instance, `capnp compile -o -:/tmp` would give an error `-o: missing argument`.