### PR TITLE
Fix incorrect, confusing comment.

### DIFF
--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -54,10 +54,7 @@ public:
   // attempt a non-blocking read or may just return zero.  To force a read, use a non-zero minBytes.
   // To detect EOF without throwing an exception, use tryRead().
   //
-  // Cap'n Proto never asks for more bytes than it knows are part of the message.  Therefore, if
-  // the InputStream happens to know that the stream will never reach maxBytes -- even if it has
-  // reached minBytes -- it should throw an exception to avoid wasting time processing an incomplete
-  // message.  If it can't even reach minBytes, it MUST throw an exception, as the caller is not
+  // If the InputStream can't produce minBytes, it MUST throw an exception, as the caller is not
   // expected to understand how to deal with partial reads.
 
   virtual size_t tryRead(void* buffer, size_t minBytes, size_t maxBytes) = 0;


### PR DESCRIPTION
The comment on `InputStream::read()` describes a contract that would cause problems if actually followed. In particular, a `BufferedInputStreamWrapper` can issue a `read()` request to its inner stream with `maxBytes` reaching past the end of a message. This occurs [here](https://github.com/sandstorm-io/capnproto/blob/b059922062be4d1a500b12748760507c0b60e0d6/c%2B%2B/src/kj/io.c%2B%2B#L106), where the stream refills its buffer. It would be incorrect for the inner stream to throw a exception just because `maxBytes` could not be reached in this case.