### PR TITLE
Canonicalize NaN on the hppa architecture

### DIFF
--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -39,7 +39,7 @@
 #include "blob.h"
 #include "endian.h"
 
-#if __mips__ && !defined(CAPNP_CANONICALIZE_NAN)
+#if (defined(__mips__) || defined(__hppa__)) && !defined(CAPNP_CANONICALIZE_NAN)
 #define CAPNP_CANONICALIZE_NAN 1
 // Explicitly detect NaNs and canonicalize them to the quiet NaN value as would be returned by
 // __builtin_nan("") on systems implementing the IEEE-754 recommended (but not required) NaN


### PR DESCRIPTION
Original credit to John David Anlin on [Debian bug 781787](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=781787) who noticed the hppa architecture was affected in the same way as mips wrt NaN quirks. In his own words:

> The hppa and mips architecture have the same nan format (i.e., quiet and signalling nans are
> different from x86, etc).  With the attached change, capnproto builds successfully on hppa.  See:
> http://buildd.debian-ports.org/status/fetch.php?pkg=capnproto&arch=hppa&ver=0.4.1-3&stamp=1428027386
