### PR TITLE
Improvements to syntax highlighting

### DIFF
--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -106,25 +106,25 @@
         <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
       </context>
     </contexts>
+    <itemDatas>
+      <!-- Since my highlighting approach is different from most programming languages, the contexts
+          don't fit nicely into the standard set, so I have to define colors explicitly.  A couple
+          of these, like "keyword" and "type", could be mapped to dsKeyword and dsDataType, but
+          there's a chance the user has mapped the colors for those things to things that would
+          conflict with the manually-defined colors here, which would probably be even more annoying
+          than having the colors be inconsitent from other languages.  So, I use manual colors for
+          everything, except comments, which I figure are less likely to have this problem. -->
+      <itemData name="Normal"       defStyleNum="dsNormal"/>
+      <itemData name="Keyword"      defStyleNum="dsOthers" color="#000099" bold="1"/>
+      <itemData name="Id"           defStyleNum="dsOthers" color="#0099FF"/>
+      <itemData name="Annotation"   defStyleNum="dsOthers" color="#999900"/>
+      <itemData name="Type"         defStyleNum="dsOthers" color="#009900"/>
+      <itemData name="KeyType"      defStyleNum="dsOthers" color="#009900" bold="1"/>
+      <itemData name="Value"        defStyleNum="dsOthers" color="#003399"/>
+      <itemData name="Comment"      defStyleNum="dsComment"/>
+      <itemData name="Symbol"       defStyleNum="dsOthers" bold="1"/>
+    </itemDatas>
   </highlighting>
-  <itemDatas>
-    <!-- Since my highlighting approach is different from most programming languages, the contexts
-         don't fit nicely into the standard set, so I have to define colors explicitly.  A couple
-         of these, like "keyword" and "type", could be mapped to dsKeyword and dsDataType, but
-         there's a chance the user has mapped the colors for those things to things that would
-         conflict with the manually-defined colors here, which would probably be even more annoying
-         than having the colors be inconsitent from other languages.  So, I use manual colors for
-         everything, except comments, which I figure are less likely to have this problem. -->
-    <itemData name="Normal"       defStyleNum="dsNormal"/>
-    <itemData name="Keyword"      defStyleNum="dsOthers" color="#000099" bold="1"/>
-    <itemData name="Id"           defStyleNum="dsOthers" color="#0099FF"/>
-    <itemData name="Annotation"   defStyleNum="dsOthers" color="#999900"/>
-    <itemData name="Type"         defStyleNum="dsOthers" color="#009900"/>
-    <itemData name="KeyType"      defStyleNum="dsOthers" color="#009900" bold="1"/>
-    <itemData name="Value"        defStyleNum="dsOthers" color="#003399"/>
-    <itemData name="Comment"      defStyleNum="dsComment"/>
-    <itemData name="Symbol"       defStyleNum="dsOthers" bold="1"/>
-  </itemDatas>
   <general>
     <comments><comment name="singleLine" start="#"/></comments>
     <keywords casesensitive="1"/>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -112,19 +112,10 @@
       <context name="Annotation" attribute="Annotation" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
-        <AnyChar attribute="Annotation" context="ParenAnnotation" String="(["/>
+        <AnyChar attribute="Value" context="ParenValue" String="(["/>
         <RegExpr attribute="Annotation" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};:=$)," lookAhead="true"/>
-      </context>
-      <context name="ParenAnnotation" attribute="Annotation" lineEndContext="#stay">
-        <DetectChar attribute="Comment" context="Comment" char="#"/>
-        <DetectChar attribute="String" context="String" char="&quot;"/>
-        <AnyChar attribute="Annotation" context="ParenAnnotation" String="(["/>
-        <AnyChar attribute="Annotation" context="#pop" String=")]"/>
-        <AnyChar attribute="Symbol" context="#pop" String="{};" lookAhead="true"/>
-        <RegExpr attribute="Annotation" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
-        <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
       </context>
     </contexts>
     <itemDatas>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -58,8 +58,13 @@
         <AnyChar attribute="Symbol" context="#stay" String="!%&amp;*+-./&lt;=&gt;?^|~;[]()"/>
       </context>
       <context name="Comment" attribute="Comment" lineEndContext="#pop"></context>
+      <context name="String" attribute="String" lineEndContext="#stay">
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
       <context name="Value" attribute="Value" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
+        <keyword String="keyword" context="#stay" attribute="Keyword" />
         <AnyChar attribute="Value" context="ParenValue" String="(["/>
         <RegExpr attribute="Value" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Value" context="#stay" String="'([^'\\]|\\.)*'"/>
@@ -75,6 +80,7 @@
       </context>
       <context name="Type" attribute="Type" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
         <AnyChar attribute="Type" context="ParenType" String="(["/>
         <keyword String="type" context="#stay" attribute="KeyType" />
         <RegExpr attribute="Type" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
@@ -92,6 +98,7 @@
       </context>
       <context name="Annotation" attribute="Annotation" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
         <AnyChar attribute="Annotation" context="ParenAnnotation" String="(["/>
         <RegExpr attribute="Annotation" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
@@ -99,6 +106,7 @@
       </context>
       <context name="ParenAnnotation" attribute="Annotation" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
         <AnyChar attribute="Annotation" context="ParenAnnotation" String="(["/>
         <AnyChar attribute="Annotation" context="#pop" String=")]"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};" lookAhead="true"/>
@@ -122,6 +130,7 @@
       <itemData name="KeyType"      defStyleNum="dsOthers" color="#009900" bold="1"/>
       <itemData name="Value"        defStyleNum="dsOthers" color="#003399"/>
       <itemData name="Comment"      defStyleNum="dsComment"/>
+      <itemData name="String"       defStyleNum="dsString"/>
       <itemData name="Symbol"       defStyleNum="dsOthers" bold="1"/>
     </itemDatas>
   </highlighting>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -63,6 +63,10 @@
         <DetectChar attribute="String" context="#pop" char="&quot;"/>
       </context>
       <context name="Value" attribute="Value" lineEndContext="#stay">
+        <StringDetect String="0x&quot;" attribute="String" context="String"/>
+        <HlCHex attribute="Hex" context="#stay"/>
+        <Float attribute="Float" context="#stay"/>
+        <Int attribute="Decimal" context="#stay"/>
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
@@ -73,11 +77,18 @@
       </context>
       <context name="ParenValue" attribute="Value" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <StringDetect String="0x&quot;" attribute="String" context="String"/>
+        <DetectChar attribute="String" context="String" char="&quot;"/>
+        <HlCHex attribute="Hex" context="#stay"/>
+        <Float attribute="Float" context="#stay"/>
+        <Int attribute="Decimal" context="#stay"/>
+        <keyword String="keyword" context="#stay" attribute="Keyword" />
         <AnyChar attribute="Value" context="ParenValue" String="(["/>
         <AnyChar attribute="Value" context="#pop" String=")]"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};" lookAhead="true"/>
         <RegExpr attribute="Value" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Value" context="#stay" String="'([^'\\]|\\.)*'"/>
+        <DetectChar attribute="Symbol" context="Value" char="="/>
       </context>
       <context name="Type" attribute="Type" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
@@ -133,6 +144,9 @@
       <itemData name="Value"        defStyleNum="dsOthers" color="#003399"/>
       <itemData name="Comment"      defStyleNum="dsComment"/>
       <itemData name="String"       defStyleNum="dsString"/>
+      <itemData name="Float"        defStyleNum="dsFloat"/>
+      <itemData name="Hex"          defStyleNum="dsBaseN"/>
+      <itemData name="Decimal"      defStyleNum="dsDecVal"/>
       <itemData name="Symbol"       defStyleNum="dsOthers" bold="1"/>
     </itemDatas>
   </highlighting>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -25,6 +25,8 @@
       <item>group</item>
       <item>true</item>
       <item>false</item>
+      <item>file</item>
+      <item>field</item>
     </list>
     <list name="type">
       <item>Void</item>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -23,6 +23,8 @@
       <item>from</item>
       <item>fixed</item>
       <item>group</item>
+      <item>true</item>
+      <item>false</item>
     </list>
     <list name="type">
       <item>Void</item>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -72,7 +72,7 @@
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
-        <AnyChar attribute="Value" context="ParenValue" String="(["/>
+        <AnyChar attribute="Symbol" context="ParenValue" String="(["/>
         <RegExpr attribute="Value" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Value" context="#stay" String="'([^'\\]|\\.)*'"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};:=$)," lookAhead="true"/>
@@ -85,8 +85,8 @@
         <Float attribute="Float" context="#stay"/>
         <Int attribute="Decimal" context="#stay"/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
-        <AnyChar attribute="Value" context="ParenValue" String="(["/>
-        <AnyChar attribute="Value" context="#pop" String=")]"/>
+        <AnyChar attribute="Symbol" context="ParenValue" String="(["/>
+        <AnyChar attribute="Symbol" context="#pop" String=")]"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};" lookAhead="true"/>
         <RegExpr attribute="Value" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Value" context="#stay" String="'([^'\\]|\\.)*'"/>
@@ -95,7 +95,7 @@
       <context name="Type" attribute="Type" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
-        <AnyChar attribute="Type" context="ParenType" String="(["/>
+        <AnyChar attribute="Symbol" context="ParenType" String="(["/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
         <keyword String="type" context="#stay" attribute="KeyType" />
         <RegExpr attribute="Type" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
@@ -104,8 +104,8 @@
       </context>
       <context name="ParenType" attribute="Type" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
-        <AnyChar attribute="Type" context="ParenType" String="(["/>
-        <AnyChar attribute="Type" context="#pop" String=")]"/>
+        <AnyChar attribute="Symbol" context="ParenType" String="(["/>
+        <AnyChar attribute="Symbol" context="#pop" String=")]"/>
         <keyword String="type" context="#stay" attribute="KeyType" />
         <AnyChar attribute="Symbol" context="#pop" String="{};" lookAhead="true"/>
         <RegExpr attribute="Type" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
@@ -114,7 +114,7 @@
       <context name="Annotation" attribute="Annotation" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
-        <AnyChar attribute="Value" context="ParenValue" String="(["/>
+        <AnyChar attribute="Symbol" context="ParenValue" String="(["/>
         <RegExpr attribute="Annotation" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};:=$)," lookAhead="true"/>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -25,8 +25,6 @@
       <item>group</item>
       <item>true</item>
       <item>false</item>
-      <item>file</item>
-      <item>field</item>
     </list>
     <list name="type">
       <item>Void</item>
@@ -55,6 +53,7 @@
         <DetectChar attribute="Symbol" context="Value" char="="/>
         <DetectChar attribute="Symbol" context="Type" char=":"/>
         <DetectChar attribute="Annotation" context="Annotation" char="$"/>
+        <StringDetect String="annotation" attribute="Keyword" context="AnnotationDecl"/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
         <DetectChar attribute="Symbol" context="#stay" char="{" beginRegion="Brace1"/>
         <DetectChar attribute="Symbol" context="#stay" char="}" endRegion="Brace1"/>
@@ -118,6 +117,15 @@
         <RegExpr attribute="Annotation" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Annotation" context="#stay" String="'([^'\\]|\\.)*'"/>
         <AnyChar attribute="Symbol" context="#pop" String="{};:=$)," lookAhead="true"/>
+      </context>
+      <context name="AnnotationDecl" attribute="Annotation" lineEndContext="#stay">
+        <DetectChar attribute="Comment" context="Comment" char="#"/>
+        <keyword String="keyword" context="#stay" attribute="Keyword" />
+        <StringDetect String="field" attribute="Keyword" context="#stay"/>
+        <StringDetect String="file" attribute="Keyword" context="#stay"/>
+        <RegExpr attribute="Id" context="#stay" String="@(0x[0-9a-fA-F]+|[0-9]+)\b"/>
+        <AnyChar attribute="Symbol" context="#stay" String="([,"/>
+        <AnyChar attribute="Symbol" context="#pop" String="{};:=$)" lookAhead="true"/>
       </context>
     </contexts>
     <itemDatas>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -48,8 +48,8 @@
       <context name="Normal" attribute="Normal" lineEndContext="#stay">
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <RegExpr attribute="Id" context="#stay" String="@(0x[0-9a-fA-F]+|[0-9]+)\b"/>
-        <DetectChar attribute="Value" context="Value" char="="/>
-        <DetectChar attribute="Type" context="Type" char=":"/>
+        <DetectChar attribute="Symbol" context="Value" char="="/>
+        <DetectChar attribute="Symbol" context="Type" char=":"/>
         <DetectChar attribute="Annotation" context="Annotation" char="$"/>
         <keyword String="keyword" context="#stay" attribute="Keyword" />
         <DetectChar attribute="Symbol" context="#stay" char="{" beginRegion="Brace1"/>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -137,11 +137,11 @@
           than having the colors be inconsitent from other languages.  So, I use manual colors for
           everything, except comments, which I figure are less likely to have this problem. -->
       <itemData name="Normal"       defStyleNum="dsNormal"/>
-      <itemData name="Keyword"      defStyleNum="dsOthers" color="#000099" bold="1"/>
+      <itemData name="Keyword"      defStyleNum="dsKeyword"/>
       <itemData name="Id"           defStyleNum="dsOthers" color="#0099FF"/>
       <itemData name="Annotation"   defStyleNum="dsOthers" color="#999900"/>
-      <itemData name="Type"         defStyleNum="dsOthers" color="#009900"/>
-      <itemData name="KeyType"      defStyleNum="dsOthers" color="#009900" bold="1"/>
+      <itemData name="Type"         defStyleNum="dsDataType" />
+      <itemData name="KeyType"      defStyleNum="dsDataType" bold="1"/>
       <itemData name="Value"        defStyleNum="dsOthers" color="#003399"/>
       <itemData name="Comment"      defStyleNum="dsComment"/>
       <itemData name="String"       defStyleNum="dsString"/>

--- a/highlighting/qtcreator/capnp.xml
+++ b/highlighting/qtcreator/capnp.xml
@@ -22,10 +22,9 @@
       <item>with</item>
       <item>from</item>
       <item>fixed</item>
+      <item>group</item>
     </list>
     <list name="type">
-      <item>union</item>
-      <item>group</item>
       <item>Void</item>
       <item>Bool</item>
       <item>Int8</item>
@@ -82,6 +81,7 @@
         <DetectChar attribute="Comment" context="Comment" char="#"/>
         <DetectChar attribute="String" context="String" char="&quot;"/>
         <AnyChar attribute="Type" context="ParenType" String="(["/>
+        <keyword String="keyword" context="#stay" attribute="Keyword" />
         <keyword String="type" context="#stay" attribute="KeyType" />
         <RegExpr attribute="Type" context="#stay" String="&quot;([^&quot;\\]|\\.)*&quot;"/>
         <RegExpr attribute="Type" context="#stay" String="'([^'\\]|\\.)*'"/>


### PR DESCRIPTION
I split this up into lots of small commits to make it easier to review. It also contains the commit from #208 since I don't know how to make pull requests depend on each other (is this even possible?).

The commit `Highlight: Use default colors for keywords and types` conflicts with the comment regarding not using dsKeyword and dsDataType since I don't quite understand the problem described in the comment. Does this mean that some of the hardcoded colours would be the same as the ones for keywords or types? In Kate/KDevelop this is not a problem since the colours in the syntax highlighting definition are only a default an can be overridden per language in the settings dialog:
![settings](https://cloud.githubusercontent.com/assets/4019307/7760452/7e2e2782-0013-11e5-8341-435753936ee5.png)

I can also try and contribute this syntax highlighting file to upstream Kate I you don't mind that.


I tested the highlighting using this file: https://paste.kde.org/ptdamq4xz