### PR TITLE
Avoid incorrect library version with BSD sed

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -189,7 +189,7 @@ endif
 
 # Don't include security release in soname -- we want to replace old binaries
 # in this case.
-SO_VERSION = $(shell echo $(VERSION) | sed -re 's/^([0-9]+[.][0-9]+[.][0-9]+)([.][0-9]+)?(-.*)?$$/\1\3/g')
+SO_VERSION = $(shell echo $(VERSION) | $(ESED) -e 's/^([0-9]+[.][0-9]+[.][0-9]+)([.][0-9]+)?(-.*)?$$/\1\3/g')
 
 libkj_la_LIBADD = $(PTHREAD_LIBS)
 libkj_la_LDFLAGS = -release $(SO_VERSION) -no-undefined

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -52,6 +52,21 @@ AC_PROG_CXX
 AC_LANG([C++])
 AX_CXX_COMPILE_STDCXX_11
 
+AC_MSG_CHECKING([how to run sed with extended regex support])
+AS_IF(
+    [test "$(echo test | sed -E 's/([st]+)$/xx\1/' 2>/dev/null)" = "texxst"], [
+        AC_MSG_RESULT([sed -E])
+        ESED="sed -E"
+    ],
+    [test "$(echo test | sed -r 's/([st]+)$/xx\1/' 2>/dev/null)" = "texxst"], [
+        AC_MSG_RESULT([sed -r])
+        ESED="sed -r"
+    ],
+    [AC_MSG_ERROR([cannot find sed with extended regex support (neither -r nor -E work)])]
+)
+AC_SUBST([ESED])
+
+
 AS_CASE("${host_os}", *mingw*, [
     # We don't use pthreads on MinGW.
     PTHREAD_CFLAGS="-mthreads"


### PR DESCRIPTION
BSD sed does not support GNU sed's `-r` switch, but uses `-E` instead for the same functionality. Because `-r` was used in `Makefile.am` to set the `SO_VERSION` and failed there on platforms with BSD sed (e.g. OS X and possibly some BSDs, too) `SO_VERSION` was empty, causing libtool to use the next given parameter as version number, which was `-no-undefined`.

Fix this by testing for the regex flag in `configure.ac` (note that some implementations of sed support `-E` but do not document it).

This fixes the library version name on OS X:
```
-rwxr-xr-x  1 root  admin   526K May 23 19:12 libcapnp-0.5.2.dylib
-rwxr-xr-x  1 root  admin   819K May 23 19:12 libcapnp-rpc-0.5.2.dylib
-rw-r--r--  1 root  admin   1.1M May 23 19:12 libcapnp-rpc.a
lrwxr-xr-x  1 root  admin    24B May 23 19:12 libcapnp-rpc.dylib -> libcapnp-rpc-0.5.2.dylib
-rw-r--r--  1 root  admin   749K May 23 19:12 libcapnp.a
lrwxr-xr-x  1 root  admin    20B May 23 19:12 libcapnp.dylib -> libcapnp-0.5.2.dylib
-rwxr-xr-x  1 root  admin   782K May 23 19:12 libcapnpc-0.5.2.dylib
-rw-r--r--  1 root  admin   978K May 23 19:12 libcapnpc.a
lrwxr-xr-x  1 root  admin    21B May 23 19:12 libcapnpc.dylib -> libcapnpc-0.5.2.dylib
-rwxr-xr-x  1 root  admin   167K May 23 19:12 libkj-0.5.2.dylib
-rwxr-xr-x  1 root  admin   258K May 23 19:12 libkj-async-0.5.2.dylib
-rw-r--r--  1 root  admin   340K May 23 19:12 libkj-async.a
lrwxr-xr-x  1 root  admin    23B May 23 19:12 libkj-async.dylib -> libkj-async-0.5.2.dylib
-rw-r--r--  1 root  admin   247K May 23 19:12 libkj.a
lrwxr-xr-x  1 root  admin    17B May 23 19:12 libkj.dylib -> libkj-0.5.2.dylib
drwxr-xr-x  4 root  admin   136B May 23 19:12 pkgconfig
```