### PR TITLE
Fixed installation of schema files via CMake.

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -49,11 +49,15 @@ set(capnp_headers
   pointer-helpers.h
   generated-header-support.h
 )
+set(capnp_schemas
+  c++.capnp
+  schema.capnp
+)
 add_library(capnp ${capnp_sources})
 target_link_libraries(capnp kj)
 
 install(TARGETS capnp ARCHIVE DESTINATION "${LIB_INSTALL_DIR}")
-install(FILES ${capnp_headers} DESTINATION "${INCLUDE_INSTALL_DIR}/capnp")
+install(FILES ${capnp_headers} ${capnp_schemas} DESTINATION "${INCLUDE_INSTALL_DIR}/capnp")
 
 set(capnp-rpc_sources
   serialize-async.c++
@@ -75,11 +79,16 @@ set(capnp-rpc_headers
   persistent.capnp.h
   ez-rpc.h
 )
+set(capnp-rpc_schemas
+  rpc.capnp
+  rpc-twoparty.capnp
+  persistent.capnp
+)
 if(NOT CAPNP_LITE)
   add_library(capnp-rpc ${capnp-rpc_sources})
   target_link_libraries(capnp-rpc kj-async kj)
   install(TARGETS capnp-rpc ARCHIVE DESTINATION "${LIB_INSTALL_DIR}")
-  install(FILES ${capnp-rpc_headers} DESTINATION "${INCLUDE_INSTALL_DIR}/capnp")
+  install(FILES ${capnp-rpc_headers} ${capnp-rpc_schemas} DESTINATION "${INCLUDE_INSTALL_DIR}/capnp")
 endif()
 
 # Tools/Compilers ==============================================================
@@ -95,18 +104,10 @@ set(capnpc_sources
   compiler/compiler.c++
   schema-parser.c++
 )
-set(capnpc_headers
-  c++.capnp
-  schema.capnp
-  rpc.capnp
-  rpc-twoparty.capnp
-  persistent.capnp
-)
 if(NOT CAPNP_LITE)
   add_library(capnpc ${capnpc_sources})
   target_link_libraries(capnpc capnp kj)
   install(TARGETS capnpc ARCHIVE DESTINATION "${LIB_INSTALL_DIR}")
-  install(FILES ${capnpc_headers} DESTINATION "${INCLUDE_INSTALL_DIR}/capnp")
 endif()
 
 if(BUILD_TOOLS AND NOT CAPNP_LITE)


### PR DESCRIPTION
If building the lite target only (i.e. having run CMake with `-DCAPNP_LITE=1 -DEXTERNAL_CAPNP=1`) then the c++.capnp and schema.capnp files were missing from the install folder, meaning that for example you couldn't set a namespace.

This changes the schema files to be installed along with their respective headers.