### PR TITLE
Allow trailing commas in parenthesized and bracketed lists.

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -375,6 +375,7 @@ heavy_tests =                                                  \
   src/capnp/capability-test.c++                                \
   src/capnp/schema-test.c++                                    \
   src/capnp/schema-loader-test.c++                             \
+  src/capnp/schema-parser-test.c++                             \
   src/capnp/dynamic-test.c++                                   \
   src/capnp/stringify-test.c++                                 \
   src/capnp/serialize-async-test.c++                           \

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -211,6 +211,7 @@ if(BUILD_TESTING)
       capability-test.c++
       schema-test.c++
       schema-loader-test.c++
+      schema-parser-test.c++
       dynamic-test.c++
       stringify-test.c++
       serialize-async-test.c++

--- a/c++/src/capnp/compiler/lexer-test.c++
+++ b/c++/src/capnp/compiler/lexer-test.c++
@@ -146,6 +146,19 @@ TEST(Lexer, Tokens) {
       "])",
       doLex<LexedTokens>("[foo bar, baz qux, corge grault]").cStr());
 
+  // Trailing commas should not create an empty final list item, but be stripped by the lexer.
+  EXPECT_STREQ(
+      "(tokens = ["
+        "(bracketedList = ["
+          "["
+            "(identifier = 'foo', startByte = 1, endByte = 4)"
+          "], ["
+            "(identifier = 'bar', startByte = 6, endByte = 9)"
+          "]"
+        "], startByte = 0, endByte = 11)"
+      "])",
+      doLex<LexedTokens>("[foo, bar,]").cStr());
+
   EXPECT_STREQ(
       "(tokens = ["
         "(bracketedList = ["

--- a/c++/src/capnp/compiler/lexer.c++
+++ b/c++/src/capnp/compiler/lexer.c++
@@ -158,9 +158,16 @@ Lexer::Lexer(Orphanage orphanageParam, ErrorReporter& errorReporter)
           // Completely empty list.
           return nullptr;
         } else {
-          auto result = kj::heapArrayBuilder<kj::Array<Orphan<Token>>>(rest.size() + 1);
+          uint restSize = rest.size();
+          if (rest.size() > 0 && rest[restSize - 1] == nullptr) {
+            // Allow for trailing commas by shortening the list by one item if the final token is
+            // nullptr
+            restSize--;
+          }
+          auto result = kj::heapArrayBuilder<kj::Array<Orphan<Token>>>(1 + restSize); // first + rest
           result.add(kj::mv(first));
-          for (auto& item: rest) {
+          for (uint i = 0; i < restSize ; i++) {
+            auto& item = rest[i];
             result.add(kj::mv(item));
           }
           return result.finish();


### PR DESCRIPTION
Add tests to verify this behavior.

Also, include `schema-parser-test.c++` in the CMake and autotools test suites.  Somehow it got left out.