### PR TITLE
Workaround nonexistent EPROTO on OpenBSD

### DIFF
--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -806,7 +806,10 @@ public:
 
         case EINTR:
         case ENETDOWN:
+#ifdef EPROTO
+        // EPROTO is not defined on OpenBSD.
         case EPROTO:
+#endif
         case EHOSTDOWN:
         case EHOSTUNREACH:
         case ENETUNREACH:


### PR DESCRIPTION
Fixes #221.