### PR TITLE
Added method accept() to TwoPartyServer for servicing arbitrary AsyncIoStreams.

### DIFF
--- a/c++/src/capnp/rpc-twoparty.c++
+++ b/c++/src/capnp/rpc-twoparty.c++
@@ -159,15 +159,19 @@ struct TwoPartyServer::AcceptedConnection {
         rpcSystem(makeRpcServer(network, kj::mv(bootstrapInterface))) {}
 };
 
+void TwoPartyServer::accept(kj::Own<kj::AsyncIoStream>&& connection)
+{
+  auto connectionState = kj::heap<AcceptedConnection>(bootstrapInterface, kj::mv(connection));
+
+  // Run the connection until disconnect.
+  auto promise = connectionState->network.onDisconnect();
+  tasks.add(promise.attach(kj::mv(connectionState)));
+}
+
 kj::Promise<void> TwoPartyServer::listen(kj::ConnectionReceiver& listener) {
   return listener.accept()
       .then([this,&listener](kj::Own<kj::AsyncIoStream>&& connection) mutable {
-    auto connectionState = kj::heap<AcceptedConnection>(bootstrapInterface, kj::mv(connection));
-
-    // Run the connection until disconnect.
-    auto promise = connectionState->network.onDisconnect();
-    tasks.add(promise.attach(kj::mv(connectionState)));
-
+    accept(kj::mv(connection));
     return listen(listener);
   });
 }

--- a/c++/src/capnp/rpc-twoparty.h
+++ b/c++/src/capnp/rpc-twoparty.h
@@ -119,6 +119,9 @@ class TwoPartyServer: private kj::TaskSet::ErrorHandler {
 public:
   explicit TwoPartyServer(Capability::Client bootstrapInterface);
 
+  void accept(kj::Own<kj::AsyncIoStream>&& connection);
+  // Accepts the connection for servicing.
+
   kj::Promise<void> listen(kj::ConnectionReceiver& listener);
   // Listens for connections on the given listener. The returned promise never resolves unless an
   // exception is thrown while trying to accept. You may discard the returned promise to cancel


### PR DESCRIPTION
This patch makes TwoPartyServer more useful. TwoPartyServer could previously only be used with AsyncIoStreams accepted by a ConnectionReceiver listener. Two-way pipes (socketpairs) for example can't be accepted in this way.

It (appears to) work(s) correctly in my application which is providing one end of a socketpair.