### PR TITLE
Increase arenaSpace to fix 32-bit builds.

### DIFF
--- a/c++/src/capnp/message.h
+++ b/c++/src/capnp/message.h
@@ -221,7 +221,7 @@ public:
   Orphanage getOrphanage();
 
 private:
-  void* arenaSpace[20];
+  void* arenaSpace[21];
   // Space in which we can construct a BuilderArena.  We don't use BuilderArena directly here
   // because we don't want clients to have to #include arena.h, which itself includes a bunch of
   // big STL headers.  We don't use a pointer to a BuilderArena because that would require an


### PR DESCRIPTION
Builds on 32-bit systems (x86 and armv7) fail because `arenaSpace` is 4 bytes too small. 

The size of `arenaSpace` was last increased in 62c0270, but it looks like the change to `BuilderArena::localCapTable` in 5413038 introduced a new vtable pointer.