### PR TITLE
Update link for Go library

### DIFF
--- a/doc/otherlang.md
+++ b/doc/otherlang.md
@@ -15,7 +15,7 @@ project's documentation for details.
 
 * [C++](cxx.html) by [@kentonv](https://github.com/kentonv)
 * [Erlang](http://ecapnp.astekk.se/) by [@kaos](https://github.com/kaos)
-* [Go](https://github.com/zombiezen/go-capnproto) by [@zombiezen](https://github.com/zombiezen) (forked from [@glycerine](https://github.com/glycerine)'s serialization-only version, below)
+* [Go](https://github.com/zombiezen/go-capnproto2) by [@zombiezen](https://github.com/zombiezen)
 * [Javascript (Node.js only)](https://github.com/kentonv/node-capnp) by [@kentonv](https://github.com/kentonv)
 * [Python](http://jparyani.github.io/pycapnp/) by [@jparyani](https://github.com/jparyani)
 * [Rust](https://github.com/dwrensha/capnproto-rust) by [@dwrensha](https://github.com/dwrensha)


### PR DESCRIPTION
The Go library in the documentation is deprecated. The author apparently rewrote it from scratch and recommends to use the new one, which should be linked from your documentation now.