### PR TITLE
Implement most of JsonCodec::decodeRaw

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Bryan Borham <bjboreham@gmail.com>: Initial MSVC support
 Philip Quinn <p@partylemon.com>: cmake build and other assorted bits
 Brian Taylor <el.wubo@gmail.com>: emacs syntax highlighting
 Ben Laurie <ben@links.org>: discovered and responsibly disclosed security bugs
+Kamal Marhubi <kamal@marhubi.com>: JSON parser
 
 This file does not list people who maintain their own Cap'n Proto
 implementations as separate projects.  Those people are awesome too!  :)

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -355,10 +355,44 @@ KJ_TEST("basic json decoding") {
     MallocMessageBuilder message;
     auto root = message.initRoot<JsonValue>();
 
-    // TODO(soon): this should fail, JSON doesn't allow leading +
-    json.decodeRaw("+123", root);
-    KJ_EXPECT(root.which() == JsonValue::NUMBER);
-    KJ_EXPECT(root.getNumber() == 123);
+    KJ_EXPECT_THROW_MESSAGE("input", json.decodeRaw("z", root));
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    // Leading + not allowed in numbers.
+    KJ_EXPECT_THROW_MESSAGE("Unexpected", json.decodeRaw("+123", root));
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    KJ_EXPECT_THROW_MESSAGE("Overflow", json.decodeRaw("1e1024", root));
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    KJ_EXPECT_THROW_MESSAGE("Underflow", json.decodeRaw("1e-1023", root));
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    KJ_EXPECT_THROW_MESSAGE("Unexpected", json.decodeRaw("[00]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected", json.decodeRaw("[01]", root));
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("-", root));
   }
 
   {

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -382,7 +382,7 @@ KJ_TEST("basic json decoding") {
     MallocMessageBuilder message;
     auto root = message.initRoot<JsonValue>();
 
-    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("-", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("-", root));
   }
 
   {
@@ -426,8 +426,8 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Invalid escape", json.decodeRaw(R"("\z")", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw(R"(["\n\", 3])", root));
     KJ_EXPECT_THROW_MESSAGE("Invalid hex", json.decodeRaw(R"("\u12zz")", root));
-    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("-", root));
-    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("--", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("-", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("--", root));
   }
 }
 

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -185,21 +185,11 @@ KJ_TEST("encode union") {
 
 KJ_TEST("basic json decoding") {
   // TODO(cleanup): this test is a mess!
-  // TODO(soon): add expected failing cases.
   JsonCodec json;
   {
     MallocMessageBuilder message;
     auto root = message.initRoot<JsonValue>();
     json.decodeRaw("null", root);
-
-    KJ_EXPECT(root.which() == JsonValue::NULL_);
-    KJ_EXPECT(root.getNull() == VOID);
-  }
-
-  {
-    MallocMessageBuilder message;
-    auto root = message.initRoot<JsonValue>();
-    json.decodeRaw(kj::str("null"), root);
 
     KJ_EXPECT(root.which() == JsonValue::NULL_);
     KJ_EXPECT(root.getNull() == VOID);
@@ -411,6 +401,22 @@ KJ_TEST("basic json decoding") {
     json.decodeRaw("-5.5", root);
     KJ_EXPECT(root.which() == JsonValue::NUMBER);
     KJ_EXPECT(root.getNumber() == -5.5);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("a", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("[", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("{", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1, , ]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[,]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[, 1]", root));
+    KJ_EXPECT_THROW_MESSAGE("Input remains", json.decodeRaw("11a", root));
   }
 }
 

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -199,6 +199,15 @@ KJ_TEST("basic json decoding") {
   {
     MallocMessageBuilder message;
     auto root = message.initRoot<JsonValue>();
+    json.decodeRaw(kj::str("null"), root);
+
+    KJ_EXPECT(root.which() == JsonValue::NULL_);
+    KJ_EXPECT(root.getNull() == VOID);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
 
     json.decodeRaw("false", root);
     KJ_EXPECT(root.which() == JsonValue::BOOLEAN);

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -21,7 +21,9 @@
 
 #include "json.h"
 #include <capnp/test-util.h>
+#include <capnp/compat/json.capnp.h>
 #include <kj/debug.h>
+#include <kj/string.h>
 #include <kj/test.h>
 
 namespace capnp {
@@ -179,6 +181,194 @@ KJ_TEST("encode union") {
 
   root.setBar(321);
   KJ_EXPECT(json.encode(root) == "{\"before\":\"a\",\"middle\":44,\"bar\":321,\"after\":\"c\"}");
+}
+
+KJ_TEST("basic json decoding") {
+  // TODO(cleanup): this test is a mess!
+  // TODO(soon): add expected failing cases.
+  JsonCodec json;
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+    json.decodeRaw("null", root);
+
+    KJ_EXPECT(root.which() == JsonValue::NULL_);
+    KJ_EXPECT(root.getNull() == VOID);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("false", root);
+    KJ_EXPECT(root.which() == JsonValue::BOOLEAN);
+    KJ_EXPECT(root.getBoolean() == false);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("true", root);
+    KJ_EXPECT(root.which() == JsonValue::BOOLEAN);
+    KJ_EXPECT(root.getBoolean() == true);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("\"foo\"", root);
+    KJ_EXPECT(root.which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("foo") == root.getString());
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"("\"")", root);
+    KJ_EXPECT(root.which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("\"") == root.getString());
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"("\\abc\"d\\e")", root);
+    KJ_EXPECT(root.which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("\\abc\"d\\e") == root.getString());
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"("\"\\\/\b\f\n\r\t\u0003abc\u0064\u0065f")", root);
+    KJ_EXPECT(root.which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("\"\\/\b\f\n\r\t\x03""abcdef") == root.getString(), root.getString());
+  }
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("[]", root);
+    KJ_EXPECT(root.which() == JsonValue::ARRAY, root.which());
+    KJ_EXPECT(root.getArray().size() == 0);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("[true]", root);
+    KJ_EXPECT(root.which() == JsonValue::ARRAY);
+    auto array = root.getArray();
+    KJ_EXPECT(array.size() == 1, array.size());
+    KJ_EXPECT(root.getArray()[0].which() == JsonValue::BOOLEAN);
+    KJ_EXPECT(root.getArray()[0].getBoolean() == true);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("  [  true  , false\t\n , null]", root);
+    KJ_EXPECT(root.which() == JsonValue::ARRAY);
+    auto array = root.getArray();
+    KJ_EXPECT(array.size() == 3);
+    KJ_EXPECT(array[0].which() == JsonValue::BOOLEAN);
+    KJ_EXPECT(array[0].getBoolean() == true);
+    KJ_EXPECT(array[1].which() == JsonValue::BOOLEAN);
+    KJ_EXPECT(array[1].getBoolean() == false);
+    KJ_EXPECT(array[2].which() == JsonValue::NULL_);
+    KJ_EXPECT(array[2].getNull() == VOID);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("{}", root);
+    KJ_EXPECT(root.which() == JsonValue::OBJECT, root.which());
+    KJ_EXPECT(root.getObject().size() == 0);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"({"some": null})", root);
+    KJ_EXPECT(root.which() == JsonValue::OBJECT, root.which());
+    auto object = root.getObject();
+    KJ_EXPECT(object.size() == 1);
+    KJ_EXPECT(kj::str("some") == object[0].getName());
+    KJ_EXPECT(object[0].getValue().which() == JsonValue::NULL_);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw(R"({"foo\n\tbaz": "a val", "bar": ["a", -5.5e11,  { "z": {}}]})", root);
+    KJ_EXPECT(root.which() == JsonValue::OBJECT, root.which());
+    auto object = root.getObject();
+    KJ_EXPECT(object.size() == 2);
+    KJ_EXPECT(kj::str("foo\n\tbaz") == object[0].getName());
+    KJ_EXPECT(object[0].getValue().which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("a val") == object[0].getValue().getString());
+
+    KJ_EXPECT(kj::str("bar") == object[1].getName());
+    KJ_EXPECT(object[1].getValue().which() == JsonValue::ARRAY);
+    auto array = object[1].getValue().getArray();
+    KJ_EXPECT(array.size() == 3, array.size());
+    KJ_EXPECT(array[0].which() == JsonValue::STRING);
+    KJ_EXPECT(kj::str("a") == array[0].getString());
+    KJ_EXPECT(array[1].which() == JsonValue::NUMBER);
+    KJ_EXPECT(array[1].getNumber() == -5.5e11);
+    KJ_EXPECT(array[2].which() == JsonValue::OBJECT);
+    KJ_EXPECT(array[2].getObject().size() == 1);
+    KJ_EXPECT(array[2].getObject()[0].getValue().which() == JsonValue::OBJECT);
+    KJ_EXPECT(array[2].getObject()[0].getValue().getObject().size() == 0);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("123", root);
+    KJ_EXPECT(root.which() == JsonValue::NUMBER);
+    KJ_EXPECT(root.getNumber() == 123);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    // TODO(soon): this should fail, JSON doesn't allow leading +
+    json.decodeRaw("+123", root);
+    KJ_EXPECT(root.which() == JsonValue::NUMBER);
+    KJ_EXPECT(root.getNumber() == 123);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("-5", root);
+    KJ_EXPECT(root.which() == JsonValue::NUMBER);
+    KJ_EXPECT(root.getNumber() == -5);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
+    json.decodeRaw("-5.5", root);
+    KJ_EXPECT(root.which() == JsonValue::NUMBER);
+    KJ_EXPECT(root.getNumber() == -5.5);
+  }
 }
 
 class TestHandler: public JsonCodec::Handler<Text> {

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -416,7 +416,16 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1, , ]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[,]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[, 1]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1\"\"]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1,, \"\"]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{\"a\"1: 0}", root));
     KJ_EXPECT_THROW_MESSAGE("Input remains", json.decodeRaw("11a", root));
+    KJ_EXPECT_THROW_MESSAGE("Invalid escape", json.decodeRaw(R"("\z")", root));
+    KJ_EXPECT_THROW_MESSAGE("Invalid escape", json.decodeRaw(R"("\z")", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw(R"(["\n\", 3])", root));
+    KJ_EXPECT_THROW_MESSAGE("Invalid hex", json.decodeRaw(R"("\u12zz")", root));
+    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("-", root));
+    KJ_EXPECT_THROW_MESSAGE("Expected number", json.decodeRaw("--", root));
   }
 }
 

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -415,10 +415,12 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1, , ]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[,]", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[true,]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[, 1]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1\"\"]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[1,, \"\"]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{\"a\"1: 0}", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw(R"({"some": null,})", root));
     KJ_EXPECT_THROW_MESSAGE("Input remains", json.decodeRaw("11a", root));
     KJ_EXPECT_THROW_MESSAGE("Invalid escape", json.decodeRaw(R"("\z")", root));
     KJ_EXPECT_THROW_MESSAGE("Invalid escape", json.decodeRaw(R"("\z")", root));

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -474,6 +474,7 @@ public:
   }
 
   char nextChar() {
+    KJ_REQUIRE(remaining_.size() > 0, "JSON message ends prematurely.");
     return remaining_.front();
   }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -584,7 +584,7 @@ public:
             unescapeAndAppend(kj::arrayPtr(remaining_.begin(), 4), decoded);
             advance(4);
             break;
-          default: KJ_FAIL_REQUIRE("invalid escape", nextChar()); break;
+          default: KJ_FAIL_REQUIRE("Invalid escape in JSON string."); break;
         }
       }
 
@@ -637,7 +637,7 @@ public:
       } else if ('A' <= c && c <= 'F') {
         codePoint |= c - 'A';
       } else {
-        KJ_FAIL_REQUIRE("invalid hex digit in unicode escape", c);
+        KJ_FAIL_REQUIRE("Invalid hex digit in unicode escape.", c);
       }
     }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -45,12 +45,6 @@ struct FieldHash {
 
 }  // namespace
 
-namespace _ {  // private
-
-void parseJsonValue(kj::ArrayPtr<const char> input, JsonValue::Builder output);
-
-}  // namespace _ (private)
-
 struct JsonCodec::Impl {
   bool prettyPrint = false;
 
@@ -221,10 +215,6 @@ kj::String JsonCodec::encodeRaw(JsonValue::Reader value) const {
   return impl->encodeRaw(value, 0, multiline, false).flatten();
 }
 
-void JsonCodec::decodeRaw(kj::ArrayPtr<const char> input, JsonValue::Builder output) const {
-  _::parseJsonValue(input, output);
-}
-
 void JsonCodec::encode(DynamicValue::Reader input, Type type, JsonValue::Builder output) const {
   // TODO(soon): For interfaces, check for handlers on superclasses, per documentation...
   // TODO(soon): For branded types, should we check for handlers on the generic?
@@ -382,7 +372,7 @@ Orphan<DynamicValue> JsonCodec::decode(
 
 // -----------------------------------------------------------------------------
 
-namespace _ {  // private
+namespace {
 
 class Parser {
 public:
@@ -616,14 +606,14 @@ const kj::ArrayPtr<const char> Parser::NULL_ = kj::ArrayPtr<const char>({'n','u'
 const kj::ArrayPtr<const char> Parser::FALSE = kj::ArrayPtr<const char>({'f','a','l','s','e'});
 const kj::ArrayPtr<const char> Parser::TRUE = kj::ArrayPtr<const char>({'t','r','u','e'});
 
+}  // namespace
 
-void parseJsonValue(kj::ArrayPtr<const char> input, JsonValue::Builder output) {
+
+void JsonCodec::decodeRaw(kj::ArrayPtr<const char> input, JsonValue::Builder output) const {
   // TODO(security): should we check there are no non-whitespace characters left in input?
   Parser parser(input);
   parser.parseValue(output);
 }
-
-}  // namespace _ (private)
 
 // -----------------------------------------------------------------------------
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -22,7 +22,7 @@
 #include "json.h"
 #include <cmath>    // for HUGEVAL to check for overflow in std::strtod
 #include <cstdlib>  // std::strtod
-#include <errno.h>  // for std::strtod errors
+#include <cerrno>   // for std::strtod errors
 #include <unordered_map>
 #include <capnp/orphan.h>
 #include <kj/debug.h>

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -422,7 +422,7 @@ public:
       values.add(kj::mv(orphan));
 
       if (consumeWhitespace(), nextChar() != ']') {
-        // TODO(soon): This incorrectly allows a trailing comma.
+        // TODO(someday): The JSON spec forbids a trailing comma, but we allow it.
         consume(',');
       }
     }
@@ -458,7 +458,7 @@ public:
       fields.add(kj::mv(orphan));
 
       if (consumeWhitespace(), nextChar() != '}') {
-        // TODO(soon): This incorrectly allows a trailing comma.
+        // TODO(someday): The JSON spec forbids a trailing comma, but we allow it.
         consume(',');
       }
     }

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -377,7 +377,7 @@ namespace {
 class Parser {
 public:
   Parser(kj::ArrayPtr<const char> input) : input_(input), remaining_(input_) {}
-  void parseValue(JsonValue::Builder &output) {
+  void parseValue(JsonValue::Builder& output) {
     consumeWhitespace();
     KJ_REQUIRE(remaining_.size() > 0, "JSON message ends prematurely.");
 
@@ -394,7 +394,7 @@ public:
     }
   }
 
-  void parseNumber(JsonValue::Builder &output) {
+  void parseNumber(JsonValue::Builder& output) {
     // TODO(someday): strtod allows leading +, while JSON grammar does not.
     // strtod consumes leading whitespace, so we don't have to.
     char *numEnd;
@@ -403,11 +403,11 @@ public:
     advanceTo(numEnd);
   }
 
-  void parseString(JsonValue::Builder &output) {
+  void parseString(JsonValue::Builder& output) {
     output.setString(consumeQuotedString());
   }
 
-  void parseArray(JsonValue::Builder &output) {
+  void parseArray(JsonValue::Builder& output) {
     // TODO(perf): Using orphans leaves holes in the message. It's expected
     // that a JsonValue is used for interop, and won't be sent or written as a
     // Cap'n Proto message.
@@ -437,7 +437,7 @@ public:
     consume(']');
   }
 
-  void parseObject(JsonValue::Builder &output) {
+  void parseObject(JsonValue::Builder& output) {
     kj::Vector<Orphan<JsonValue::Field>> fields;
     auto orphanage = Orphanage::getForMessageContaining(output);
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -488,7 +488,7 @@ public:
   }
 
   void advance(size_t numBytes = 1) {
-    KJ_REQUIRE(numBytes < remaining_.size(), "JSON message ends prematurely.");
+    KJ_REQUIRE(numBytes <= remaining_.size(), "JSON message ends prematurely.");
     remaining_ = kj::arrayPtr(remaining_.begin() + numBytes, remaining_.end());
   }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -658,10 +658,21 @@ private:
 
 };  // class Parser
 
+// clang warns about these constructors running on program start. All they do is each set a pointer
+// and a size_t, so we politely ask clang to let it slide.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+#endif
+
 // Array literal used instead of string literal to avoid null terminator.
 const kj::ArrayPtr<const char> Parser::NULL_ = kj::ArrayPtr<const char>({'n','u','l','l'});
 const kj::ArrayPtr<const char> Parser::FALSE = kj::ArrayPtr<const char>({'f','a','l','s','e'});
 const kj::ArrayPtr<const char> Parser::TRUE = kj::ArrayPtr<const char>({'t','r','u','e'});
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 }  // namespace
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -417,7 +417,7 @@ public:
   void parseArray(JsonValue::Builder& output) {
     // TODO(perf): Using orphans leaves holes in the message. It's expected
     // that a JsonValue is used for interop, and won't be sent or written as a
-    // Cap'n Proto message.
+    // Cap'n Proto message.  This also applies to parseObject below.
     kj::Vector<Orphan<JsonValue>> values;
     auto orphanage = Orphanage::getForMessageContaining(output);
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -384,7 +384,7 @@ namespace {
 class Parser {
 public:
   Parser(size_t maxNestingDepth, kj::ArrayPtr<const char> input) :
-    maxNestingDepth_(maxNestingDepth), input_(input), remaining_(input_), nestingDepth_(0) {}
+    maxNestingDepth(maxNestingDepth), input(input), remaining(input), nestingDepth(0) {}
 
   void parseValue(JsonValue::Builder& output) {
     consumeWhitespace();
@@ -435,8 +435,8 @@ public:
     bool expectComma = false;
 
     consume('[');
-    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.");
-    KJ_DEFER(--nestingDepth_);
+    KJ_REQUIRE(++nestingDepth <= maxNestingDepth, "JSON message nested too deeply.");
+    KJ_DEFER(--nestingDepth);
 
     while (consumeWhitespace(), nextChar() != ']') {
       auto orphan = orphanage.newOrphan<JsonValue>();
@@ -470,8 +470,8 @@ public:
     bool expectComma = false;
 
     consume('{');
-    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.");
-    KJ_DEFER(--nestingDepth_);
+    KJ_REQUIRE(++nestingDepth <= maxNestingDepth, "JSON message nested too deeply.");
+    KJ_DEFER(--nestingDepth);
 
     while (consumeWhitespace(), nextChar() != '}') {
       auto orphan = orphanage.newOrphan<JsonValue::Field>();
@@ -508,23 +508,23 @@ public:
   }
 
   bool inputExhausted() {
-    return remaining_.size() == 0 || remaining_.front() == '\0';
+    return remaining.size() == 0 || remaining.front() == '\0';
   }
 
   char nextChar() {
     KJ_REQUIRE(!inputExhausted(), "JSON message ends prematurely.");
-    return remaining_.front();
+    return remaining.front();
   }
 
   void advance(size_t numBytes = 1) {
-    KJ_REQUIRE(numBytes <= remaining_.size(), "JSON message ends prematurely.");
-    remaining_ = kj::arrayPtr(remaining_.begin() + numBytes, remaining_.end());
+    KJ_REQUIRE(numBytes <= remaining.size(), "JSON message ends prematurely.");
+    remaining = kj::arrayPtr(remaining.begin() + numBytes, remaining.end());
   }
 
   void advanceTo(const char *newPos) {
-    KJ_REQUIRE(remaining_.begin() <= newPos && newPos < remaining_.end(),
+    KJ_REQUIRE(remaining.begin() <= newPos && newPos < remaining.end(),
         "JSON message ends prematurely.");
-    remaining_ = kj::arrayPtr(newPos, remaining_.end());
+    remaining = kj::arrayPtr(newPos, remaining.end());
   }
 
   void consume(char expected) {
@@ -535,9 +535,9 @@ public:
   }
 
   void consume(kj::ArrayPtr<const char> expected) {
-    KJ_REQUIRE(remaining_.size() >= expected.size());
+    KJ_REQUIRE(remaining.size() >= expected.size());
 
-    auto prefix = remaining_.slice(0, expected.size());
+    auto prefix = remaining.slice(0, expected.size());
     KJ_REQUIRE(prefix == expected, "Unexpected input in JSON message.");
 
     advance(expected.size());
@@ -560,10 +560,10 @@ public:
 
   template <typename Predicate>
   kj::ArrayPtr<const char> consumeWhile(Predicate&& predicate) {
-    auto originalPos = remaining_.begin();
+    auto originalPos = remaining.begin();
     while (!inputExhausted() && predicate(nextChar())) { advance(); }
 
-    return kj::arrayPtr(originalPos, remaining_.begin());
+    return kj::arrayPtr(originalPos, remaining.begin());
   }
   
   void consumeWhitespace() {
@@ -605,7 +605,7 @@ public:
           case 't' : decoded.add('\t'); advance(); break;
           case 'u' :
             advance();  // consume 'u'
-            unescapeAndAppend(kj::arrayPtr(remaining_.begin(), 4), decoded);
+            unescapeAndAppend(kj::arrayPtr(remaining.begin(), 4), decoded);
             advance(4);
             break;
           default: KJ_FAIL_REQUIRE("Invalid escape in JSON string."); break;
@@ -622,7 +622,7 @@ public:
   }
 
   kj::String consumeNumber() {
-    auto originalPos = remaining_.begin();
+    auto originalPos = remaining.begin();
 
     tryConsume('-');
     if (!tryConsume('0')) {
@@ -639,10 +639,10 @@ public:
       consumeWhile([](char c) { return '0' <= c && c <= '9'; });
     }
 
-    KJ_REQUIRE(remaining_.begin() != originalPos, "Expected number in JSON input.");
+    KJ_REQUIRE(remaining.begin() != originalPos, "Expected number in JSON input.");
 
     kj::Vector<char> number;
-    number.addAll(originalPos, remaining_.begin());
+    number.addAll(originalPos, remaining.begin());
     number.add('\0');
 
     return kj::String(number.releaseAsArray());
@@ -674,10 +674,10 @@ public:
   }
 
 private:
-  const size_t maxNestingDepth_;
-  const kj::ArrayPtr<const char> input_;
-  kj::ArrayPtr<const char> remaining_;
-  size_t nestingDepth_;
+  const size_t maxNestingDepth;
+  const kj::ArrayPtr<const char> input;
+  kj::ArrayPtr<const char> remaining;
+  size_t nestingDepth;
 
 };  // class Parser
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -520,7 +520,7 @@ public:
 
   void consume(char expected) {
     char current = nextChar();
-    KJ_REQUIRE(current == expected, "Unexpected character in JSON message.");
+    KJ_REQUIRE(current == expected, "Unexpected input in JSON message.");
 
     advance();
   }

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -390,7 +390,7 @@ public:
     consumeWhitespace();
     KJ_DEFER(consumeWhitespace());
 
-    KJ_REQUIRE(remaining_.size() > 0, "JSON message ends prematurely.");
+    KJ_REQUIRE(!inputExhausted(), "JSON message ends prematurely.");
 
     switch (nextChar()) {
       case 'n': consume(NULL_); output.setNull();         break;
@@ -503,7 +503,7 @@ public:
   }
 
   char nextChar() {
-    KJ_REQUIRE(remaining_.size() > 0, "JSON message ends prematurely.");
+    KJ_REQUIRE(!inputExhausted(), "JSON message ends prematurely.");
     return remaining_.front();
   }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -434,7 +434,7 @@ public:
     auto orphanage = Orphanage::getForMessageContaining(output);
 
     consume('[');
-    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.", nestingDepth_);
+    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.");
     KJ_DEFER(--nestingDepth_);
 
     while (consumeWhitespace(), nextChar() != ']') {
@@ -464,7 +464,7 @@ public:
     auto orphanage = Orphanage::getForMessageContaining(output);
 
     consume('{');
-    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.", nestingDepth_);
+    KJ_REQUIRE(++nestingDepth_ <= maxNestingDepth_, "JSON message nested too deeply.");
     KJ_DEFER(--nestingDepth_);
 
     while (consumeWhitespace(), nextChar() != '}') {

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -504,7 +504,8 @@ public:
     advance(expected.size());
   }
 
-  kj::ArrayPtr<const char> consumeWhile(kj::Function<bool(char)> predicate) {
+  template <typename Predicate>
+  kj::ArrayPtr<const char> consumeWhile(Predicate&& predicate) {
     auto originalPos = remaining_.begin();
     while (predicate(nextChar())) { advance(); }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -393,9 +393,9 @@ public:
     KJ_REQUIRE(!inputExhausted(), "JSON message ends prematurely.");
 
     switch (nextChar()) {
-      case 'n': consume(NULL_); output.setNull();         break;
-      case 'f': consume(FALSE); output.setBoolean(false); break;
-      case 't': consume(TRUE);  output.setBoolean(true);  break;
+      case 'n': consume(kj::StringPtr("null"));  output.setNull();         break;
+      case 'f': consume(kj::StringPtr("false")); output.setBoolean(false); break;
+      case 't': consume(kj::StringPtr("true"));  output.setBoolean(true);  break;
       case '"': parseString(output); break;
       case '[': parseArray(output);  break;
       case '{': parseObject(output); break;
@@ -647,32 +647,12 @@ public:
   }
 
 private:
-  static const kj::ArrayPtr<const char> NULL_;
-  static const kj::ArrayPtr<const char> FALSE;
-  static const kj::ArrayPtr<const char> TRUE;
-
   const size_t maxNestingDepth_;
   const kj::ArrayPtr<const char> input_;
   kj::ArrayPtr<const char> remaining_;
   size_t nestingDepth_;
 
 };  // class Parser
-
-// clang warns about these constructors running on program start. All they do is each set a pointer
-// and a size_t, so we politely ask clang to let it slide.
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wglobal-constructors"
-#endif
-
-// Array literal used instead of string literal to avoid null terminator.
-const kj::ArrayPtr<const char> Parser::NULL_ = kj::ArrayPtr<const char>({'n','u','l','l'});
-const kj::ArrayPtr<const char> Parser::FALSE = kj::ArrayPtr<const char>({'f','a','l','s','e'});
-const kj::ArrayPtr<const char> Parser::TRUE = kj::ArrayPtr<const char>({'t','r','u','e'});
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 }  // namespace
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "json.h"
-#include <cmath>    // for HUGEVAL to check for overflow in std::strtod
-#include <cstdlib>  // std::strtod
-#include <cerrno>   // for std::strtod errors
+#include <math.h>    // for HUGEVAL to check for overflow in std::strtod
+#include <stdlib.h>  // std::strtod
+#include <errno.h>   // for std::strtod errors
 #include <unordered_map>
 #include <capnp/orphan.h>
 #include <kj/debug.h>

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -440,7 +440,7 @@ public:
     output.initArray(values.size());
     auto array = output.getArray();
 
-    for (size_t i = 0; i < values.size(); ++i) {
+    for (auto i : kj::indices(values)) {
       array.adoptWithCaveats(i, kj::mv(values[i]));
     }
 
@@ -476,7 +476,7 @@ public:
     output.initObject(fields.size());
     auto object = output.getObject();
 
-    for (size_t i = 0; i < fields.size(); ++i) {
+    for (auto i : kj::indices(fields)) {
       object.adoptWithCaveats(i, kj::mv(fields[i]));
     }
 

--- a/c++/src/capnp/compat/json.h
+++ b/c++/src/capnp/compat/json.h
@@ -69,6 +69,10 @@ public:
   // Enable to insert newlines, indentation, and other extra spacing into the output. The default
   // is to use minimal whitespace.
 
+  void setMaxNestingDepth(size_t maxNestingDepth);
+  // Set maximum nesting depth when decoding JSON to prevent highly nested input from overflowing
+  // the call stack. The default is 64.
+
   template <typename T>
   kj::String encode(T&& value);
   // Encode any Cap'n Proto value to JSON, including primitives and


### PR DESCRIPTION
This is the first step towards JSON decoding, implementing the basic
functionality of JsonCodec::decodeRaw. The main outstanding issues are:

- it allows trailing commas in arrays and objects
- it is too liberal in number syntax, eg allowing a leading +
- it does rejects non-ASCII characters in \u escapes

Refs https://github.com/sandstorm-io/capnproto/issues/255