### PR TITLE
Fix UnixEventPort value on 32-bit big endian archs

### DIFF
--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -458,7 +458,7 @@ static siginfo_t toRegularSiginfo(const struct signalfd_siginfo& siginfo) {
         // we write the pointer, we'll end up with the right value for the int? Presumably the
         // two fields of signalfd_siginfo are actually extracted from one of these unions
         // originally, so actually contain redundant data? Better write some tests...
-        result.si_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(siginfo.ssi_ptr));
+        memcpy(&result.si_ptr, &siginfo.ssi_ptr, sizeof(result.si_ptr));
         break;
 
       case SI_TIMER:


### PR DESCRIPTION
toRegularSiginfo attempts to convert signalfd_siginfo.ssi_ptr (a 64-bit
integer across all architectures) to a pointer. On 32-bit big endian
architectures, sival_int/sival_ptr will be stored in the high 32-bits
of the ssi_ptr value.

Prior to this change, the value was "lost" as we cast away the high
bits of ssi_ptr in the conversion to a 32-bit pointer.

This fixes AsyncUnixTest::SignalWith{,Pointer}Value on affected archs.

The comment in AsyncUnixTest::SignalWithValue mentions sigqueue() is broken on droid bionic -- not entirely clear to me if this is related & I don't have the hardware to check.