### PR TITLE
Adjust consumeNumber() to more striclty follow the JSON number format

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -642,11 +642,13 @@ public:
     }
 
     if (tryConsume('.')) {
+      consumeOne([](char c) { return '0' <= c && c <= '9'; });
       consumeWhile([](char c) { return '0' <= c && c <= '9'; });
     }
 
     if (tryConsume('e') || tryConsume('E')) {
       tryConsume('+') || tryConsume('-');
+      consumeOne([](char c) { return '0' <= c && c <= '9'; });
       consumeWhile([](char c) { return '0' <= c && c <= '9'; });
     }
 


### PR DESCRIPTION
I adjusted the function `kj::String consumeNumber()`
so that now more strictly follows the JSON number syntax as defined in:
https://tools.ietf.org/html/rfc7159

Disclaimer, I suggest someone else verifies this. I am pretty sure it is correct but
I don't how to test it. 
