### PR TITLE
adjust the set of white space characters to the set described by RFC7159

### DIFF
--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -298,6 +298,15 @@ KJ_TEST("basic json decoding") {
     MallocMessageBuilder message;
     auto root = message.initRoot<JsonValue>();
 
+    json.decodeRaw("\r\n\t {\r\n\t }\r\n\t ", root);
+    KJ_EXPECT(root.which() == JsonValue::OBJECT, (uint)root.which());
+    KJ_EXPECT(root.getObject().size() == 0);
+  }
+
+  {
+    MallocMessageBuilder message;
+    auto root = message.initRoot<JsonValue>();
+
     json.decodeRaw(R"({"some": null})", root);
     KJ_EXPECT(root.which() == JsonValue::OBJECT, (uint)root.which());
     auto object = root.getObject();
@@ -428,6 +437,8 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Invalid hex", json.decodeRaw(R"("\u12zz")", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("-", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("--", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("\f{}", root));
+    KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{\v}", root));
   }
 }
 

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -581,11 +581,9 @@ public:
     consumeWhile([](char chr) {
       return (
         chr == ' '  ||
-        chr == '\f' ||
         chr == '\n' ||
         chr == '\r' ||
-        chr == '\t' ||
-        chr == '\v'
+        chr == '\t'
       );
     });
   }


### PR DESCRIPTION
Vertical tab and form feed are not specified as white space characters 
in RFC7159 but they are used as such in the parsing code:
c++/src/capnp/compat/json.c++
This patch corrects this.
 
