### PR TITLE
Drop onlick() handlers in documentation, in favor of simple links.

### DIFF
--- a/doc/_includes/header.html
+++ b/doc/_includes/header.html
@@ -41,18 +41,18 @@
 
       <section id="menu">
         <ul>
-          <li><a href="{{ site.baseurl }}index.html">Introduction</a></li>
-          <li><a href="{{ site.baseurl }}news/">News</a></li>
-          <li><a href="{{ site.baseurl }}install.html">Installation</a></li>
-          <li><a href="{{ site.baseurl }}language.html">Schema Language</a></li>
-          <li><a href="{{ site.baseurl }}encoding.html">Encoding</a></li>
-          <li><a href="{{ site.baseurl }}rpc.html">RPC Protocol</a></li>
-          <li><a href="{{ site.baseurl }}capnp-tool.html">The <code>capnp</code> Tool</a></li>
-          <li><a href="{{ site.baseurl }}cxx.html">C++ Serialization</a></li>
-          <li><a href="{{ site.baseurl }}cxxrpc.html">C++ RPC</a></li>
-          <li><a href="{{ site.baseurl }}otherlang.html">Other Languages</a></li>
-          <li><a href="{{ site.baseurl }}roadmap.html">Road Map</a></li>
-          <li><a href="{{ site.baseurl }}faq.html">FAQ</a></li>
+          <li><a href="{{ site.baseurl }}index.html"><p>Introduction</p></a></li>
+          <li><a href="{{ site.baseurl }}news/"><p>News</p></a></li>
+          <li><a href="{{ site.baseurl }}install.html"><p>Installation</p></a></li>
+          <li><a href="{{ site.baseurl }}language.html"><p>Schema Language</p></a></li>
+          <li><a href="{{ site.baseurl }}encoding.html"><p>Encoding</p></a></li>
+          <li><a href="{{ site.baseurl }}rpc.html"><p>RPC Protocol</p></a></li>
+          <li><a href="{{ site.baseurl }}capnp-tool.html"><p>The <code>capnp</code> Tool</p></a></li>
+          <li><a href="{{ site.baseurl }}cxx.html"><p>C++ Serialization</p></a></li>
+          <li><a href="{{ site.baseurl }}cxxrpc.html"><p>C++ RPC</p></a></li>
+          <li><a href="{{ site.baseurl }}otherlang.html"><p>Other Languages</p></a></li>
+          <li><a href="{{ site.baseurl }}roadmap.html"><p>Road Map</p></a></li>
+          <li><a href="{{ site.baseurl }}faq.html"><p>FAQ</p></a></li>
         </ul>
       </section>
       <section id="main_content" class="inner">

--- a/doc/javascripts/main.js
+++ b/doc/javascripts/main.js
@@ -44,32 +44,17 @@ function initSidebar() {
     var href = link.href;
     if (href.lastIndexOf(filename) >= 0) {
       var parent = link.parentNode;
-      var p = document.createElement("p");
 
       while (link.childNodes.length > 0) {
         var child = link.childNodes[0];
         link.removeChild(child);
-        p.appendChild(child);
+        parent.appendChild(child);
       }
       parent.removeChild(link);
-      p.onclick = (function(url) {
-        return function(event) {
-          window.location.href = url;
-          event.stopPropagation();
-        }
-      })(href + "#");
-      parent.appendChild(p);
       items[i].className = "selected";
       toc = document.createElement("ul");
       toc.id = "toc";
       items[i].appendChild(toc);
-    } else {
-      items[i].onclick = (function(url) {
-        return function(event) {
-          window.location.href = url;
-          event.stopPropagation();
-        }
-      })(href);
     }
   }
 
@@ -117,21 +102,15 @@ function setupSidebar() {
       var item = document.createElement("li");
       var p = document.createElement("p");
       var link = document.createElement("a");
-      link.appendChild(document.createTextNode(headings[i].innerText || headings[i].textContent));
+      p.appendChild(document.createTextNode(headings[i].innerText || headings[i].textContent));
       var hlinks = headings[i].getElementsByTagName("a");
       if (hlinks.length == 1) {
         link.href = hlinks[0].href;
       } else {
         link.href = "#" + headings[i].id;
       }
-      p.appendChild(link);
-      p.onclick = (function(url) {
-        return function(event) {
-          window.location.href = url;
-          event.stopPropagation();
-        }
-      })(link.href);
-      item.appendChild(p);
+      link.appendChild(p);
+      item.appendChild(link);
       parent.appendChild(item);
     }
   }
@@ -144,16 +123,10 @@ function setupNewsSidebar(items) {
       var item = document.createElement("li");
       var p = document.createElement("p");
       var link = document.createElement("a");
-      link.appendChild(document.createTextNode(items[i].title));
+      p.appendChild(document.createTextNode(items[i].title));
       link.href = items[i].url;
-      p.appendChild(link);
-      p.onclick = (function(url) {
-        return function(event) {
-          window.location.href = url;
-          event.stopPropagation();
-        }
-      })(link.href);
-      item.appendChild(p);
+      link.appendChild(p);
+      item.appendChild(link);
       toc.appendChild(item);
     }
   }

--- a/doc/stylesheets/stylesheet.css
+++ b/doc/stylesheets/stylesheet.css
@@ -599,9 +599,14 @@ body.narrow #menu {
 
 #menu li {
   margin: 0;
-  padding: 10px 15px 10px 15px;
   list-style-type: none;
   background-color: #212121;
+}
+#menu>ul>li>a>p, #menu>ul>li.selected {
+  padding: 10px 15px 10px 15px;
+}
+#menu>ul>li>a>p {
+  text-indent: 0;
 }
 #menu>ul>li {
   border-right: 1px solid #111;
@@ -681,7 +686,7 @@ ul#toc {
   margin: 0;
   text-indent: -15px;
 }
-#menu p:hover {
+#menu #toc p:hover {
   background-color: #313131;
   cursor: pointer;
 }


### PR DESCRIPTION
This should look and act exactly the same as the current version, except:

  1. The header of the currently-selected section is no longer clickable. (Currently it has an `onclick()` handler that maps it to "#".)
  2. You can now command-click (or middle-click or whatever) the links and have them open in a new tab, without changing the state of the current tab.