### PR TITLE
Check num remaining bytes of escaped json character

### DIFF
--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -410,7 +410,7 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("a", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("[", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("{", root));
-    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("\"\\u", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("\"\\u\"", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}]", root));

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -410,7 +410,7 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("a", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("[", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("{", root));
-    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("\\u", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("\"\\u", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}]", root));

--- a/c++/src/capnp/compat/json-test.c++
+++ b/c++/src/capnp/compat/json-test.c++
@@ -410,6 +410,7 @@ KJ_TEST("basic json decoding") {
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("a", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("[", root));
     KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("{", root));
+    KJ_EXPECT_THROW_MESSAGE("ends prematurely", json.decodeRaw("\\u", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("{]", root));
     KJ_EXPECT_THROW_MESSAGE("Unexpected input", json.decodeRaw("[}]", root));

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -616,6 +616,7 @@ public:
           case 't' : decoded.add('\t'); advance(); break;
           case 'u' :
             advance();  // consume 'u'
+            KJ_REQUIRE(remaining.size() >= 4, "JSON message ends prematurely.");
             unescapeAndAppend(kj::arrayPtr(remaining.begin(), 4), decoded);
             advance(4);
             break;


### PR DESCRIPTION
It seems the JSON parsing is potentially reading past the end of the input buffer.

I'm pretty confident the patch should work but I need to verify that by installing Ekam and run the tests. I'll probably be able to do that before the end of this month.