### PR TITLE
Account for the possibility of adopting an empty struct.

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -896,10 +896,15 @@ struct WireHelpers {
 
     if (dstSegment == srcSegment) {
       // Same segment, so create a direct pointer.
-      dst->setKindAndTarget(srcTag->kind(), srcPtr, dstSegment);
 
-      // We can just copy the upper 32 bits.  (Use memcpy() to comply with aliasing rules.)
-      memcpy(&dst->upper32Bits, &srcTag->upper32Bits, sizeof(srcTag->upper32Bits));
+      if (srcTag->kind() == WirePointer::STRUCT && srcTag->structRef.wordSize() == 0) {
+        dst->setKindAndTargetForEmptyStruct();
+      } else {
+        dst->setKindAndTarget(srcTag->kind(), srcPtr, dstSegment);
+
+        // We can just copy the upper 32 bits.  (Use memcpy() to comply with aliasing rules.)
+        memcpy(&dst->upper32Bits, &srcTag->upper32Bits, sizeof(srcTag->upper32Bits));
+      }
     } else {
       // Need to create a far pointer.  Try to allocate it in the same segment as the source, so
       // that it doesn't need to be a double-far.

--- a/c++/src/capnp/orphan-test.c++
+++ b/c++/src/capnp/orphan-test.c++
@@ -48,6 +48,16 @@ TEST(Orphans, Structs) {
   checkTestMessage(root.asReader().getStructField());
 }
 
+TEST(Orphans, EmptyStruct) {
+  MallocMessageBuilder builder;
+  auto root = builder.initRoot<test::TestAnyPointer>();
+  auto anyPointer = root.getAnyPointerField();
+  EXPECT_TRUE(anyPointer.isNull());
+  auto orphan = builder.getOrphanage().newOrphan<test::TestEmptyStruct>();
+  anyPointer.adopt(kj::mv(orphan));
+  EXPECT_FALSE(anyPointer.isNull());
+}
+
 TEST(Orphans, Lists) {
   MallocMessageBuilder builder;
   auto root = builder.initRoot<TestAllTypes>();


### PR DESCRIPTION
Fixes a bug reported by David Buckley in this thread: https://groups.google.com/forum/#!topic/capnproto/3MIU8xZBX1Q

Adds a test that fails before the fix and succeeds after the fix.