### PR TITLE
Support extracting the current exception count on MSVC2015.

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -551,12 +551,12 @@ uint uncaughtExceptionCount() {
 #elif _MSC_VER
 
 #if _MSC_VER >= 1900
-// MSVC14 has a refactored CRT, so the appropriate runtime function and offsets changed.
+// MSVC14 has a refactored CRT which now provides a direct accessor for this value.
 // See https://svn.boost.org/trac/boost/ticket/10158 for a brief discussion.
-extern "C" char *__cdecl __vcrt_getptd();
+extern "C" int *__cdecl __processing_throw();
 
 uint uncaughtExceptionCount() {
-  return *reinterpret_cast<uint*>(__vcrt_getptd() + (sizeof(void*) == 8 ? 0x38 : 0x1c));
+  return static_cast<uint>(*__processing_throw());
 }
 
 #elif _MSC_VER >= 1400


### PR DESCRIPTION
The MSVC runtime was heavily refactored, so the internal function we call to
get the current exception count changed for newer MSVC versions (as did the
offset).

I have not actually tested this code, as I don't have a native Windows dev
environment available at the moment. I just saw the `uncaught_exceptions`
proposal in #273 and remembered this comment, and realized I could fix it.