### PR TITLE
Make Arena movable

### DIFF
--- a/c++/src/kj/arena-test.c++
+++ b/c++/src/kj/arena-test.c++
@@ -286,6 +286,20 @@ TEST(Arena, Constructor) {
   EXPECT_EQ("foo", arena.allocate<StringPtr>("foo", 3));
 }
 
+TEST(Arena, MoveConstructor) {
+  TestObject::count = 0;
+
+  Arena arena1;
+  TestObject& obj1 = arena1.allocate<TestObject>();
+
+  {
+    Arena arena2(kj::mv(arena1));
+    EXPECT_EQ(1, TestObject::count);
+  }
+
+  EXPECT_EQ(0, TestObject::count);
+}
+
 TEST(Arena, Strings) {
   Arena arena;
 

--- a/c++/src/kj/arena.c++
+++ b/c++/src/kj/arena.c++
@@ -41,12 +41,32 @@ Arena::Arena(ArrayPtr<byte> scratch)
   }
 }
 
+Arena::Arena(Arena&& other) noexcept
+    : nextChunkSize(other.nextChunkSize), chunkList(other.chunkList),
+      objectList(other.objectList), currentChunk(other.currentChunk) {
+  other.chunkList = nullptr;
+  other.objectList = nullptr;
+  other.currentChunk = nullptr;
+}
+
 Arena::~Arena() noexcept(false) {
   // Run cleanup() explicitly, but if it throws an exception, make sure to run it again as part of
   // unwind.  The second call will not throw because destructors are required to guard against
   // exceptions when already unwinding.
   KJ_ON_SCOPE_FAILURE(cleanup());
   cleanup();
+}
+
+Arena& Arena::operator=(Arena&& other) {
+  cleanup();
+  nextChunkSize = other.nextChunkSize;
+  chunkList = other.chunkList;
+  objectList = other.objectList;
+  currentChunk = other.currentChunk;
+  other.chunkList = nullptr;
+  other.objectList = nullptr;
+  other.currentChunk = nullptr;
+  return *this;
 }
 
 void Arena::cleanup() {

--- a/c++/src/kj/arena.h
+++ b/c++/src/kj/arena.h
@@ -50,8 +50,12 @@ public:
   explicit Arena(ArrayPtr<byte> scratch);
   // Allocates from the given scratch space first, only resorting to the heap when it runs out.
 
+  Arena(Arena&& other) noexcept;
+
   KJ_DISALLOW_COPY(Arena);
   ~Arena() noexcept(false);
+
+  Arena& operator=(Arena&& other);
 
   template <typename T, typename... Params>
   T& allocate(Params&&... params);


### PR DESCRIPTION
If a `kj::Arena` is used to hold data needed for the fulfillment of a promise, it may be desirable to attach the arena to the promise using `Promise<T>::attach(...)`.  For this, a move constructor is required.