### PR TITLE
Generate separate .pc files for kj and kj-async

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -97,10 +97,16 @@ if(NOT MSVC)  # Don't install pkg-config files when building with MSVC
   set(PTHREAD_CFLAGS "-pthread")
   set(STDLIB_FLAG)  # TODO: Unsupported
 
+  configure_file(kj.pc.in "${CMAKE_CURRENT_BINARY_DIR}/kj.pc" @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kj.pc" DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
+
   configure_file(capnp.pc.in "${CMAKE_CURRENT_BINARY_DIR}/capnp.pc" @ONLY)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/capnp.pc" DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
 
   if(NOT CAPNP_LITE)
+    configure_file(kj-async.pc.in "${CMAKE_CURRENT_BINARY_DIR}/kj-async.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kj-async.pc" DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
+
     configure_file(capnp-rpc.pc.in "${CMAKE_CURRENT_BINARY_DIR}/capnp-rpc.pc" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/capnp-rpc.pc" DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
   endif()

--- a/c++/capnp-rpc.pc.in
+++ b/c++/capnp-rpc.pc.in
@@ -1,11 +1,10 @@
 prefix=@prefix@
-exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
 Name: Cap'n Proto RPC
 Description: Fast object-oriented RPC system
 Version: @VERSION@
-Libs: -L${libdir} -lcapnp-rpc -lkj-async
-Requires: capnp = @VERSION@
+Libs: -L${libdir} -lcapnp-rpc
+Requires: capnp = @VERSION@ kj-async = @VERSION@
 Cflags: -I${includedir}

--- a/c++/kj-async.pc.in
+++ b/c++/kj-async.pc.in
@@ -3,9 +3,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: Cap'n Proto
-Description: Insanely fast serialization system
+Description: basic utility library called KJ (async part)
 Version: @VERSION@
-Libs: -L${libdir} -lcapnp @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
-Libs.private: @LIBS@
+Libs: -L${libdir} -lkj-async @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Requires: kj = @VERSION@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/c++/kj-async.pc.in
+++ b/c++/kj-async.pc.in
@@ -2,8 +2,8 @@ prefix=@prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: Cap'n Proto
-Description: basic utility library called KJ (async part)
+Name: KJ Async Framework Library
+Description: Basic utility library called KJ (async part)
 Version: @VERSION@
 Libs: -L${libdir} -lkj-async @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Requires: kj = @VERSION@

--- a/c++/kj.pc.in
+++ b/c++/kj.pc.in
@@ -2,8 +2,8 @@ prefix=@prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: Cap'n Proto
-Description: basic utility library called KJ
+Name: KJ Framework Library
+Description: Basic utility library called KJ
 Version: @VERSION@
 Libs: -L${libdir} -lkj @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/c++/kj.pc.in
+++ b/c++/kj.pc.in
@@ -3,9 +3,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: Cap'n Proto
-Description: Insanely fast serialization system
+Description: basic utility library called KJ
 Version: @VERSION@
-Libs: -L${libdir} -lcapnp @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
-Libs.private: @LIBS@
-Requires: kj = @VERSION@
+Libs: -L${libdir} -lkj @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -285,6 +285,24 @@ TEST(Async, DeepChain4) {
   promise.wait(waitScope);
 }
 
+TEST(Async, IgnoreResult) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  bool done = false;
+
+  Promise<void> promise = Promise<int>(123).then([&](int i) {
+    done = true;
+    return i + 321;
+  }).ignoreResult();
+
+  EXPECT_FALSE(done);
+
+  promise.wait(waitScope);
+
+  EXPECT_TRUE(done);
+}
+
 TEST(Async, SeparateFulfiller) {
   EventLoop loop;
   WaitScope waitScope(loop);

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -194,6 +194,11 @@ public:
   // actual I/O.  To solve this, use `kj::evalLater()` to yield control; this way, all other events
   // in the queue will get a chance to run before your callback is executed.
 
+  Promise<void> ignoreResult() KJ_WARN_UNUSED_RESULT { return then([](T&&) {}); }
+  // Convenience method to convert the promise to a void promise by ignoring the return value.
+  //
+  // You must still wait on the returned promise if you want the task to execute.
+
   template <typename ErrorFunc>
   Promise<T> catch_(ErrorFunc&& errorHandler) KJ_WARN_UNUSED_RESULT;
   // Equivalent to `.then(identityFunc, errorHandler)`, where `identifyFunc` is a function that


### PR DESCRIPTION
This would allow applications to use kj only as the promise implementation is really interesting also for projects which don't want to make RPC calls.