### PR TITLE
*.pc.in: add exec_prefix lines

### DIFF
--- a/c++/capnp-rpc.pc.in
+++ b/c++/capnp-rpc.pc.in
@@ -1,4 +1,5 @@
 prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 

--- a/c++/capnp.pc.in
+++ b/c++/capnp.pc.in
@@ -1,4 +1,5 @@
 prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 

--- a/c++/kj-async.pc.in
+++ b/c++/kj-async.pc.in
@@ -1,4 +1,5 @@
 prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 

--- a/c++/kj.pc.in
+++ b/c++/kj.pc.in
@@ -1,4 +1,5 @@
 prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 


### PR DESCRIPTION
The removal of exec_prefix in a900f2002e7489c20755235612386cebab7823bf caused the generated .pc files to be unusable when built with autotools.

The generated libdir value would read:

```
libdir=${exec_prefix}/lib`
```

but since exec_prefix was unspecified, pkg-config would choke:

```
zarvox@localhost $ pkg-config capnp-rpc --cflags --libs
Variable 'exec_prefix' not defined in '/usr/local/lib/pkgconfig/capnp-rpc.pc'
```