### PR TITLE
capnp/ez-rpc: add method setMainInterface

### DIFF
--- a/c++/src/capnp/ez-rpc-test.c++
+++ b/c++/src/capnp/ez-rpc-test.c++
@@ -44,6 +44,24 @@ TEST(EzRpc, Basic) {
   EXPECT_EQ(1, callCount);
 }
 
+TEST(EzRpc, SetMainInterface) {
+  int callCount = 0;
+  EzRpcServer server(nullptr, "localhost");
+  server.setMainInterface(kj::heap<TestInterfaceImpl>(callCount));
+
+  EzRpcClient client("localhost", server.getPort().wait(server.getWaitScope()));
+
+  auto cap = client.getMain<test::TestInterface>();
+  auto request = cap.fooRequest();
+  request.setI(123);
+  request.setJ(true);
+
+  EXPECT_EQ(0, callCount);
+  auto response = request.send().wait(server.getWaitScope());
+  EXPECT_EQ("foo", response.getX());
+  EXPECT_EQ(1, callCount);
+}
+
 TEST(EzRpc, DeprecatedNames) {
   EzRpcServer server("localhost");
   int callCount = 0;

--- a/c++/src/capnp/ez-rpc.c++
+++ b/c++/src/capnp/ez-rpc.c++
@@ -334,6 +334,10 @@ EzRpcServer::EzRpcServer(int socketFd, uint port, ReaderOptions readerOpts)
 
 EzRpcServer::~EzRpcServer() noexcept(false) {}
 
+void EzRpcServer::setMainInterface(Capability::Client cap) {
+  impl->mainInterface = kj::mv(cap);
+}
+
 void EzRpcServer::exportCap(kj::StringPtr name, Capability::Client cap) {
   Impl::ExportedCap entry(kj::heapString(name), cap);
   impl->exportMap[entry.name] = kj::mv(entry);

--- a/c++/src/capnp/ez-rpc.h
+++ b/c++/src/capnp/ez-rpc.h
@@ -207,6 +207,9 @@ public:
 
   ~EzRpcServer() noexcept(false);
 
+  void setMainInterface(Capability::Client cap);
+  // Set / replace main interface.
+
   void exportCap(kj::StringPtr name, Capability::Client cap);
   // Export a capability publicly under the given name, so that clients can import it.
   //


### PR DESCRIPTION
Add an option to change main interface at run time.

Main motivation for this change is that my server's constructor
depends on event loop being initialized.
So it could not created before EzRpcServer constructor.