### PR TITLE
Fix uninitialized members of ListBuilder

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1609,6 +1609,7 @@ struct WireHelpers {
       return { segment, ptr };
     } else {
       // List of structs.
+      KJ_DASSERT(value.structDataSize % BITS_PER_WORD == 0 * BITS);
       word* ptr = allocate(ref, segment, capTable, totalSize + POINTER_SIZE_IN_WORDS,
                            WirePointer::LIST, orphanArena);
       ref->listRef.setInlineComposite(totalSize);

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -643,7 +643,8 @@ class ListBuilder: public kj::DisallowConstCopy {
 public:
   inline explicit ListBuilder(ElementSize elementSize)
       : segment(nullptr), capTable(nullptr), ptr(nullptr), elementCount(0 * ELEMENTS),
-        step(0 * BITS / ELEMENTS), elementSize(elementSize) {}
+        step(0 * BITS / ELEMENTS), elementSize(elementSize), structDataSize(0 * BITS),
+        structPointerCount(0 * POINTERS) {}
 
   MSVC_DEFAULT_ASSIGNMENT_WORKAROUND(, ListBuilder)
 


### PR DESCRIPTION
Adding a `KJ_DASSERT` in the `setListPointer` logic flagged
non-word-multiple data sections in `INLINE_COMPOSITE` lists, which
should be impossible. This traced back to uninitialized member variables
in `ListBuilder` in the case that it was created from a null pointer.