### PR TITLE
Fixed access violation in GetFunctorStartAddress()

### DIFF
--- a/c++/src/kj/async-inl.h
+++ b/c++/src/kj/async-inl.h
@@ -285,9 +285,14 @@ class PtmfHelper {
 #undef BODY
 
   void* apply(void* obj) {
+#if defined(__arm__) || defined(__mips__) || defined(__aarch64__)
+    if (adj & 1) {
+      ptrdiff_t voff = (ptrdiff_t)ptr;
+#else
     ptrdiff_t voff = (ptrdiff_t)ptr;
     if (voff & 1) {
       voff &= ~1;
+#endif
       return *(void**)(*(char**)obj + voff);
     } else {
       return ptr;

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -26,6 +26,10 @@
 namespace kj {
 namespace {
 
+TEST(Async, GetFunctorStartAddress) {
+  EXPECT_TRUE(nullptr != _::GetFunctorStartAddress<>::apply([](){return 0;}));
+}
+
 TEST(Async, EvalVoid) {
   EventLoop loop;
   WaitScope waitScope(loop);


### PR DESCRIPTION
The method to determine, if a pointer to a member function points to a virtual method or not, depends on the ABI. Please see also:
* http://infocenter.arm.com/help/topic/com.arm.doc.ihi0041e/IHI0041E_cppabi.pdf chapter 3.2
* https://blog.mozilla.org/nfroyd/2014/02/20/finding-addresses-of-virtual-functions

To reproduce it, run unit test Async/GetFunctorStartAddress on an ARM hardware. If you don't have one, just compile cap'n'proto with an ARM compiler and run it via QEMU. #