### PR TITLE
Fix building with Xcode 7.3

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 
 #include "json.h"
-#include <math.h>    // for HUGEVAL to check for overflow in std::strtod
-#include <cstdlib>   // std::strtod
-#include <errno.h>   // for std::strtod errors
+#include <math.h>    // for HUGEVAL to check for overflow in strtod
+#include <stdlib.h>  // strtod
+#include <errno.h>   // for strtod errors
 #include <unordered_map>
 #include <capnp/orphan.h>
 #include <kj/debug.h>
@@ -518,7 +518,7 @@ public:
     char *endPtr;
 
     errno = 0;
-    double value = std::strtod(numberStr.begin(), &endPtr);
+    double value = strtod(numberStr.begin(), &endPtr);
 
     KJ_ASSERT(endPtr != numberStr.begin(), "strtod should not fail! Is consumeNumber wrong?");
     KJ_REQUIRE((value != HUGE_VAL && value != -HUGE_VAL) || errno != ERANGE,

--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -21,7 +21,7 @@
 
 #include "json.h"
 #include <math.h>    // for HUGEVAL to check for overflow in std::strtod
-#include <stdlib.h>  // std::strtod
+#include <cstdlib>   // std::strtod
 #include <errno.h>   // for std::strtod errors
 #include <unordered_map>
 #include <capnp/orphan.h>


### PR DESCRIPTION
This pull requests fixes the following compiler error of the master branch with Apple's latest toolchain:

```
src/capnp/compat/json.c++:521:20: error: no member named 'strtod' in namespace 'std'; did you mean simply 'strtod'?
    double value = std::strtod(numberStr.begin(), &endPtr);
                   ^~~~~~~~~~~
                   strtod
/usr/include/stdlib.h:162:9: note: 'strtod' declared here
double   strtod(const char *, char **) __DARWIN_ALIAS(strtod);
         ^
1 error generated.
make: *** [src/capnp/compat/json.lo] Error 1
```