### PR TITLE
Compile fix for musl libc

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -19,19 +19,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <stdlib.h>
 #include "exception.h"
 #include "string.h"
 #include "debug.h"
 #include "threadlocal.h"
 #include "miniposix.h"
-#include <stdlib.h>
 #include <exception>
 #include <new>
 #include <signal.h>
 #include <sys/mman.h>
 #include "io.h"
 
-#if (__linux__ && !__ANDROID__) || __APPLE__
+#if (__linux__ && __GLIBC__ && !__ANDROID__) || __APPLE__
 #define KJ_HAS_BACKTRACE 1
 #include <execinfo.h>
 #endif


### PR DESCRIPTION
glibc is not the only libc on Linux, this fixes compilation for musl based Linux (like Alpine Linux).