### PR TITLE
Fix build on OSX.

### DIFF
--- a/c++/src/capnp/compat/json.c++
+++ b/c++/src/capnp/compat/json.c++
@@ -21,7 +21,7 @@
 
 #include "json.h"
 #include <math.h>    // for HUGEVAL to check for overflow in strtod
-#include <stdlib.h>  // strtod
+#include <cstdlib>  // strtod
 #include <errno.h>   // for strtod errors
 #include <unordered_map>
 #include <capnp/orphan.h>


### PR DESCRIPTION
Fixes these errors:

```
../src/capnp/compat/json.c++:389:19: error: no member named 'strtoll' in namespace 'std'; did you mean simply 'strtoll'?
  int64_t value = std::strtoll(s.begin(), &endPtr, 10);
                  ^~~~~~~~~~~~
                  strtoll
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/stdlib.h:169:3: note: 'strtoll'
      declared here
         strtoll(const char *, char **, int);
         ^
../src/capnp/compat/json.c++:398:20: error: no member named 'strtoull' in namespace 'std'; did you mean simply 'strtoull'?
  uint64_t value = std::strtoull(s.begin(), &endPtr, 10);
                   ^~~~~~~~~~~~~
                   strtoull
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/stdlib.h:175:3: note: 'strtoull'
      declared here
         strtoull(const char *, char **, int);
         ^
../src/capnp/compat/json.c++:407:18: error: no member named 'strtod' in namespace 'std'; did you mean simply 'strtod'?
  double value = std::strtod(s.begin(), &endPtr);
                 ^~~~~~~~~~~
                 strtod
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/stdlib.h:162:9: note: 'strtod'
      declared here
double   strtod(const char *, char **) __DARWIN_ALIAS(strtod);
         ^
3 errors generated.
```

I've verified that, alternatively, it also works to remove the `std` namespace at the function invocations, changing `std::strtoll()` to `::strtoll()` or just `strtoll()`, and similarly for the other calls.