### PR TITLE
Modify `trimSourceFilename()` to remove all text before a prefix.

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -227,9 +227,11 @@ kj::StringPtr trimSourceFilename(kj::StringPtr filename) {
   };
 
 retry:
+  const char* prefixLocation = nullptr;
   for (const char* prefix: PREFIXES) {
-    if (filename.startsWith(prefix)) {
-      filename = filename.slice(strlen(prefix));
+    if ((prefixLocation = strstr(filename.cStr(), prefix)) != nullptr) {
+      size_t prefixLength = (prefixLocation - filename.cStr()) + strlen(prefix);
+      filename = filename.slice(prefixLength);
       goto retry;
     }
   }


### PR DESCRIPTION
A quick stab at fixing #235 (and the tests under CMake) by looking for the `PREFIXES` anywhere in the string and simply removing all text up-to-and-including them.