### PR TITLE
Bka fix union with group in generic struct

### DIFF
--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1121,39 +1121,39 @@ private:
         return FieldText {
             kj::strTree(
                 kj::mv(unionDiscrim.readerIsDecl),
-                "  inline ", titleCase, "::Reader get", titleCase, "() const;\n"
+                "  inline typename ", titleCase, "::Reader get", titleCase, "() const;\n"
                 "\n"),
 
             kj::strTree(
                 kj::mv(unionDiscrim.builderIsDecl),
-                "  inline ", titleCase, "::Builder get", titleCase, "();\n"
-                "  inline ", titleCase, "::Builder init", titleCase, "();\n"
+                "  inline typename ", titleCase, "::Builder get", titleCase, "();\n"
+                "  inline typename ", titleCase, "::Builder init", titleCase, "();\n"
                 "\n"),
 
             hasDiscriminantValue(proto) ? kj::strTree() :
-                kj::strTree("  inline ", titleCase, "::Pipeline get", titleCase, "();\n"),
+                kj::strTree("  inline typename ", titleCase, "::Pipeline get", titleCase, "();\n"),
 
             kj::strTree(
                 kj::mv(unionDiscrim.isDefs),
                 templateContext.allDecls(),
-                "inline ", scope, titleCase, "::Reader ", scope, "Reader::get", titleCase, "() const {\n",
+                "inline typename ", scope, titleCase, "::Reader ", scope, "Reader::get", titleCase, "() const {\n",
                 unionDiscrim.check,
                 "  return ", scope, titleCase, "::Reader(_reader);\n"
                 "}\n",
                 templateContext.allDecls(),
-                "inline ", scope, titleCase, "::Builder ", scope, "Builder::get", titleCase, "() {\n",
+                "inline typename ", scope, titleCase, "::Builder ", scope, "Builder::get", titleCase, "() {\n",
                 unionDiscrim.check,
                 "  return ", scope, titleCase, "::Builder(_builder);\n"
                 "}\n",
                 hasDiscriminantValue(proto) ? kj::strTree() : kj::strTree(
                   "#if !CAPNP_LITE\n",
                   templateContext.allDecls(),
-                  "inline ", scope, titleCase, "::Pipeline ", scope, "Pipeline::get", titleCase, "() {\n",
+                  "inline typename ", scope, titleCase, "::Pipeline ", scope, "Pipeline::get", titleCase, "() {\n",
                   "  return ", scope, titleCase, "::Pipeline(_typeless.noop());\n"
                   "}\n"
                   "#endif  // !CAPNP_LITE\n"),
                 templateContext.allDecls(),
-                "inline ", scope, titleCase, "::Builder ", scope, "Builder::init", titleCase, "() {\n",
+                "inline typename ", scope, titleCase, "::Builder ", scope, "Builder::init", titleCase, "() {\n",
                 unionDiscrim.set,
                 KJ_MAP(slot, slots) {
                   switch (sectionFor(slot.whichType)) {

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -530,6 +530,13 @@ struct TestGenerics(Foo, Bar) {
   foo @0 :Foo;
   rev @1 :TestGenerics(Bar, Foo);
 
+  union {
+    uv @2:Void;
+    ug :group {
+      ugfoo @3:Int32;
+    }
+  }
+
   struct Inner {
     foo @0 :Foo;
     bar @1 :Bar;


### PR DESCRIPTION
Union with group in generic struct leads to compilation error in generated header:

````cpp
In file included from external/capnproto/c++/src/capnp/test_capnp/capnp/test.capnp.c++:4:0:
external/capnproto/c++/src/capnp/test_capnp/capnp/test.capnp.h:9565:10: error: need ‘typename’ before ‘capnproto_test::capnp::test::TestGenerics<Foo, Bar>::Ug::Reader’ because ‘capnproto_test::capnp::test::TestGenerics<Foo, Bar>::Ug’ is a dependent scope
   inline Ug::Reader getUg() const;
````
Relavant parts in header file:

````cpp
template <typename Foo = ::capnp::AnyPointer, typename Bar = ::capnp::AnyPointer>
struct TestGenerics {
  ...
  struct Ug;
};

template <typename Foo, typename Bar>
class TestGenerics<Foo, Bar>::Reader {
  ...
  inline Ug::Reader getUg() const;
};
````

Compiler misses `typename` keyword before Ug::Reader. 

First commit ads test that leads to compilation error. Second commit fixes the problem (for me).

