### PR TITLE
Re-enable MSVC lite-mode

### DIFF
--- a/c++/src/capnp/any-test.c++
+++ b/c++/src/capnp/any-test.c++
@@ -247,6 +247,8 @@ TEST(Any, AnyStructListCapInSchema) {
     checkList(anyList.as<List<int>>(), {123, 456, 789});
   }
 
+  #if !CAPNP_LITE
+  // This portion of the test relies on a Client, not present in lite-mode.
   {
     kj::EventLoop loop;
     kj::WaitScope waitScope(loop);
@@ -259,6 +261,7 @@ TEST(Any, AnyStructListCapInSchema) {
     req.send().wait(waitScope);
     EXPECT_EQ(1, callCount);
   }
+  #endif
 }
 
 

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -252,7 +252,6 @@ public:
   // portion of each segment, whereas tryGetSegment() returns something that includes
   // not-yet-allocated space.
 
-#if !CAPNP_LITE
   inline CapTableBuilder* getLocalCapTable() {
     // Return a CapTableBuilder that merely implements local loopback. That is, you can set
     // capabilities, then read the same capabilities back, but there is no intent ever to transmit
@@ -269,7 +268,6 @@ public:
 
     return &localCapTable;
   }
-#endif  // !CAPNP_LITE
 
   SegmentBuilder* getSegment(SegmentId id);
   // Get the segment with the given id.  Crashes or throws an exception if no such segment exists.
@@ -304,8 +302,8 @@ private:
   MessageBuilder* message;
   ReadLimiter dummyLimiter;
 
-#if !CAPNP_LITE
   class LocalCapTable: public CapTableBuilder {
+#if !CAPNP_LITE
   public:
     kj::Maybe<kj::Own<ClientHook>> extractCap(uint index) override;
     uint injectCap(kj::Own<ClientHook>&& cap) override;
@@ -313,10 +311,10 @@ private:
 
   private:
     kj::Vector<kj::Maybe<kj::Own<ClientHook>>> capTable;
+#endif // ! CAPNP_LITE
   };
 
   LocalCapTable localCapTable;
-#endif  // !CAPNP_LITE
 
   SegmentBuilder segment0;
   kj::ArrayPtr<const word> segment0ForOutput;

--- a/c++/src/capnp/common-test.c++
+++ b/c++/src/capnp/common-test.c++
@@ -77,9 +77,11 @@ using capnproto_test::capnp::test::TestInterface;
 static_assert(equalTypes<FromAny<int>, int>(), "");
 static_assert(equalTypes<FromAny<TestAllTypes::Reader>, TestAllTypes>(), "");
 static_assert(equalTypes<FromAny<TestAllTypes::Builder>, TestAllTypes>(), "");
+#if !CAPNP_LITE
 static_assert(equalTypes<FromAny<TestAllTypes::Pipeline>, TestAllTypes>(), "");
 static_assert(equalTypes<FromAny<TestInterface::Client>, TestInterface>(), "");
 static_assert(equalTypes<FromAny<kj::Own<TestInterface::Server>>, TestInterface>(), "");
+#endif
 
 }  // namespace
 }  // namespace capnp

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -156,19 +156,19 @@ template <typename T> struct Kind_<T, kj::VoidSfinae<typename schemas::EnumInfo<
 
 }  // namespace _ (private)
 
-#if CAPNP_LITE
-
-#define CAPNP_KIND(T) ::capnp::_::Kind_<T>::kind
-// Avoid constexpr methods in lite mode (MSVC is bad at constexpr).
-
-#else  // CAPNP_LITE
-
 template <typename T, Kind k = _::Kind_<T>::kind>
 inline constexpr Kind kind() {
   // This overload of kind() matches types which have a Kind_ specialization.
 
   return k;
 }
+
+#if CAPNP_LITE
+
+#define CAPNP_KIND(T) ::capnp::_::Kind_<T>::kind
+// Avoid constexpr methods in lite mode (MSVC is bad at constexpr).
+
+#else  // CAPNP_LITE
 
 #define CAPNP_KIND(T) ::capnp::kind<T>()
 // Use this macro rather than kind<T>() in any code which must work in lite mode.

--- a/c++/src/capnp/compiler/capnp.c++
+++ b/c++/src/capnp/compiler/capnp.c++
@@ -28,7 +28,7 @@
 #include <capnp/schema.capnp.h>
 #include <kj/vector.h>
 #include <kj/io.h>
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include <kj/debug.h>
 #include "../message.h"
 #include <iostream>
@@ -43,9 +43,6 @@
 
 #if _WIN32
 #include <process.h>
-#include <io.h>
-#include <fcntl.h>
-#define pipe(fds) _pipe(fds, 8192, _O_BINARY)
 #else
 #include <sys/wait.h>
 #endif
@@ -447,7 +444,7 @@ public:
       }
 
       int pipeFds[2];
-      KJ_SYSCALL(pipe(pipeFds));
+      KJ_SYSCALL(kj::miniposix::pipe(pipeFds));
 
       kj::String exeName;
       bool shouldSearchPath = true;

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -30,7 +30,7 @@
 #include <kj/vector.h>
 #include "../schema-loader.h"
 #include "../dynamic.h"
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <map>
@@ -48,10 +48,6 @@
 
 #ifndef VERSION
 #define VERSION "(unknown)"
-#endif
-
-#if _WIN32
-#define mkdir(path, mode) mkdir(path)
 #endif
 
 namespace capnp {
@@ -2917,7 +2913,7 @@ private:
       makeDirectory(kj::str(path.slice(0, *slashpos)));
     }
 
-    if (mkdir(path.cStr(), 0777) < 0) {
+    if (kj::miniposix::mkdir(path.cStr(), 0777) < 0) {
       int error = errno;
       if (error != EEXIST) {
         KJ_FAIL_SYSCALL("mkdir(path)", error, path);

--- a/c++/src/capnp/compiler/capnpc-capnp.c++
+++ b/c++/src/capnp/compiler/capnpc-capnp.c++
@@ -30,7 +30,7 @@
 #include <kj/vector.h>
 #include "../schema-loader.h"
 #include "../dynamic.h"
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include <unordered_map>
 #include <kj/main.h>
 #include <algorithm>

--- a/c++/src/capnp/compiler/evolution-test.c++
+++ b/c++/src/capnp/compiler/evolution-test.c++
@@ -37,7 +37,7 @@
 #include <time.h>
 #include <kj/main.h>
 #include <kj/io.h>
-#include <unistd.h>
+#include <kj/miniposix.h>
 
 namespace capnp {
 namespace compiler {

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -28,7 +28,7 @@
 #include <kj/io.h>
 #include <capnp/message.h>
 #include <map>
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -99,7 +99,7 @@ kj::Array<const byte> mmapForRead(kj::StringPtr filename) {
 
     byte buffer[4096];
     for (;;) {
-      ssize_t n;
+      kj::miniposix::ssize_t n;
       KJ_SYSCALL(n = read(fd, buffer, sizeof(buffer)));
       if (n == 0) break;
       data.addAll(buffer, buffer + n);

--- a/c++/src/capnp/encoding-test.c++
+++ b/c++/src/capnp/encoding-test.c++
@@ -1667,6 +1667,8 @@ TEST(Encoding, Embeds) {
     checkTestMessage(reader.getRoot<TestAllTypes>());
   }
 
+#if !CAPNP_LITE
+
   {
     MallocMessageBuilder builder;
     auto root = builder.getRoot<TestAllTypes>();
@@ -1674,6 +1676,8 @@ TEST(Encoding, Embeds) {
     kj::StringPtr text = test::EMBEDDED_TEXT;
     EXPECT_EQ(kj::str(root, '\n').size(), text.size());
   }
+
+#endif // CAPNP_LITE
 
   {
     checkTestMessage(test::EMBEDDED_STRUCT);

--- a/c++/src/capnp/fuzz-test.c++
+++ b/c++/src/capnp/fuzz-test.c++
@@ -25,7 +25,7 @@
 #include "serialize.h"
 #include <kj/test.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include "test-util.h"
 
 namespace capnp {

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -36,9 +36,11 @@ namespace {
 
 class DummyCapTableReader: public _::CapTableReader {
 public:
+#if !CAPNP_LITE
   kj::Maybe<kj::Own<ClientHook>> extractCap(uint index) override {
     return nullptr;
   }
+#endif
 };
 static constexpr DummyCapTableReader dummyCapTableReader = DummyCapTableReader();
 

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -31,7 +31,7 @@
 #include <kj/vector.h>
 #include <kj/debug.h>
 #include <kj/io.h>
-#include <unistd.h>
+#include <kj/miniposix.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -400,7 +400,7 @@ kj::Array<const char> SchemaFile::DiskFileReader::read(kj::StringPtr path) const
 
     char buffer[4096];
     for (;;) {
-      ssize_t n;
+      kj::miniposix::ssize_t n;
       KJ_SYSCALL(n = ::read(fd, buffer, sizeof(buffer)));
       if (n == 0) break;
       data.addAll(buffer, buffer + n);

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -11,13 +11,13 @@ set(kj_sources_lite
   mutex.c++
   string.c++
   thread.c++
+  main.c++
+  arena.c++
 )
 set(kj_sources_heavy
   units.c++
   refcount.c++
   string-tree.c++
-  arena.c++
-  main.c++
   parse/char.c++
 )
 if(NOT CAPNP_LITE)

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -794,6 +794,15 @@ class Maybe;
 
 namespace _ {  // private
 
+#if _MSC_VER
+  // TODO(msvc): MSVC barfs on noexcept(instance<T&>().~T()) where T = kj::Exception and
+  // kj::_::Void. It and every other factorization I've tried produces:
+  //   error C2325: 'kj::Blah' unexpected type to the right of '.~': expected 'void'
+#define MSVC_NOEXCEPT_DTOR_WORKAROUND(T) __is_nothrow_destructible(T)
+#else
+#define MSVC_NOEXCEPT_DTOR_WORKAROUND(T) noexcept(instance<T&>().~T())
+#endif
+
 template <typename T>
 class NullableValue {
   // Class whose interface behaves much like T*, but actually contains an instance of T and a
@@ -818,7 +827,7 @@ public:
       ctor(value, other.value);
     }
   }
-  inline ~NullableValue() noexcept(noexcept(instance<T&>().~T())) {
+  inline ~NullableValue() noexcept(MSVC_NOEXCEPT_DTOR_WORKAROUND(T)) {
     if (isSet) {
       dtor(value);
     }

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -340,6 +340,10 @@ template <bool b> using EnableIf = typename EnableIf_<b>::Type;
 //     template <typename T, typename = EnableIf<isValid<T>()>
 //     void func(T&& t);
 
+template <typename...> struct VoidSfinae_ { using Type = void; };
+template <typename... Ts> using VoidSfinae = typename VoidSfinae_<Ts...>::Type;
+// Note: VoidSfinae is std::void_t from C++17.
+
 template <typename T>
 T instance() noexcept;
 // Like std::declval, but doesn't transform T into an rvalue reference.  If you want that, specify

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -22,17 +22,15 @@
 #include "main.h"
 #include "debug.h"
 #include "arena.h"
+#include "miniposix.h"
 #include <map>
 #include <set>
 #include <stdlib.h>
-#include <unistd.h>
 #include <errno.h>
 #include <limits.h>
 
 #if _WIN32
 #include <windows.h>
-#include <io.h>
-#include <fcntl.h>
 #else
 #include <sys/uio.h>
 #endif

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -30,7 +30,9 @@
 #include <limits.h>
 
 #if _WIN32
+#define NOMINMAX
 #include <windows.h>
+#undef NOMINMAX
 #else
 #include <sys/uio.h>
 #endif

--- a/c++/src/kj/miniposix.h
+++ b/c++/src/kj/miniposix.h
@@ -19,8 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef KJ_PORTABLE_FD_H_
-#define KJ_PORTABLE_FD_H_
+#ifndef KJ_MINIPOSIX_H_
+#define KJ_MINIPOSIX_H_
 
 // This header provides a small subset of the POSIX API which also happens to be available on
 // Windows under slightly-different names.
@@ -32,6 +32,7 @@
 #if _WIN32
 #include <io.h>
 #include <direct.h>
+#include <fcntl.h>  // _O_BINARY
 #else
 #include <limits.h>
 #include <errno.h>
@@ -61,6 +62,17 @@ inline int close(int fd) {
   return ::_close(fd);
 }
 
+#ifndef F_OK
+#define F_OK 0  // access() existence test
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode) & S_IFMT) ==  S_IFREG)  // stat() regular file test
+#endif
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & S_IFMT) ==  S_IFDIR)  // stat() directory test
+#endif
+
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif
@@ -85,7 +97,7 @@ using ::close;
 // We're on Windows, including MinGW. pipe() and mkdir() are non-standard even on MinGW.
 
 inline int pipe(int fds[2]) {
-  return ::_pipe(fds, 4096, false);
+  return ::_pipe(fds, 8192, _O_BINARY);
 }
 inline int mkdir(const char* path, int mode) {
   return ::_mkdir(path);
@@ -133,4 +145,4 @@ inline size_t iovMax(size_t count) {
 }  // namespace miniposix
 }  // namespace kj
 
-#endif  // KJ_WIN32_FD_H_
+#endif  // KJ_MINIPOSIX_H_

--- a/c++/src/kj/mutex-test.c++
+++ b/c++/src/kj/mutex-test.c++
@@ -25,7 +25,9 @@
 #include <kj/compat/gtest.h>
 
 #if _WIN32
+#define NOGDI  // NOGDI is needed to make EXPECT_EQ(123u, *lock) compile for some reason
 #include <windows.h>
+#undef NOGDI
 #else
 #include <pthread.h>
 #include <unistd.h>

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -67,10 +67,6 @@ struct Id {
 // =======================================================================================
 // Quantity and UnitRatio -- implement unit analysis via the type system
 
-#if !_MSC_VER
-// TODO(msvc): MSVC has trouble with this intense templating. Luckily Cap'n Proto can deal with
-//   using regular integers in place of Quantity, so we can just skip all this.
-
 template <typename T> constexpr bool isIntegral() { return false; }
 template <> constexpr bool isIntegral<char>() { return true; }
 template <> constexpr bool isIntegral<signed char>() { return true; }
@@ -225,9 +221,12 @@ class Quantity {
 public:
   inline constexpr Quantity() {}
 
-  inline constexpr Quantity(decltype(maxValue)): value(maxValue) {}
-  inline constexpr Quantity(decltype(minValue)): value(minValue) {}
+  inline constexpr Quantity(MaxValue_): value(maxValue) {}
+  inline constexpr Quantity(MinValue_): value(minValue) {}
   // Allow initialization from maxValue and minValue.
+  // TODO(msvc): decltype(maxValue) and decltype(minValue) deduce unknown-type for these function
+  // parameters, causing the compiler to complain of a duplicate constructor definition, so we
+  // specify MaxValue_ and MinValue_ types explicitly.
 
   inline explicit constexpr Quantity(Number value): value(value) {}
   // This constructor was intended to be private, but GCC complains about it being private in a
@@ -354,14 +353,10 @@ private:
   friend inline constexpr T unit();
 };
 
-#endif  // !_MSC_VER
-
 template <typename T>
 inline constexpr T unit() { return T(1); }
 // unit<Quantity<T, U>>() returns a Quantity of value 1.  It also, intentionally, works on basic
 // numeric types.
-
-#if !_MSC_VER
 
 template <typename Number1, typename Number2, typename Unit>
 inline constexpr auto operator*(Number1 a, Quantity<Number2, Unit> b)
@@ -432,8 +427,6 @@ template <typename T>
 inline constexpr T origin() { return T(0 * unit<UnitOf<T>>()); }
 // origin<Absolute<T, U>>() returns an Absolute of value 0.  It also, intentionally, works on basic
 // numeric types.
-
-#endif  // !_MSC_VER
 
 }  // namespace kj
 


### PR DESCRIPTION
This branch contains the changes required to make lite-mode Cap'n Proto master compile again under MSVC. I tested this branch by using it to do the three-step "external capnp" bootstrapping dance (Linux, then MinGW, then MSVC).

There were a couple tests which needed at least partial disabling because they used either RPC features, or a brand pointer, neither of which are available in lite-mode.

Otherwise, all MSVC-compiled lite-mode tests pass except Exception/TrimSourceFileName: https://gist.github.com/harrishancock/6dcec0534341876a3356d081d841a79c

MSVC choked on the current implementations of both Kind_ and FromAny_. I replaced them with a std::void_t-style implementation (I named the voider alias kj::VoidSfinae). It is more verbose, but MSVC accepts it.

I replaced unistd.h with miniposix.h in all places required by MSVC to compile, including some non-lite-mode areas out of optimism that I'll be able to get the compiler ported next. Linux remains happy with the header changes, but I haven't tested on Mac. I also fiddled with the arguments passed to _pipe() on Windows (including MinGW).

There are three ugly workarounds included in this branch:
- I added a CAPNP_STYLE(T) macro, because style<T>() won't work as a template argument. I hated adding this, but I didn't see a better way to fix it. This is only necessary because of FromAny, by the way. See commit ce30ee3.
- There are a couple circumstances in which MSVC cannot compile the expression `noexcept(instance<T&>().~T())` (used to detect if a type has a noexcept destructor). I worked around it with a big ugly macro and a compiler intrinsic. See commit d147ea9.
- Overloading a constructor on parameters whose types are computed using decltype() doesn't work in MSVC, which affects Quantity::Quantity(decltype(maxValue)). See commit a7ffa38.

Lastly, a few minor header and linker changes were also required.
