### PR TITLE
prevent use-after-free in internal compiler API

### DIFF
--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -324,7 +324,8 @@ private:
   // Map of parser modules to compiler modules.
 
   Workspace workspace;
-  // The temporary workspace.
+  // The temporary workspace. This field must be declared after `modules` because objects
+  // allocated in the workspace may hold references to the compiled modules in `modules`.
 
   std::unordered_map<uint64_t, Node*> nodesById;
   // Map of nodes by ID.

--- a/c++/src/capnp/compiler/compiler.c++
+++ b/c++/src/capnp/compiler/compiler.c++
@@ -320,11 +320,11 @@ private:
   kj::Arena nodeArena;
   // Arena used to allocate nodes and other permanent objects.
 
-  Workspace workspace;
-  // The temporary workspace.
-
   std::unordered_map<Module*, kj::Own<CompiledModule>> modules;
   // Map of parser modules to compiler modules.
+
+  Workspace workspace;
+  // The temporary workspace.
 
   std::unordered_map<uint64_t, Node*> nodesById;
   // Map of nodes by ID.


### PR DESCRIPTION
Fixes #345.

I'm not sure whether the bug this fixes is observable from the public API. For example, `SchemaParser` avoids the problem by [being careful to clear the workspace](https://github.com/sandstorm-io/capnproto/blob/49ce5c971845823c09139ab269d58b6c2962172f/c%2B%2B/src/capnp/schema-parser.c%2B%2B#L191).
