### PR TITLE
Add missing include when building on Linux

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -63,7 +63,11 @@ else()
   #
   # We have to use -std=gnu++0x isntead of -std=c++11 because otherwise we lose
   # GNU extensions that we need.
-  add_compile_options(-std=gnu++0x -Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -pthread)
+  add_compile_options(-std=gnu++0x -Wall -Wextra -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter)
+
+  if (NOT ANDROID)
+    add_compile_options(-pthread)
+  endif()
 endif()
 
 # Source =======================================================================

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -58,7 +58,7 @@ set(kj-std_headers
 )
 add_library(kj ${kj_sources})
 add_library(CapnProto::kj ALIAS kj)
-if(UNIX)
+if(UNIX AND NOT ANDROID)
   target_link_libraries(kj PUBLIC pthread)
 endif()
 #make sure the lite flag propagates to all users (internal + external) of this library

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -1229,7 +1229,7 @@ public:
         // OK, we know the cmsghdr is valid, at least.
 
         // Find the start of the message payload.
-        const byte* begin = CMSG_DATA(cmsg);
+        const byte* begin = (const byte *)CMSG_DATA(cmsg);
 
         // Cap the message length to the available space.
         const byte* end = pos + kj::min(available, cmsg->cmsg_len);

--- a/c++/src/kj/miniposix.h
+++ b/c++/src/kj/miniposix.h
@@ -44,6 +44,10 @@
 #include <sys/types.h>
 #endif
 
+#if !_WIN32
+#include <sys/uio.h>
+#endif
+
 namespace kj {
 namespace miniposix {
 


### PR DESCRIPTION
Discovered trying to build on Android using CMake.  UIO_MAXIOV is only
exported by the linux/uio.h header which was never included.  Not sure
how normal Linux builds work.

There's also a missing reinterpet_cast & linking against -pthread is implicit on Android, so omit the -pthread flag when building against the NDK.