### PR TITLE
Mark Builder::operator Reader/asReader() member functions const.

### DIFF
--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -427,8 +427,8 @@ struct List<AnyPointer, Kind::OTHER> {
     inline Builder(decltype(nullptr)): builder(ElementSize::POINTER) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline AnyPointer::Builder operator[](uint index) {
@@ -592,8 +592,8 @@ public:
   inline Builder(decltype(nullptr)): builder(ElementSize::INLINE_COMPOSITE) {}
   inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-  inline operator Reader() { return Reader(builder.asReader()); }
-  inline Reader asReader() { return Reader(builder.asReader()); }
+  inline operator Reader() const { return Reader(builder.asReader()); }
+  inline Reader asReader() const { return Reader(builder.asReader()); }
 
   inline uint size() const { return builder.size() / ELEMENTS; }
   inline AnyStruct::Builder operator[](uint index) {

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -678,8 +678,8 @@ struct List<T, Kind::INTERFACE> {
     inline Builder(decltype(nullptr)) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline typename T::Client operator[](uint index) {

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -143,8 +143,8 @@ struct List<T, Kind::PRIMITIVE> {
     inline Builder(decltype(nullptr)) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline T operator[](uint index) {
@@ -239,8 +239,8 @@ struct List<T, Kind::STRUCT> {
     inline Builder(decltype(nullptr)) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline typename T::Builder operator[](uint index) {
@@ -362,8 +362,8 @@ struct List<List<T>, Kind::LIST> {
     inline Builder(decltype(nullptr)) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline typename List<T>::Builder operator[](uint index) {
@@ -470,8 +470,8 @@ struct List<T, Kind::BLOB> {
     inline Builder(decltype(nullptr)) {}
     inline explicit Builder(_::ListBuilder builder): builder(builder) {}
 
-    inline operator Reader() { return Reader(builder.asReader()); }
-    inline Reader asReader() { return Reader(builder.asReader()); }
+    inline operator Reader() const { return Reader(builder.asReader()); }
+    inline Reader asReader() const { return Reader(builder.asReader()); }
 
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline typename T::Builder operator[](uint index) {


### PR DESCRIPTION
Fixes https://github.com/sandstorm-io/capnproto/issues/349.