### PR TITLE
Only Glibc on Linux has execinfo.h

### DIFF
--- a/c++/src/kj/exception.c++
+++ b/c++/src/kj/exception.c++
@@ -33,7 +33,7 @@
 #endif
 #include "io.h"
 
-#if (__linux__ && !__ANDROID__) || __APPLE__
+#if (__linux__ && __GLIBC__) || __APPLE__
 #define KJ_HAS_BACKTRACE 1
 #include <execinfo.h>
 #endif


### PR DESCRIPTION
Fix as done elsewhere so that it builds correctly on Musl libc
as well as Glibc.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>