### PR TITLE
include stdlib.h to fix build on OSX

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -26,6 +26,7 @@
 #include <kj/arena.h>
 #include <set>
 #include <map>
+#include <stdlib.h>
 
 namespace capnp {
 namespace compiler {


### PR DESCRIPTION
Fixes [this problem](https://github.com/sandstorm-io/capnproto/commit/af899ceb5fc1c650090d7ae8ff79e925b1c7e9a9#commitcomment-18895614) reported by @kaos.