### PR TITLE
Fix Mac OS X build failure "undeclared identifier getenv"

### DIFF
--- a/c++/src/capnp/compiler/node-translator.c++
+++ b/c++/src/capnp/compiler/node-translator.c++
@@ -26,6 +26,7 @@
 #include <kj/arena.h>
 #include <set>
 #include <map>
+#include <stdlib.h>
 
 namespace capnp {
 namespace compiler {


### PR DESCRIPTION
Currently on Mac OS X there's a build error with

`node-translator.c++:35:10: error: use of undeclared identifier 'getenv'`

This just explicitly adds the `#include <stdlib.h>` which presumably is implicit on linux.

Mac OS X El Capitan
cmake 3.4.2
Apple LLVM version 7.3.0 (clang-703.0.29)