### PR TITLE
Fix segfault race condition when kj::Thread is detached

### DIFF
--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -21,6 +21,7 @@
 
 #include "thread.h"
 #include "debug.h"
+#include "mutex.h"
 
 #if _WIN32
 #include <windows.h>
@@ -30,19 +31,108 @@
 #endif
 
 namespace kj {
+namespace _ {
+  struct SharedObjects {
+    // Structure to hold all the data that is shared by the created
+    // and creating threads. Wrapped into one struct rather than
+    // locking and unlocking each individual member.
+    Function<void()> func;
+    kj::Maybe<kj::Exception> exception;
+    int refCount = 0;
+    //SharedObjects() = default;
+    SharedObjects( Function<void()> func ) : func(kj::mv(func)) {}
+  };
+
+  class CustomSharedPtr {
+    // Similar to std::shared_ptr in intention, but avoids bringing the std lib into kj
+    // and the data is kj::MutexGuarded so that different threads can access it.
+    // N.B. each thread should have its own instance of this class. The data it points
+    // to can be shared safely, but not instances of this class.
+  public:
+    typedef MutexGuarded<SharedObjects>* orphaned_ref;
+
+    template<typename... T_params>
+    static CustomSharedPtr create( T_params&&... args ) {
+      CustomSharedPtr result( new MutexGuarded<SharedObjects>( kj::fwd<T_params>(args)... ) );
+      ++result.ptr->lockExclusive()->refCount;
+      return result;
+    }
+
+    static CustomSharedPtr adopt( orphaned_ref orphanedPtr ) {
+      // Creates a new reference to already existing data, but does
+      // *not* increment the reference count. This is so that unowned
+      // references created when the release() method is used can be
+      // picked up. Each call to release() *must* be matched with a
+      // call to adopt() or memory leaks will occur.
+      return CustomSharedPtr( orphanedPtr );
+    }
+
+    orphaned_ref get() const {
+      // Returns a pointer that can be used in adopt(), but does *not*
+      // release ownership. This is so that the pointer can be used in
+      // some call that may or may not be successful, before deciding
+      // whether to release ownership.
+      return ptr;
+    }
+
+    orphaned_ref release() {
+      // Returns a pointer that can be used in adopt() and releases
+      // ownership. Each call to this method *must* be matched with
+      // a call to adopt() or memory will leak.
+      auto ptrCopy=ptr;
+      ptr=nullptr;
+      return ptrCopy;
+    }
+
+    ~CustomSharedPtr() {
+      if( ptr )
+      {
+        unsigned refCount= --ptr->lockExclusive()->refCount;
+        if( refCount==0 ) delete ptr;
+      }
+    }
+
+    CustomSharedPtr( const CustomSharedPtr& other ) : ptr(other.ptr) {
+      if( ptr ) ++ptr->lockExclusive()->refCount;
+    }
+
+    CustomSharedPtr( CustomSharedPtr&& other ) : ptr(other.ptr) {
+      other.ptr=nullptr;
+    }
+
+    inline const MutexGuarded<SharedObjects>* operator->() const { return ptr; }
+
+    // In theory these can have implementations, but they're not required
+    // in the current code so why complicate things?
+    CustomSharedPtr& operator=( const CustomSharedPtr& other ) = delete;
+    CustomSharedPtr& operator=( CustomSharedPtr&& other ) = delete;
+  protected:
+    explicit CustomSharedPtr( MutexGuarded<SharedObjects>* ptr ) : ptr(ptr) {}
+    MutexGuarded<SharedObjects>* ptr;
+  };
+
+} // end of "namespace _"
+
+struct Thread::Impl {
+  _::CustomSharedPtr sharedData;
+  template<typename... T_params>
+  Impl( T_params&&... args ) : sharedData( _::CustomSharedPtr::create( kj::fwd<T_params>(args)... ) ) {}
+};
 
 #if _WIN32
 
-Thread::Thread(Function<void()> func): func(kj::mv(func)) {
+Thread::Thread(Function<void()> func): impl(heap<Impl>(kj::mv(func))) {
+  _::CustomSharedPtr tempRef=impl->sharedData; // this holds a ref in case creating a thread fails
   threadHandle = CreateThread(nullptr, 0, &runThread, this, 0, nullptr);
   KJ_ASSERT(threadHandle != nullptr, "CreateThread failed.");
+  tempRef.release(); // if an exception is thrown, this gets skipped and tempRef clears the reference
 }
 
 Thread::~Thread() noexcept(false) {
   if (!detached) {
     KJ_ASSERT(WaitForSingleObject(threadHandle, INFINITE) != WAIT_FAILED);
 
-    KJ_IF_MAYBE(e, exception) {
+    KJ_IF_MAYBE(e, impl->sharedData->lockExclusive()->exception) {
       kj::throwRecoverableException(kj::mv(*e));
     }
   }
@@ -54,26 +144,28 @@ void Thread::detach() {
 }
 
 DWORD Thread::runThread(void* ptr) {
-  Thread* thread = reinterpret_cast<Thread*>(ptr);
+  _::CustomSharedPtr sharedData=_::CustomSharedPtr::adopt( reinterpret_cast<_::CustomSharedPtr::orphaned_ref>(ptr) );
   KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
-    thread->func();
+    sharedData->lockExclusive()->func();
   })) {
-    thread->exception = kj::mv(*exception);
+    sharedData->lockExclusive()->exception = kj::mv(*exception);
   }
   return 0;
 }
 
 #else  // _WIN32
 
-Thread::Thread(Function<void()> func): func(kj::mv(func)) {
+Thread::Thread(Function<void()> func): impl(heap<Impl>(kj::mv(func))) {
   static_assert(sizeof(threadId) >= sizeof(pthread_t),
                 "pthread_t is larger than a long long on your platform.  Please port.");
 
+  _::CustomSharedPtr tempRef=impl->sharedData; // this holds a ref in case creating a thread fails
   int pthreadResult = pthread_create(reinterpret_cast<pthread_t*>(&threadId),
-                                     nullptr, &runThread, this);
+                                     nullptr, &runThread, tempRef.get() );
   if (pthreadResult != 0) {
     KJ_FAIL_SYSCALL("pthread_create", pthreadResult);
   }
+  else tempRef.release(); // release the reference so that the new thread can take it up
 }
 
 Thread::~Thread() noexcept(false) {
@@ -83,7 +175,7 @@ Thread::~Thread() noexcept(false) {
       KJ_FAIL_SYSCALL("pthread_join", pthreadResult) { break; }
     }
 
-    KJ_IF_MAYBE(e, exception) {
+    KJ_IF_MAYBE(e, impl->sharedData->lockExclusive()->exception) {
       kj::throwRecoverableException(kj::mv(*e));
     }
   }
@@ -105,11 +197,11 @@ void Thread::detach() {
 }
 
 void* Thread::runThread(void* ptr) {
-  Thread* thread = reinterpret_cast<Thread*>(ptr);
+  _::CustomSharedPtr sharedData=_::CustomSharedPtr::adopt( reinterpret_cast<_::CustomSharedPtr::orphaned_ref>(ptr) );
   KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
-    thread->func();
+    sharedData->lockExclusive()->func();
   })) {
-    thread->exception = kj::mv(*exception);
+    sharedData->lockExclusive()->exception = kj::mv(*exception);
   }
   return nullptr;
 }

--- a/c++/src/kj/thread.h
+++ b/c++/src/kj/thread.h
@@ -55,13 +55,13 @@ public:
   //   the Thread object and the thread itself will need to share a refcounted object.
 
 private:
-  Function<void()> func;
+  struct Impl;
+  kj::Own<Impl> impl;
 #if _WIN32
   void* threadHandle;
 #else
   unsigned long long threadId;  // actually pthread_t
 #endif
-  kj::Maybe<kj::Exception> exception;
   bool detached = false;
 
 #if _WIN32


### PR DESCRIPTION
This is to address the point discussed on https://groups.google.com/forum/#!topic/capnproto/Qbn3SEKBqLg

I need to test a bit more (particularly windows) but I thought I'd open early to get comments on the general approach.  This breaks pretty much every kj memory management rule at some point.  In particular, I can see no way of achieving the result without effectively passing an unowned new to the OS thread creation function.  I've tried to mitigate this by having it securely held until confirmation the thread was successfully created, and wrapping back in a smart pointer as soon as the new thread starts.

Also, this now requires two heap allocations in the kj::Thread constructor - one for the pimple idiom members and one for the shared thread data.  This could be cut to one for the shared data but it would mean putting a load of cruft in the header.  Threads aren't often created in kj or capnproto so I'm hoping this isn't too much of an issue.

After writing this I'm starting to wonder if the functor and exception actually need to be protected with a mutex.  The points they're accessed from in each thread are fairly well defined.  It could be quicker to just use std::atomic on the reference counter.  Would that be acceptable use of the std lib in kj?