### PR TITLE
Fixes for windows

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1606,7 +1606,7 @@ struct WireHelpers {
       if (dataSize % BYTES_PER_WORD != 0 * BYTES) {
         //Zero-pad the data if it didn't use the entire last word
         byte* padStart = reinterpret_cast<byte*>(ptr) + (dataSize / BYTES);
-        bzero(padStart, (BYTES_PER_WORD * WORDS - (dataSize % BYTES_PER_WORD)) / BYTES);
+        memset(padStart, 0, (BYTES_PER_WORD * WORDS - (dataSize % BYTES_PER_WORD)) / BYTES);
       }
     }
 

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -24,10 +24,12 @@
 
 #if _WIN32
 #include <windows.h>
+#include "windows-sanity.h"
 #else
 #include <pthread.h>
 #include <signal.h>
 #endif
+
 
 namespace kj {
 

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -30,7 +30,6 @@
 #include <signal.h>
 #endif
 
-
 namespace kj {
 
 #if _WIN32
@@ -128,7 +127,6 @@ void* Thread::runThread(void* ptr) {
 void Thread::ThreadState::unref() {
 #if _MSC_VER
   if (_InterlockedDecrement(&refcount)) {
-    _ReadBarrier();
 #else
   if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_RELEASE) == 0) {
     __atomic_thread_fence(__ATOMIC_ACQUIRE);

--- a/c++/src/kj/thread.c++
+++ b/c++/src/kj/thread.c++
@@ -42,7 +42,7 @@ Thread::~Thread() noexcept(false) {
   if (!detached) {
     KJ_ASSERT(WaitForSingleObject(threadHandle, INFINITE) != WAIT_FAILED);
 
-    KJ_IF_MAYBE(e, exception) {
+    KJ_IF_MAYBE(e, state->exception) {
       kj::throwRecoverableException(kj::mv(*e));
     }
   }
@@ -125,7 +125,7 @@ void* Thread::runThread(void* ptr) {
 
 void Thread::ThreadState::unref() {
 #if _MSC_VER
-  if (_InterlockedDecrement_rel(&refcount)) {
+  if (_InterlockedDecrement(&refcount)) {
     _ReadBarrier();
 #else
   if (__atomic_sub_fetch(&refcount, 1, __ATOMIC_RELEASE) == 0) {

--- a/c++/src/kj/thread.h
+++ b/c++/src/kj/thread.h
@@ -59,7 +59,7 @@ private:
     Function<void()> func;
     kj::Maybe<kj::Exception> exception;
 
-    int refcount;
+    unsigned int refcount;
     // Owned by the parent thread and the child thread.
 
     void unref();


### PR DESCRIPTION
A few trivial fixes to get capnproto mostly compiling on windows.
I'm not a windows expert so I suggest someone who is reviews these changes.  After this change kj and capnproto seem to compile but the full build still fails on something in the test, with

    6>  Compiling Cap'n Proto schema test.capnp
    6>  '""' is not recognized as an internal or external command,
    6>  operable program or batch file.
    6>C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.CppCommon.targets(171,5): error MSB6006: "cmd.exe" exited with code 9009.

I suspect it's an issue with cmake not passing on the path of the external capnp executable but I don't know enough about it.

Tested on

* Windows 10 + cmake 3.4.3 + MSVC 2015 (partial build success)
* Ubuntu + gcc 4.8 (`make check` run successfully)