### PR TITLE
Dockerfile for capnproto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:jessie
+RUN \
+  apt-get update && apt-get install -y \
+    autoconf automake libtool g++ git make \
+    && rm -rf /var/lib/apt/lists/*
+COPY . /tmp/capnproto
+RUN cd /tmp/capnproto/c++ && \
+      autoreconf -i && \
+      ./configure && \
+      make -j6 check && \
+      make install
+WORKDIR /tmp/capnproto

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ RUN \
     autoconf automake libtool g++ git make \
     && rm -rf /var/lib/apt/lists/*
 COPY . /tmp/capnproto
-RUN cd /tmp/capnproto/c++ && \
-      autoreconf -i && \
-      ./configure && \
-      make -j6 check && \
-      make install
+RUN \
+  cd /tmp/capnproto/c++ && \
+    autoreconf -i && \
+    ./configure && \
+    make -j6 check && \
+    make install && \
+    make clean
 WORKDIR /tmp/capnproto

--- a/doc/install.md
+++ b/doc/install.md
@@ -108,7 +108,9 @@ Note: These packages are not maintained by us and are sometimes not up to date w
 If you download directly from Git, you will need to have the GNU autotools --
 [autoconf](http://www.gnu.org/software/autoconf/),
 [automake](http://www.gnu.org/software/automake/), and
-[libtool](http://www.gnu.org/software/libtool/) -- installed.
+[libtool](http://www.gnu.org/software/libtool/) -- installed, unless you choose
+to use build or pull the Docker image which already has the dependencies
+installed.
 
     git clone https://github.com/sandstorm-io/capnproto.git
     cd capnproto/c++
@@ -116,6 +118,16 @@ If you download directly from Git, you will need to have the GNU autotools --
     ./configure
     make -j6 check
     sudo make install
+
+The Dockerfile delivered with the git repository provides a quick means for
+spawning a debian environment with all dependencies installed to build or run 
+`capnpro`. Run `docker build -t capnproto .` to produce the image and run
+`docker run --it capnproto` to spawn a container from the produced image.o
+
+In case you have files you need to work with, mount them into the container
+using to command `docker run --it capnproto -v $PATH_TO_SRC_DIR:/tmp/workdir`.
+Inside the container you may navigate to `/tmp/workdir` where you will find
+your source directory mounted.
 
 ## Installation: Windows
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -120,14 +120,21 @@ installed.
     sudo make install
 
 The Dockerfile delivered with the git repository provides a quick means for
-spawning a debian environment with all dependencies installed to build or run 
-`capnpro`. Run `docker build -t capnproto .` to produce the image and run
-`docker run --it capnproto` to spawn a container from the produced image.o
+spawning a debian environment with all dependencies installed to build, test
+and run `capnpro`. Run `docker build -t capnproto .` to produce the image and
+run `docker run --it capnproto` to spawn a container from the produced image.
 
 In case you have files you need to work with, mount them into the container
-using to command `docker run --it capnproto -v $PATH_TO_SRC_DIR:/tmp/workdir`.
-Inside the container you may navigate to `/tmp/workdir` where you will find
+to have them accessible within that environment. Mounting `$PATH_TO_SRC_DIR`
+into `/tmp/workdir` inside the container is simply done through the command
+`docker run --it capnproto -v $PATH_TO_SRC_DIR:/tmp/workdir`. Inside the
+container you may navigate to `/tmp/workdir` where you will find
 your source directory mounted.
+
+The `capnproto` repository is copied into the Docker container into the path
+`/tmp/capnproto`. Feel free to mount the path to the capnproto repository on
+your filesystem into this path in order to rebuild any changes you want to
+test.
 
 ## Installation: Windows
 


### PR DESCRIPTION
I setup a Dockerfile to allow myself to spawn an environment with all the dependencies available to build, test and run `capnp`. I added some documentation to explain how to use this container.

Upon `docker build .` the current state of the rep is copied into `/tmp/capnproto` and whichever version is there is build and installed. Using `docker run -it $IMAGE -v $PATH_TO_THIS_REP:/tmp/capnproto` one can mount a volume on `/tmp/capnproto` that points to the repository's path on the host such that all changes will be reflected in both environments -- so much easier to develop like this :wink:. 

Shall we setup an official capnproto automated build on Docker hub and Quay?

[![](https://images.microbadger.com/badges/image/vidbina/capnproto.svg)](http://microbadger.com/images/vidbina/capnproto "Get your own image badge on microbadger.com")