### PR TITLE
Add a move constructor to kj::TaskSet

### DIFF
--- a/c++/src/kj/async.c++
+++ b/c++/src/kj/async.c++
@@ -480,6 +480,9 @@ TaskSet::TaskSet(ErrorHandler& errorHandler)
 
 TaskSet::~TaskSet() noexcept(false) {}
 
+TaskSet::TaskSet(TaskSet&& other)
+    : impl(kj::mv(other.impl)) {}
+
 void TaskSet::add(Promise<void>&& promise) {
   impl->add(kj::mv(promise));
 }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -507,6 +507,8 @@ public:
   // `loop` will be used to wait on promises.  `errorHandler` will be executed any time a task
   // throws an exception, and will execute within the given EventLoop.
 
+  TaskSet(TaskSet&& other);
+
   ~TaskSet() noexcept(false);
 
   void add(Promise<void>&& promise);


### PR DESCRIPTION
TaskSet currently doesn't have a move constructor.  I'm not sure if this is intentional or one has never been required before?  If this is intentional just close the pull request.

I have a particular use case which requires a move constructor, which I can detail if required (basically moving them so that they're deleted on the correct thread).