### PR TITLE
Disable UrgentObserver test on macOS.

### DIFF
--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -455,6 +455,8 @@ TEST(AsyncUnixTest, WriteObserver) {
   EXPECT_TRUE(writable);
 }
 
+#if !__APPLE__
+// Disabled on macOS due to https://github.com/sandstorm-io/capnproto/issues/374.
 TEST(AsyncUnixTest, UrgentObserver) {
   // Verify that FdObserver correctly detects availability of out-of-band data.
   // Availability of out-of-band data is implementation-specific.
@@ -519,6 +521,7 @@ TEST(AsyncUnixTest, UrgentObserver) {
   KJ_SYSCALL(send(clientFd, &c, 1, 0));
   KJ_SYSCALL(shutdown(clientFd, SHUT_RDWR));
 }
+#endif
 
 TEST(AsyncUnixTest, SteadyTimers) {
   captureSignals();

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -237,6 +237,9 @@ public:
   //
   // It is an error to call `whenUrgentDataAvailable()` again when the promise returned previously
   // has not yet resolved. If you do this, the previous promise may throw an exception.
+  //
+  // WARNING: This has some known weird behavior on macOS. See
+  //   https://github.com/sandstorm-io/capnproto/issues/374.
 
 private:
   UnixEventPort& eventPort;


### PR DESCRIPTION
As suggested by @mologie in https://github.com/sandstorm-io/capnproto/issues/374.