### PR TITLE
Fix RealmGateway to avoid double-transforms on loopback.

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -545,6 +545,10 @@ kj::Own<ClientHook> newLocalPromiseClient(kj::Promise<kj::Own<ClientHook>>&& pro
   return kj::refcounted<QueuedClient>(kj::mv(promise));
 }
 
+kj::Own<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Own<PipelineHook>>&& promise) {
+  return kj::refcounted<QueuedPipeline>(kj::mv(promise));
+}
+
 // =======================================================================================
 
 namespace {

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -595,6 +595,10 @@ kj::Own<ClientHook> newLocalPromiseClient(kj::Promise<kj::Own<ClientHook>>&& pro
 // the new client.  This hook's `getResolved()` and `whenMoreResolved()` methods will reflect the
 // redirection to the eventual replacement client.
 
+kj::Own<PipelineHook> newLocalPromisePipeline(kj::Promise<kj::Own<PipelineHook>>&& promise);
+// Returns a PipelineHook that queues up calls until `promise` resolves, then forwards them to
+// the new pipeline.
+
 kj::Own<ClientHook> newBrokenCap(kj::StringPtr reason);
 kj::Own<ClientHook> newBrokenCap(kj::Exception&& reason);
 // Helper function that creates a capability which simply throws exceptions when called.

--- a/c++/src/kj/async-prelude.h
+++ b/c++/src/kj/async-prelude.h
@@ -30,6 +30,7 @@
 #endif
 
 #include "exception.h"
+#include "tuple.h"
 
 namespace kj {
 
@@ -85,6 +86,17 @@ template <typename Func, typename T>
 using ReturnType = typename ReturnType_<Func, T>::Type;
 // The return type of functor Func given a parameter of type T, with the special exception that if
 // T is void, this is the return type of Func called with no arguments.
+
+template <typename T> struct SplitTuplePromise_ { typedef Promise<T> Type; };
+template <typename... T>
+struct SplitTuplePromise_<kj::_::Tuple<T...>> {
+  typedef kj::Tuple<Promise<JoinPromises<T>>...> Type;
+};
+
+template <typename T>
+using SplitTuplePromise = typename SplitTuplePromise_<T>::Type;
+// T -> Promise<T>
+// Tuple<T> -> Tuple<Promise<T>>
 
 struct Void {};
 // Application code should NOT refer to this!  See `kj::READY_NOW` instead.

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -492,6 +492,21 @@ TEST(Async, ForkRef) {
   EXPECT_EQ(789, branch2.wait(waitScope));
 }
 
+TEST(Async, Split) {
+  EventLoop loop;
+  WaitScope waitScope(loop);
+
+  Promise<Tuple<int, String, Promise<int>>> promise = evalLater([&]() {
+    return kj::tuple(123, str("foo"), Promise<int>(321));
+  });
+
+  Tuple<Promise<int>, Promise<String>, Promise<int>> split = promise.split();
+
+  EXPECT_EQ(123, get<0>(split).wait(waitScope));
+  EXPECT_EQ("foo", get<1>(split).wait(waitScope));
+  EXPECT_EQ(321, get<2>(split).wait(waitScope));
+}
+
 TEST(Async, ExclusiveJoin) {
   {
     EventLoop loop;

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -29,7 +29,6 @@
 #include "async-prelude.h"
 #include "exception.h"
 #include "refcount.h"
-#include "tuple.h"
 
 namespace kj {
 
@@ -241,6 +240,12 @@ public:
   // `T` must be copy-constructable for this to work.  Or, in the special case where `T` is
   // `Own<U>`, `U` must have a method `Own<U> addRef()` which returns a new reference to the same
   // (or an equivalent) object (probably implemented via reference counting).
+
+  _::SplitTuplePromise<T> split();
+  // Split a promise for a tuple into a tuple of promises.
+  //
+  // E.g. if you have `Promise<kj::Tuple<T, U>>`, `split()` returns
+  // `kj::Tuple<Promise<T>, Promise<U>>`.
 
   Promise<T> exclusiveJoin(Promise<T>&& other) KJ_WARN_UNUSED_RESULT;
   // Return a new promise that resolves when either the original promise resolves or `other`

--- a/c++/src/kj/tuple.h
+++ b/c++/src/kj/tuple.h
@@ -350,6 +350,15 @@ inline auto apply(Func&& func, Params&&... params)
   return _::expandAndApply(kj::fwd<Func>(func), kj::fwd<Params>(params)...);
 }
 
+template <typename T> struct TupleSize_ { static constexpr size_t size = 1; };
+template <typename... T> struct TupleSize_<_::Tuple<T...>> {
+  static constexpr size_t size = sizeof...(T);
+};
+
+template <typename T>
+constexpr size_t tupleSize() { return TupleSize_<T>::size; }
+// Returns size of the tuple T.
+
 }  // namespace kj
 
 #endif  // KJ_TUPLE_H_


### PR DESCRIPTION
Previously, in the presence of promise capabilities, a save() request could cross over the same gateway twice (or more!). Some gateways (e.g. Sandstorm's) implement one-way transformations, so this could cause the request to fail when it shouldn't.