### PR TITLE
Support RPC on Windows (MinGW)

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -139,6 +139,7 @@ includekj_HEADERS =                                            \
   src/kj/async-inl.h                                           \
   src/kj/time.h                                                \
   src/kj/async-unix.h                                          \
+  src/kj/async-win32.h                                         \
   src/kj/async-io.h                                            \
   src/kj/main.h                                                \
   src/kj/test.h                                                \
@@ -225,12 +226,14 @@ libkj_test_la_LDFLAGS = -release $(VERSION) -no-undefined
 libkj_test_la_SOURCES = src/kj/test.c++
 
 if !LITE_MODE
-libkj_async_la_LIBADD = libkj.la $(PTHREAD_LIBS)
+libkj_async_la_LIBADD = libkj.la $(ASYNC_LIBS) $(PTHREAD_LIBS)
 libkj_async_la_LDFLAGS = -release $(SO_VERSION) -no-undefined
 libkj_async_la_SOURCES=                                        \
   src/kj/async.c++                                             \
   src/kj/async-unix.c++                                        \
+  src/kj/async-win32.c++                                       \
   src/kj/async-io.c++                                          \
+  src/kj/async-io-win32.c++                                    \
   src/kj/time.c++
 endif !LITE_MODE
 
@@ -260,7 +263,7 @@ libcapnp_la_SOURCES=                                           \
 
 if !LITE_MODE
 
-libcapnp_rpc_la_LIBADD = libcapnp.la libkj-async.la libkj.la $(PTHREAD_LIBS)
+libcapnp_rpc_la_LIBADD = libcapnp.la libkj-async.la libkj.la $(ASYNC_LIBS) $(PTHREAD_LIBS)
 libcapnp_rpc_la_LDFLAGS = -release $(SO_VERSION) -no-undefined
 libcapnp_rpc_la_SOURCES=                                       \
   src/capnp/serialize-async.c++                                \
@@ -386,6 +389,7 @@ check_PROGRAMS = capnp-test capnp-evolution-test
 heavy_tests =                                                  \
   src/kj/async-test.c++                                        \
   src/kj/async-unix-test.c++                                   \
+  src/kj/async-win32-test.c++                                  \
   src/kj/async-io-test.c++                                     \
   src/kj/parse/common-test.c++                                 \
   src/kj/parse/char-test.c++                                   \

--- a/c++/configure.ac
+++ b/c++/configure.ac
@@ -57,11 +57,15 @@ AS_CASE("${host_os}", *mingw*, [
     PTHREAD_CFLAGS="-mthreads"
     PTHREAD_LIBS=""
     PTHREAD_CC=""
+    ASYNC_LIBS="-lws2_32"
     AC_SUBST(PTHREAD_LIBS)
     AC_SUBST(PTHREAD_CFLAGS)
     AC_SUBST(PTHREAD_CC)
+    AC_SUBST(ASYNC_LIBS)
   ], *, [
     ACX_PTHREAD
+    ASYNC_LIBS=""
+    AC_SUBST(ASYNC_LIBS)
   ])
 
 LT_INIT

--- a/c++/src/capnp/fuzz-test.c++
+++ b/c++/src/capnp/fuzz-test.c++
@@ -28,6 +28,12 @@
 #include <kj/miniposix.h>
 #include "test-util.h"
 
+#if !_WIN32
+// This test is super-slow on Windows seemingly due to generating exception stack traces being
+// expensive.
+//
+// TODO(perf): Maybe create an API to disable stack traces, and use it here.
+
 namespace capnp {
 namespace _ {  // private
 namespace {
@@ -257,3 +263,5 @@ KJ_TEST("fuzz-test double-far pointer") {
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp
+
+#endif

--- a/c++/src/capnp/rpc-twoparty-test.c++
+++ b/c++/src/capnp/rpc-twoparty-test.c++
@@ -22,7 +22,6 @@
 #include "rpc-twoparty.h"
 #include "test-util.h"
 #include <capnp/rpc.capnp.h>
-#include <kj/async-unix.h>
 #include <kj/debug.h>
 #include <kj/thread.h>
 #include <kj/compat/gtest.h>

--- a/c++/src/kj/async-io-win32.c++
+++ b/c++/src/kj/async-io-win32.c++
@@ -1,0 +1,1169 @@
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if _WIN32
+// For Unix implementation, see async-io.c++.
+
+// Request Vista-level APIs.
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+
+#include "async-io.h"
+#include "async-win32.h"
+#include "debug.h"
+#include "thread.h"
+#include "io.h"
+#include "vector.h"
+#include <set>
+
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+
+#ifndef IPV6_V6ONLY
+// MinGW's headers are missing this.
+#define IPV6_V6ONLY 27
+#endif
+
+namespace kj {
+
+namespace _ {  // private
+
+int win32Socketpair(SOCKET socks[2]) {
+  // This function from: https://github.com/ncm/selectable-socketpair/blob/master/socketpair.c
+  //
+  // Copyright notice:
+  //
+  //    Copyright 2007, 2010 by Nathan C. Myers <ncm@cantrip.org>
+  //    Redistribution and use in source and binary forms, with or without modification,
+  //    are permitted provided that the following conditions are met:
+  //
+  //        Redistributions of source code must retain the above copyright notice, this
+  //        list of conditions and the following disclaimer.
+  //
+  //        Redistributions in binary form must reproduce the above copyright notice,
+  //        this list of conditions and the following disclaimer in the documentation
+  //        and/or other materials provided with the distribution.
+  //
+  //        The name of the author must not be used to endorse or promote products
+  //        derived from this software without specific prior written permission.
+  //
+  //    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  //    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  //    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  //    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  //    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  //    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  //    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  //    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  //    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  //    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  // Note: This function is called from some Cap'n Proto unit tests, despite not having a public
+  //   header declaration.
+  // TODO(cleanup): Consider putting this somewhere public? Note that since it depends on Winsock,
+  //   it needs to be in the kj-async library.
+
+  union {
+    struct sockaddr_in inaddr;
+    struct sockaddr addr;
+  } a;
+  SOCKET listener;
+  int e;
+  socklen_t addrlen = sizeof(a.inaddr);
+  int reuse = 1;
+
+  if (socks == 0) {
+    WSASetLastError(WSAEINVAL);
+    return SOCKET_ERROR;
+  }
+  socks[0] = socks[1] = -1;
+
+  listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (listener == -1)
+    return SOCKET_ERROR;
+
+  memset(&a, 0, sizeof(a));
+  a.inaddr.sin_family = AF_INET;
+  a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.inaddr.sin_port = 0;
+
+  for (;;) {
+    if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
+           (char*) &reuse, (socklen_t) sizeof(reuse)) == -1)
+      break;
+    if  (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
+      break;
+
+    memset(&a, 0, sizeof(a));
+    if  (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR)
+      break;
+    // win32 getsockname may only set the port number, p=0.0005.
+    // ( http://msdn.microsoft.com/library/ms738543.aspx ):
+    a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.inaddr.sin_family = AF_INET;
+
+    if (listen(listener, 1) == SOCKET_ERROR)
+      break;
+
+    socks[0] = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, WSA_FLAG_OVERLAPPED);
+    if (socks[0] == -1)
+      break;
+    if (connect(socks[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
+      break;
+
+    socks[1] = accept(listener, NULL, NULL);
+    if (socks[1] == -1)
+      break;
+
+    closesocket(listener);
+    return 0;
+  }
+
+  e = WSAGetLastError();
+  closesocket(listener);
+  closesocket(socks[0]);
+  closesocket(socks[1]);
+  WSASetLastError(e);
+  socks[0] = socks[1] = -1;
+  return SOCKET_ERROR;
+}
+
+}  // namespace _
+
+namespace {
+
+bool detectWine() {
+  HMODULE hntdll = GetModuleHandle("ntdll.dll");
+  if(hntdll == NULL) return false;
+  return GetProcAddress(hntdll, "wine_get_version") != nullptr;
+}
+
+bool isWine() {
+  static bool result = detectWine();
+  return result;
+}
+
+// =======================================================================================
+
+static constexpr uint NEW_FD_FLAGS = LowLevelAsyncIoProvider::TAKE_OWNERSHIP;
+
+class OwnedFd {
+public:
+  OwnedFd(SOCKET fd, uint flags): fd(fd), flags(flags) {
+    // TODO(perf): Maybe use SetFileCompletionNotificationModes() to tell Windows not to bother
+    //   delivering an event when the operation completes inline. Not currently implemented on
+    //   Wine, though.
+  }
+
+  ~OwnedFd() noexcept(false) {
+    if (flags & LowLevelAsyncIoProvider::TAKE_OWNERSHIP) {
+      KJ_WINSOCK(closesocket(fd)) { break; }
+    }
+    static_assert(sizeof(SOCKET) == 8, "nope");
+  }
+
+protected:
+  SOCKET fd;
+
+private:
+  uint flags;
+};
+
+// =======================================================================================
+
+class AsyncStreamFd: public OwnedFd, public AsyncIoStream {
+public:
+  AsyncStreamFd(Win32EventPort& eventPort, SOCKET fd, uint flags)
+      : OwnedFd(fd, flags),
+        observer(eventPort.observeIo(reinterpret_cast<HANDLE>(fd))) {}
+  virtual ~AsyncStreamFd() noexcept(false) {}
+
+  Promise<size_t> read(void* buffer, size_t minBytes, size_t maxBytes) override {
+    return tryRead(buffer, minBytes, maxBytes).then([=](size_t result) {
+      KJ_REQUIRE(result >= minBytes, "Premature EOF") {
+        // Pretend we read zeros from the input.
+        memset(reinterpret_cast<byte*>(buffer) + result, 0, minBytes - result);
+        return minBytes;
+      }
+      return result;
+    });
+  }
+
+  Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    auto bufs = heapArray<WSABUF>(1);
+    bufs[0].buf = reinterpret_cast<char*>(buffer);
+    bufs[0].len = maxBytes;
+
+    ArrayPtr<WSABUF> ref = bufs;
+    return tryReadInternal(ref, minBytes, 0).attach(kj::mv(bufs));
+  }
+
+  Promise<void> write(const void* buffer, size_t size) override {
+    auto bufs = heapArray<WSABUF>(1);
+    bufs[0].buf = const_cast<char*>(reinterpret_cast<const char*>(buffer));
+    bufs[0].len = size;
+
+    ArrayPtr<WSABUF> ref = bufs;
+    return writeInternal(ref).attach(kj::mv(bufs));
+  }
+
+  Promise<void> write(ArrayPtr<const ArrayPtr<const byte>> pieces) override {
+    auto bufs = heapArray<WSABUF>(pieces.size());
+    for (auto i: kj::indices(pieces)) {
+      bufs[i].buf = const_cast<char*>(pieces[i].asChars().begin());
+      bufs[i].len = pieces[i].size();
+    }
+
+    ArrayPtr<WSABUF> ref = bufs;
+    return writeInternal(ref).attach(kj::mv(bufs));
+  }
+
+  kj::Promise<void> connect(const struct sockaddr* addr, uint addrlen) {
+    // In order to connect asynchronously, we need the ConnectEx() function. Apparently, we have
+    // to query the socket for it dynamically, I guess because of the insanity in which winsock
+    // can be implemented in userspace and old implementations may not support it.
+    GUID guid = WSAID_CONNECTEX;
+    LPFN_CONNECTEX connectEx = nullptr;
+    DWORD n = 0;
+    KJ_WINSOCK(WSAIoctl(fd, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid),
+                        &connectEx, sizeof(connectEx), &n, NULL, NULL)) {
+      goto fail;  // avoid memory leak due to compiler bugs
+    }
+    if (false) {
+    fail:
+      return kj::READY_NOW;
+    }
+
+    // OK, phew, we now have our ConnectEx function pointer. Call it.
+    auto op = observer->newOperation(0);
+
+    if (!connectEx(fd, addr, addrlen, NULL, 0, NULL, op->getOverlapped())) {
+      DWORD error = WSAGetLastError();
+      if (error != ERROR_IO_PENDING) {
+        KJ_FAIL_WIN32("ConnectEx()", error) { break; }
+        return kj::READY_NOW;
+      }
+    }
+
+    return op->onComplete().then([this](Win32EventPort::IoResult result) {
+      if (result.errorCode != ERROR_SUCCESS) {
+        KJ_FAIL_WIN32("ConnectEx()", result.errorCode) { return; }
+      }
+
+      // Enable shutdown() to work.
+      setsockopt(SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+    });
+  }
+
+  void shutdownWrite() override {
+    // There's no legitimate way to get an AsyncStreamFd that isn't a socket through the
+    // Win32AsyncIoProvider interface.
+    KJ_WINSOCK(shutdown(fd, SD_SEND));
+  }
+
+  void abortRead() override {
+    // There's no legitimate way to get an AsyncStreamFd that isn't a socket through the
+    // Win32AsyncIoProvider interface.
+    KJ_WINSOCK(shutdown(fd, SD_RECEIVE));
+  }
+
+  void getsockopt(int level, int option, void* value, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_WINSOCK(::getsockopt(fd, level, option,
+                            reinterpret_cast<char*>(value), &socklen));
+    *length = socklen;
+  }
+
+  void setsockopt(int level, int option, const void* value, uint length) override {
+    KJ_WINSOCK(::setsockopt(fd, level, option,
+                            reinterpret_cast<const char*>(value), length));
+  }
+
+  void getsockname(struct sockaddr* addr, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_WINSOCK(::getsockname(fd, addr, &socklen));
+    *length = socklen;
+  }
+
+  void getpeername(struct sockaddr* addr, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_WINSOCK(::getpeername(fd, addr, &socklen));
+    *length = socklen;
+  }
+
+private:
+  Own<Win32EventPort::IoObserver> observer;
+
+  Promise<size_t> tryReadInternal(ArrayPtr<WSABUF> bufs, size_t minBytes, size_t alreadyRead) {
+    // `bufs` will remain valid until the promise completes and may be freely modified.
+    //
+    // `alreadyRead` is the number of bytes we have already received via previous reads -- minBytes
+    // and buffer have already been adjusted to account for them, but this count must be included
+    // in the final return value.
+
+    auto op = observer->newOperation(0);
+
+    DWORD flags = 0;
+    if (WSARecv(fd, bufs.begin(), bufs.size(), NULL, &flags,
+                op->getOverlapped(), NULL) == SOCKET_ERROR) {
+      DWORD error = WSAGetLastError();
+      if (error != WSA_IO_PENDING) {
+        KJ_FAIL_WIN32("WSARecv()", error) { break; }
+        return alreadyRead;
+      }
+    }
+
+    return op->onComplete()
+        .then([this,bufs,minBytes,alreadyRead](Win32IocpEventPort::IoResult result) mutable
+              -> Promise<size_t> {
+      if (result.errorCode != ERROR_SUCCESS) {
+        if (alreadyRead > 0) {
+          // Report what we already read.
+          return alreadyRead;
+        } else {
+          KJ_FAIL_WIN32("WSARecv()", result.errorCode) { break; }
+          return size_t(0);
+        }
+      }
+
+      if (result.bytesTransferred == 0) {
+        return alreadyRead;
+      }
+
+      alreadyRead += result.bytesTransferred;
+      if (result.bytesTransferred >= minBytes) {
+        // We can stop here.
+        return alreadyRead;
+      }
+      minBytes -= result.bytesTransferred;
+
+      while (result.bytesTransferred >= bufs[0].len) {
+        result.bytesTransferred -= bufs[0].len;
+        bufs = bufs.slice(1, bufs.size());
+      }
+
+      if (result.bytesTransferred > 0) {
+        bufs[0].buf += result.bytesTransferred;
+        bufs[0].len -= result.bytesTransferred;
+      }
+
+      return tryReadInternal(bufs, minBytes, alreadyRead);
+    }).attach(kj::mv(bufs));
+  }
+
+  Promise<void> writeInternal(ArrayPtr<WSABUF> bufs) {
+    // `bufs` will remain valid until the promise completes and may be freely modified.
+
+    auto op = observer->newOperation(0);
+
+    if (WSASend(fd, bufs.begin(), bufs.size(), NULL, 0,
+                op->getOverlapped(), NULL) == SOCKET_ERROR) {
+      DWORD error = WSAGetLastError();
+      if (error != WSA_IO_PENDING) {
+        KJ_FAIL_WIN32("WSASend()", error) { break; }
+        return kj::READY_NOW;
+      }
+    }
+
+    return op->onComplete()
+        .then([this,bufs](Win32IocpEventPort::IoResult result) mutable -> Promise<void> {
+      if (result.errorCode != ERROR_SUCCESS) {
+        KJ_FAIL_WIN32("WSASend()", result.errorCode) { break; }
+        return kj::READY_NOW;
+      }
+
+      while (bufs.size() > 0 && result.bytesTransferred >= bufs[0].len) {
+        result.bytesTransferred -= bufs[0].len;
+        bufs = bufs.slice(1, bufs.size());
+      }
+
+      if (result.bytesTransferred > 0) {
+        bufs[0].buf += result.bytesTransferred;
+        bufs[0].len -= result.bytesTransferred;
+      }
+
+      if (bufs.size() > 0) {
+        return writeInternal(bufs);
+      } else {
+        return kj::READY_NOW;
+      }
+    }).attach(kj::mv(bufs));
+  }
+};
+
+// =======================================================================================
+
+class SocketAddress {
+public:
+  SocketAddress(const void* sockaddr, uint len): addrlen(len) {
+    KJ_REQUIRE(len <= sizeof(addr), "Sorry, your sockaddr is too big for me.");
+    memcpy(&addr.generic, sockaddr, len);
+  }
+
+  bool operator<(const SocketAddress& other) const {
+    // So we can use std::set<SocketAddress>...  see DNS lookup code.
+
+    if (wildcard < other.wildcard) return true;
+    if (wildcard > other.wildcard) return false;
+
+    if (addrlen < other.addrlen) return true;
+    if (addrlen > other.addrlen) return false;
+
+    return memcmp(&addr.generic, &other.addr.generic, addrlen) < 0;
+  }
+
+  const struct sockaddr* getRaw() const { return &addr.generic; }
+  int getRawSize() const { return addrlen; }
+
+  SOCKET socket(int type) const {
+    bool isStream = type == SOCK_STREAM;
+
+    SOCKET result = ::socket(addr.generic.sa_family, type, 0);
+
+    if (result == INVALID_SOCKET) {
+      KJ_FAIL_WIN32("WSASocket()", WSAGetLastError()) { return INVALID_SOCKET; }
+    }
+
+    if (isStream && (addr.generic.sa_family == AF_INET ||
+                     addr.generic.sa_family == AF_INET6)) {
+      // TODO(perf):  As a hack for the 0.4 release we are always setting
+      //   TCP_NODELAY because Nagle's algorithm pretty much kills Cap'n Proto's
+      //   RPC protocol.  Later, we should extend the interface to provide more
+      //   control over this.  Perhaps write() should have a flag which
+      //   specifies whether to pass MSG_MORE.
+      BOOL one = TRUE;
+      KJ_WINSOCK(setsockopt(result, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one)));
+    }
+
+    return result;
+  }
+
+  void bind(SOCKET sockfd) const {
+    if (wildcard) {
+      // Disable IPV6_V6ONLY because we want to handle both ipv4 and ipv6 on this socket.  (The
+      // default value of this option varies across platforms.)
+      DWORD value = 0;
+      KJ_WINSOCK(setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY,
+                            reinterpret_cast<char*>(&value), sizeof(value)));
+    }
+
+    KJ_WINSOCK(::bind(sockfd, &addr.generic, addrlen), toString());
+  }
+
+  uint getPort() const {
+    switch (addr.generic.sa_family) {
+      case AF_INET: return ntohs(addr.inet4.sin_port);
+      case AF_INET6: return ntohs(addr.inet6.sin6_port);
+      default: return 0;
+    }
+  }
+
+  String toString() const {
+    if (wildcard) {
+      return str("*:", getPort());
+    }
+
+    switch (addr.generic.sa_family) {
+      case AF_INET: {
+        char buffer[16];
+        if (InetNtopA(addr.inet4.sin_family, const_cast<struct in_addr*>(&addr.inet4.sin_addr),
+                      buffer, sizeof(buffer)) == nullptr) {
+          KJ_FAIL_WIN32("InetNtop", WSAGetLastError()) { break; }
+          return heapString("(inet_ntop error)");
+        }
+        return str(buffer, ':', ntohs(addr.inet4.sin_port));
+      }
+      case AF_INET6: {
+        char buffer[46];
+        if (InetNtopA(addr.inet6.sin6_family, const_cast<struct in6_addr*>(&addr.inet6.sin6_addr),
+                      buffer, sizeof(buffer)) == nullptr) {
+          KJ_FAIL_WIN32("InetNtop", WSAGetLastError()) { break; }
+          return heapString("(inet_ntop error)");
+        }
+        return str('[', buffer, "]:", ntohs(addr.inet6.sin6_port));
+      }
+      default:
+        return str("(unknown address family ", addr.generic.sa_family, ")");
+    }
+  }
+
+  static Promise<Array<SocketAddress>> lookupHost(
+      LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint);
+  // Perform a DNS lookup.
+
+  static Promise<Array<SocketAddress>> parse(
+      LowLevelAsyncIoProvider& lowLevel, StringPtr str, uint portHint) {
+    // TODO(someday):  Allow commas in `str`.
+
+    SocketAddress result;
+
+    // Try to separate the address and port.
+    ArrayPtr<const char> addrPart;
+    Maybe<StringPtr> portPart;
+
+    int af;
+
+    if (str.startsWith("[")) {
+      // Address starts with a bracket, which is a common way to write an ip6 address with a port,
+      // since without brackets around the address part, the port looks like another segment of
+      // the address.
+      af = AF_INET6;
+      size_t closeBracket = KJ_ASSERT_NONNULL(str.findLast(']'),
+          "Unclosed '[' in address string.", str);
+
+      addrPart = str.slice(1, closeBracket);
+      if (str.size() > closeBracket + 1) {
+        KJ_REQUIRE(str.slice(closeBracket + 1).startsWith(":"),
+                   "Expected port suffix after ']'.", str);
+        portPart = str.slice(closeBracket + 2);
+      }
+    } else {
+      KJ_IF_MAYBE(colon, str.findFirst(':')) {
+        if (str.slice(*colon + 1).findFirst(':') == nullptr) {
+          // There is exactly one colon and no brackets, so it must be an ip4 address with port.
+          af = AF_INET;
+          addrPart = str.slice(0, *colon);
+          portPart = str.slice(*colon + 1);
+        } else {
+          // There are two or more colons and no brackets, so the whole thing must be an ip6
+          // address with no port.
+          af = AF_INET6;
+          addrPart = str;
+        }
+      } else {
+        // No colons, so it must be an ip4 address without port.
+        af = AF_INET;
+        addrPart = str;
+      }
+    }
+
+    // Parse the port.
+    unsigned long port;
+    KJ_IF_MAYBE(portText, portPart) {
+      char* endptr;
+      port = strtoul(portText->cStr(), &endptr, 0);
+      if (portText->size() == 0 || *endptr != '\0') {
+        // Not a number.  Maybe it's a service name.  Fall back to DNS.
+        return lookupHost(lowLevel, kj::heapString(addrPart), kj::heapString(*portText), portHint);
+      }
+      KJ_REQUIRE(port < 65536, "Port number too large.");
+    } else {
+      port = portHint;
+    }
+
+    // Check for wildcard.
+    if (addrPart.size() == 1 && addrPart[0] == '*') {
+      result.wildcard = true;
+      // Create an ip6 socket and set IPV6_V6ONLY to 0 later.
+      result.addrlen = sizeof(addr.inet6);
+      result.addr.inet6.sin6_family = AF_INET6;
+      result.addr.inet6.sin6_port = htons(port);
+      auto array = kj::heapArrayBuilder<SocketAddress>(1);
+      array.add(result);
+      return array.finish();
+    }
+
+    void* addrTarget;
+    if (af == AF_INET6) {
+      result.addrlen = sizeof(addr.inet6);
+      result.addr.inet6.sin6_family = AF_INET6;
+      result.addr.inet6.sin6_port = htons(port);
+      addrTarget = &result.addr.inet6.sin6_addr;
+    } else {
+      result.addrlen = sizeof(addr.inet4);
+      result.addr.inet4.sin_family = AF_INET;
+      result.addr.inet4.sin_port = htons(port);
+      addrTarget = &result.addr.inet4.sin_addr;
+    }
+
+    // addrPart is not necessarily NUL-terminated so we have to make a copy.  :(
+    char buffer[64];
+    KJ_REQUIRE(addrPart.size() < sizeof(buffer) - 1, "IP address too long.", addrPart);
+    memcpy(buffer, addrPart.begin(), addrPart.size());
+    buffer[addrPart.size()] = '\0';
+
+    // OK, parse it!
+    switch (InetPtonA(af, buffer, addrTarget)) {
+      case 1: {
+        // success.
+        auto array = kj::heapArrayBuilder<SocketAddress>(1);
+        array.add(result);
+        return array.finish();
+      }
+      case 0:
+        // It's apparently not a simple address...  fall back to DNS.
+        return lookupHost(lowLevel, kj::heapString(addrPart), nullptr, port);
+      default:
+        KJ_FAIL_WIN32("InetPton", WSAGetLastError(), af, addrPart);
+    }
+  }
+
+  static SocketAddress getLocalAddress(int sockfd) {
+    SocketAddress result;
+    result.addrlen = sizeof(addr);
+    KJ_WINSOCK(getsockname(sockfd, &result.addr.generic, &result.addrlen));
+    return result;
+  }
+
+  static SocketAddress getWildcardForFamily(int family) {
+    SocketAddress result;
+    switch (family) {
+      case AF_INET:
+        result.addrlen = sizeof(addr.inet4);
+        result.addr.inet4.sin_family = AF_INET;
+        return result;
+      case AF_INET6:
+        result.addrlen = sizeof(addr.inet6);
+        result.addr.inet6.sin6_family = AF_INET6;
+        return result;
+      default:
+        KJ_FAIL_REQUIRE("unknown address family", family);
+    }
+  }
+
+private:
+  SocketAddress(): addrlen(0) {
+    memset(&addr, 0, sizeof(addr));
+  }
+
+  socklen_t addrlen;
+  bool wildcard = false;
+  union {
+    struct sockaddr generic;
+    struct sockaddr_in inet4;
+    struct sockaddr_in6 inet6;
+    struct sockaddr_storage storage;
+  } addr;
+
+  struct LookupParams;
+  class LookupReader;
+};
+
+class SocketAddress::LookupReader {
+  // Reads SocketAddresses off of a pipe coming from another thread that is performing
+  // getaddrinfo.
+
+public:
+  LookupReader(kj::Own<Thread>&& thread, kj::Own<AsyncInputStream>&& input)
+      : thread(kj::mv(thread)), input(kj::mv(input)) {}
+
+  ~LookupReader() {
+    if (thread) thread->detach();
+  }
+
+  Promise<Array<SocketAddress>> read() {
+    return input->tryRead(&current, sizeof(current), sizeof(current)).then(
+        [this](size_t n) -> Promise<Array<SocketAddress>> {
+      if (n < sizeof(current)) {
+        thread = nullptr;
+        // getaddrinfo()'s docs seem to say it will never return an empty list, but let's check
+        // anyway.
+        KJ_REQUIRE(addresses.size() > 0, "DNS lookup returned no addresses.") { break; }
+        return addresses.releaseAsArray();
+      } else {
+        // getaddrinfo() can return multiple copies of the same address for several reasons.
+        // A major one is that we don't give it a socket type (SOCK_STREAM vs. SOCK_DGRAM), so
+        // it may return two copies of the same address, one for each type, unless it explicitly
+        // knows that the service name given is specific to one type.  But we can't tell it a type,
+        // because we don't actually know which one the user wants, and if we specify SOCK_STREAM
+        // while the user specified a UDP service name then they'll get a resolution error which
+        // is lame.  (At least, I think that's how it works.)
+        //
+        // So we instead resort to de-duping results.
+        if (alreadySeen.insert(current).second) {
+          addresses.add(current);
+        }
+        return read();
+      }
+    });
+  }
+
+private:
+  kj::Own<Thread> thread;
+  kj::Own<AsyncInputStream> input;
+  SocketAddress current;
+  kj::Vector<SocketAddress> addresses;
+  std::set<SocketAddress> alreadySeen;
+};
+
+struct SocketAddress::LookupParams {
+  kj::String host;
+  kj::String service;
+};
+
+Promise<Array<SocketAddress>> SocketAddress::lookupHost(
+    LowLevelAsyncIoProvider& lowLevel, kj::String host, kj::String service, uint portHint) {
+  // This shitty function spawns a thread to run getaddrinfo().  Unfortunately, getaddrinfo() is
+  // the only cross-platform DNS API and it is blocking.
+  //
+  // TODO(perf): Use GetAddrInfoEx(). But there are problems:
+  // - Not implemented in Wine.
+  // - Doesn't seem compatible with I/O completion ports, in particular because it's not associated
+  //   with a handle. Could signal completion as an APC instead, but that requires the IOCP code
+  //   to use GetQueuedCompletionStatusEx() which it doesn't right now becaues it's not available
+  //   in Wine.
+  // - Requires Unicode, for some reason. Only GetAddrInfoExW() supports async, according to the
+  //   docs. Never mind that DNS itself is ASCII...
+
+  SOCKET fds[2];
+  KJ_WINSOCK(_::win32Socketpair(fds));
+
+  auto input = lowLevel.wrapInputFd(fds[0], NEW_FD_FLAGS);
+
+  int outFd = fds[1];
+
+  LookupParams params = { kj::mv(host), kj::mv(service) };
+
+  auto thread = heap<Thread>(kj::mvCapture(params, [outFd,portHint](LookupParams&& params) {
+    KJ_DEFER(closesocket(outFd));
+
+    struct addrinfo* list;
+    int status = getaddrinfo(
+        params.host == "*" ? nullptr : params.host.cStr(),
+        params.service == nullptr ? nullptr : params.service.cStr(),
+        nullptr, &list);
+    if (status == 0) {
+      KJ_DEFER(freeaddrinfo(list));
+
+      struct addrinfo* cur = list;
+      while (cur != nullptr) {
+        if (params.service == nullptr) {
+          switch (cur->ai_addr->sa_family) {
+            case AF_INET:
+              ((struct sockaddr_in*)cur->ai_addr)->sin_port = htons(portHint);
+              break;
+            case AF_INET6:
+              ((struct sockaddr_in6*)cur->ai_addr)->sin6_port = htons(portHint);
+              break;
+            default:
+              break;
+          }
+        }
+
+        SocketAddress addr;
+        memset(&addr, 0, sizeof(addr));  // mollify valgrind
+        if (params.host == "*") {
+          // Set up a wildcard SocketAddress.  Only use the port number returned by getaddrinfo().
+          addr.wildcard = true;
+          addr.addrlen = sizeof(addr.addr.inet6);
+          addr.addr.inet6.sin6_family = AF_INET6;
+          switch (cur->ai_addr->sa_family) {
+            case AF_INET:
+              addr.addr.inet6.sin6_port = ((struct sockaddr_in*)cur->ai_addr)->sin_port;
+              break;
+            case AF_INET6:
+              addr.addr.inet6.sin6_port = ((struct sockaddr_in6*)cur->ai_addr)->sin6_port;
+              break;
+            default:
+              addr.addr.inet6.sin6_port = portHint;
+              break;
+          }
+        } else {
+          addr.addrlen = cur->ai_addrlen;
+          memcpy(&addr.addr.generic, cur->ai_addr, cur->ai_addrlen);
+        }
+        static_assert(canMemcpy<SocketAddress>(), "Can't write() SocketAddress...");
+
+        const char* data = reinterpret_cast<const char*>(&addr);
+        size_t size = sizeof(addr);
+        while (size > 0) {
+          int n;
+          KJ_WINSOCK(n = send(outFd, data, size, 0));
+          data += n;
+          size -= n;
+        }
+
+        cur = cur->ai_next;
+      }
+    } else {
+      KJ_FAIL_WIN32("getaddrinfo()", status, params.host, params.service) {
+        return;
+      }
+    }
+  }));
+
+  auto reader = heap<LookupReader>(kj::mv(thread), kj::mv(input));
+  return reader->read().attach(kj::mv(reader));
+}
+
+// =======================================================================================
+
+class FdConnectionReceiver final: public ConnectionReceiver, public OwnedFd {
+public:
+  FdConnectionReceiver(Win32EventPort& eventPort, SOCKET fd, uint flags)
+      : OwnedFd(fd, flags), eventPort(eventPort),
+        observer(eventPort.observeIo(reinterpret_cast<HANDLE>(fd))),
+        address(SocketAddress::getLocalAddress(fd)) {
+    // In order to accept asynchronously, we need the AcceptEx() function. Apparently, we have
+    // to query the socket for it dynamically, I guess because of the insanity in which winsock
+    // can be implemented in userspace and old implementations may not support it.
+    GUID guid = WSAID_ACCEPTEX;
+    DWORD n = 0;
+    KJ_WINSOCK(WSAIoctl(fd, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid),
+                        &acceptEx, sizeof(acceptEx), &n, NULL, NULL)) {
+      acceptEx = nullptr;
+      return;
+    }
+  }
+
+  Promise<Own<AsyncIoStream>> accept() override {
+    SOCKET newFd = address.socket(SOCK_STREAM);
+    KJ_ASSERT(newFd != INVALID_SOCKET);
+    auto result = heap<AsyncStreamFd>(eventPort, newFd, NEW_FD_FLAGS);
+
+    auto scratch = heapArray<byte>(256);
+    DWORD dummy;
+    auto op = observer->newOperation(0);
+    if (!acceptEx(fd, newFd, scratch.begin(), 0, 128, 128, &dummy, op->getOverlapped())) {
+      DWORD error = WSAGetLastError();
+      if (error != ERROR_IO_PENDING) {
+        KJ_FAIL_WIN32("AcceptEx()", error) { break; }
+        return Own<AsyncIoStream>(kj::mv(result));  // dummy, won't be used
+      }
+    }
+
+    return op->onComplete().attach(kj::mv(scratch)).then(mvCapture(result,
+        [this](Own<AsyncIoStream> stream, Win32EventPort::IoResult ioResult) {
+      if (ioResult.errorCode != ERROR_SUCCESS) {
+        KJ_FAIL_WIN32("AcceptEx()", ioResult.errorCode) { break; }
+      } else {
+        SOCKET me = fd;
+        stream->setsockopt(SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
+                           reinterpret_cast<char*>(&me), sizeof(me));
+      }
+      return kj::mv(stream);
+    }));
+  }
+
+  uint getPort() override {
+    return address.getPort();
+  }
+
+  void getsockopt(int level, int option, void* value, uint* length) override {
+    socklen_t socklen = *length;
+    KJ_WINSOCK(::getsockopt(fd, level, option,
+                            reinterpret_cast<char*>(value), &socklen));
+    *length = socklen;
+  }
+  void setsockopt(int level, int option, const void* value, uint length) override {
+    KJ_WINSOCK(::setsockopt(fd, level, option,
+                            reinterpret_cast<const char*>(value), length));
+  }
+
+public:
+  Win32EventPort& eventPort;
+  Own<Win32EventPort::IoObserver> observer;
+  LPFN_ACCEPTEX acceptEx = nullptr;
+  SocketAddress address;
+};
+
+// TODO(someday): DatagramPortImpl
+
+class LowLevelAsyncIoProviderImpl final: public LowLevelAsyncIoProvider {
+public:
+  LowLevelAsyncIoProviderImpl()
+      : eventLoop(eventPort), waitScope(eventLoop) {}
+
+  inline WaitScope& getWaitScope() { return waitScope; }
+
+  Own<AsyncInputStream> wrapInputFd(SOCKET fd, uint flags = 0) override {
+    return heap<AsyncStreamFd>(eventPort, fd, flags);
+  }
+  Own<AsyncOutputStream> wrapOutputFd(SOCKET fd, uint flags = 0) override {
+    return heap<AsyncStreamFd>(eventPort, fd, flags);
+  }
+  Own<AsyncIoStream> wrapSocketFd(SOCKET fd, uint flags = 0) override {
+    return heap<AsyncStreamFd>(eventPort, fd, flags);
+  }
+  Promise<Own<AsyncIoStream>> wrapConnectingSocketFd(
+      SOCKET fd, const struct sockaddr* addr, uint addrlen, uint flags = 0) override {
+    auto result = heap<AsyncStreamFd>(eventPort, fd, flags);
+
+    // ConnectEx requires that the socket be bound, for some reason. Bind to an arbitrary port.
+    SocketAddress::getWildcardForFamily(addr->sa_family).bind(fd);
+
+    auto connected = result->connect(addr, addrlen);
+    return connected.then(kj::mvCapture(result, [](Own<AsyncIoStream>&& result) {
+      return kj::mv(result);
+    }));
+  }
+  Own<ConnectionReceiver> wrapListenSocketFd(SOCKET fd, uint flags = 0) override {
+    return heap<FdConnectionReceiver>(eventPort, fd, flags);
+  }
+
+  Timer& getTimer() override { return eventPort.getTimer(); }
+
+  Win32EventPort& getEventPort() { return eventPort; }
+
+private:
+  Win32IocpEventPort eventPort;
+  EventLoop eventLoop;
+  WaitScope waitScope;
+};
+
+// =======================================================================================
+
+class NetworkAddressImpl final: public NetworkAddress {
+public:
+  NetworkAddressImpl(LowLevelAsyncIoProvider& lowLevel, Array<SocketAddress> addrs)
+      : lowLevel(lowLevel), addrs(kj::mv(addrs)) {}
+
+  Promise<Own<AsyncIoStream>> connect() override {
+    auto addrsCopy = heapArray(addrs.asPtr());
+    auto promise = connectImpl(lowLevel, addrsCopy);
+    return promise.attach(kj::mv(addrsCopy));
+  }
+
+  Own<ConnectionReceiver> listen() override {
+    if (addrs.size() > 1) {
+      KJ_LOG(WARNING, "Bind address resolved to multiple addresses.  Only the first address will "
+          "be used.  If this is incorrect, specify the address numerically.  This may be fixed "
+          "in the future.", addrs[0].toString());
+    }
+
+    int fd = addrs[0].socket(SOCK_STREAM);
+
+    {
+      KJ_ON_SCOPE_FAILURE(closesocket(fd));
+
+      // We always enable SO_REUSEADDR because having to take your server down for five minutes
+      // before it can restart really sucks.
+      int optval = 1;
+      KJ_WINSOCK(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
+                            reinterpret_cast<char*>(&optval), sizeof(optval)));
+
+      addrs[0].bind(fd);
+
+      // TODO(someday):  Let queue size be specified explicitly in string addresses.
+      KJ_WINSOCK(::listen(fd, SOMAXCONN));
+    }
+
+    return lowLevel.wrapListenSocketFd(fd, NEW_FD_FLAGS);
+  }
+
+  Own<DatagramPort> bindDatagramPort() override {
+    if (addrs.size() > 1) {
+      KJ_LOG(WARNING, "Bind address resolved to multiple addresses.  Only the first address will "
+          "be used.  If this is incorrect, specify the address numerically.  This may be fixed "
+          "in the future.", addrs[0].toString());
+    }
+
+    int fd = addrs[0].socket(SOCK_DGRAM);
+
+    {
+      KJ_ON_SCOPE_FAILURE(closesocket(fd));
+
+      // We always enable SO_REUSEADDR because having to take your server down for five minutes
+      // before it can restart really sucks.
+      int optval = 1;
+      KJ_WINSOCK(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
+                            reinterpret_cast<char*>(&optval), sizeof(optval)));
+
+      addrs[0].bind(fd);
+    }
+
+    return lowLevel.wrapDatagramSocketFd(fd, NEW_FD_FLAGS);
+  }
+
+  Own<NetworkAddress> clone() override {
+    return kj::heap<NetworkAddressImpl>(lowLevel, kj::heapArray(addrs.asPtr()));
+  }
+
+  String toString() override {
+    return strArray(KJ_MAP(addr, addrs) { return addr.toString(); }, ",");
+  }
+
+  const SocketAddress& chooseOneAddress() {
+    KJ_REQUIRE(addrs.size() > 0, "No addresses available.");
+    return addrs[counter++ % addrs.size()];
+  }
+
+private:
+  LowLevelAsyncIoProvider& lowLevel;
+  Array<SocketAddress> addrs;
+  uint counter = 0;
+
+  static Promise<Own<AsyncIoStream>> connectImpl(
+      LowLevelAsyncIoProvider& lowLevel, ArrayPtr<SocketAddress> addrs) {
+    KJ_ASSERT(addrs.size() > 0);
+
+    int fd = addrs[0].socket(SOCK_STREAM);
+
+    return kj::evalNow([&]() {
+      return lowLevel.wrapConnectingSocketFd(
+          fd, addrs[0].getRaw(), addrs[0].getRawSize(), NEW_FD_FLAGS);
+    }).then([](Own<AsyncIoStream>&& stream) -> Promise<Own<AsyncIoStream>> {
+      // Success, pass along.
+      return kj::mv(stream);
+    }, [&lowLevel,addrs](Exception&& exception) mutable -> Promise<Own<AsyncIoStream>> {
+      // Connect failed.
+      if (addrs.size() > 1) {
+        // Try the next address instead.
+        return connectImpl(lowLevel, addrs.slice(1, addrs.size()));
+      } else {
+        // No more addresses to try, so propagate the exception.
+        return kj::mv(exception);
+      }
+    });
+  }
+};
+
+class SocketNetwork final: public Network {
+public:
+  explicit SocketNetwork(LowLevelAsyncIoProvider& lowLevel): lowLevel(lowLevel) {}
+
+  Promise<Own<NetworkAddress>> parseAddress(StringPtr addr, uint portHint = 0) override {
+    auto& lowLevelCopy = lowLevel;
+    return evalLater(mvCapture(heapString(addr),
+        [&lowLevelCopy,portHint](String&& addr) {
+      return SocketAddress::parse(lowLevelCopy, addr, portHint);
+    })).then([&lowLevelCopy](Array<SocketAddress> addresses) -> Own<NetworkAddress> {
+      return heap<NetworkAddressImpl>(lowLevelCopy, kj::mv(addresses));
+    });
+  }
+
+  Own<NetworkAddress> getSockaddr(const void* sockaddr, uint len) override {
+    auto array = kj::heapArrayBuilder<SocketAddress>(1);
+    array.add(SocketAddress(sockaddr, len));
+    return Own<NetworkAddress>(heap<NetworkAddressImpl>(lowLevel, array.finish()));
+  }
+
+private:
+  LowLevelAsyncIoProvider& lowLevel;
+};
+
+// =======================================================================================
+
+class AsyncIoProviderImpl final: public AsyncIoProvider {
+public:
+  AsyncIoProviderImpl(LowLevelAsyncIoProvider& lowLevel)
+      : lowLevel(lowLevel), network(lowLevel) {}
+
+  OneWayPipe newOneWayPipe() override {
+    SOCKET fds[2];
+    KJ_WINSOCK(_::win32Socketpair(fds));
+    auto in = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
+    auto out = lowLevel.wrapOutputFd(fds[1], NEW_FD_FLAGS);
+    in->shutdownWrite();
+    return { kj::mv(in), kj::mv(out) };
+  }
+
+  TwoWayPipe newTwoWayPipe() override {
+    SOCKET fds[2];
+    KJ_WINSOCK(_::win32Socketpair(fds));
+    return TwoWayPipe { {
+      lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS),
+      lowLevel.wrapSocketFd(fds[1], NEW_FD_FLAGS)
+    } };
+  }
+
+  Network& getNetwork() override {
+    return network;
+  }
+
+  PipeThread newPipeThread(
+      Function<void(AsyncIoProvider&, AsyncIoStream&, WaitScope&)> startFunc) override {
+    SOCKET fds[2];
+    KJ_WINSOCK(_::win32Socketpair(fds));
+
+    int threadFd = fds[1];
+    KJ_ON_SCOPE_FAILURE(closesocket(threadFd));
+
+    auto pipe = lowLevel.wrapSocketFd(fds[0], NEW_FD_FLAGS);
+
+    auto thread = heap<Thread>(kj::mvCapture(startFunc,
+        [threadFd](Function<void(AsyncIoProvider&, AsyncIoStream&, WaitScope&)>&& startFunc) {
+      LowLevelAsyncIoProviderImpl lowLevel;
+      auto stream = lowLevel.wrapSocketFd(threadFd, NEW_FD_FLAGS);
+      AsyncIoProviderImpl ioProvider(lowLevel);
+      startFunc(ioProvider, *stream, lowLevel.getWaitScope());
+    }));
+
+    return { kj::mv(thread), kj::mv(pipe) };
+  }
+
+  Timer& getTimer() override { return lowLevel.getTimer(); }
+
+private:
+  LowLevelAsyncIoProvider& lowLevel;
+  SocketNetwork network;
+};
+
+}  // namespace
+
+Promise<void> AsyncInputStream::read(void* buffer, size_t bytes) {
+  return read(buffer, bytes, bytes).then([](size_t) {});
+}
+
+void AsyncIoStream::getsockopt(int level, int option, void* value, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void AsyncIoStream::setsockopt(int level, int option, const void* value, uint length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void AsyncIoStream::getsockname(struct sockaddr* addr, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void AsyncIoStream::getpeername(struct sockaddr* addr, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void ConnectionReceiver::getsockopt(int level, int option, void* value, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void ConnectionReceiver::setsockopt(int level, int option, const void* value, uint length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void DatagramPort::getsockopt(int level, int option, void* value, uint* length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+void DatagramPort::setsockopt(int level, int option, const void* value, uint length) {
+  KJ_UNIMPLEMENTED("Not a socket.");
+}
+Own<DatagramPort> NetworkAddress::bindDatagramPort() {
+  KJ_UNIMPLEMENTED("Datagram sockets not implemented.");
+}
+Own<DatagramPort> LowLevelAsyncIoProvider::wrapDatagramSocketFd(SOCKET fd, uint flags) {
+  KJ_UNIMPLEMENTED("Datagram sockets not implemented.");
+}
+
+Own<AsyncIoProvider> newAsyncIoProvider(LowLevelAsyncIoProvider& lowLevel) {
+  return kj::heap<AsyncIoProviderImpl>(lowLevel);
+}
+
+AsyncIoContext setupAsyncIo() {
+  WSADATA dontcare;
+  int result = WSAStartup(MAKEWORD(2, 2), &dontcare);
+  if (result != 0) {
+    KJ_FAIL_WIN32("WSAStartup()", result);
+  }
+
+  auto lowLevel = heap<LowLevelAsyncIoProviderImpl>();
+  auto ioProvider = kj::heap<AsyncIoProviderImpl>(*lowLevel);
+  auto& waitScope = lowLevel->getWaitScope();
+  auto& eventPort = lowLevel->getEventPort();
+  return { kj::mv(lowLevel), kj::mv(ioProvider), waitScope, eventPort };
+}
+
+}  // namespace kj
+
+#endif  // _WIN32

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -19,6 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !_WIN32
+// For Win32 implementation, see async-io-win32.c++.
+
 #include "async-io.h"
 #include "async-unix.h"
 #include "debug.h"
@@ -1381,3 +1384,5 @@ AsyncIoContext setupAsyncIo() {
 }
 
 }  // namespace kj
+
+#endif  // !_WIN32

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -893,28 +893,10 @@ public:
   UnixEventPort::FdObserver observer;
 };
 
-class TimerImpl final: public Timer {
-public:
-  TimerImpl(UnixEventPort& eventPort): eventPort(eventPort) {}
-
-  TimePoint now() override { return eventPort.steadyTime(); }
-
-  Promise<void> atTime(TimePoint time) override {
-    return eventPort.atSteadyTime(time);
-  }
-
-  Promise<void> afterDelay(Duration delay) override {
-    return eventPort.atSteadyTime(eventPort.steadyTime() + delay);
-  }
-
-private:
-  UnixEventPort& eventPort;
-};
-
 class LowLevelAsyncIoProviderImpl final: public LowLevelAsyncIoProvider {
 public:
   LowLevelAsyncIoProviderImpl()
-      : eventLoop(eventPort), timer(eventPort), waitScope(eventLoop) {}
+      : eventLoop(eventPort), waitScope(eventLoop) {}
 
   inline WaitScope& getWaitScope() { return waitScope; }
 
@@ -948,14 +930,13 @@ public:
     return heap<DatagramPortImpl>(*this, eventPort, fd, flags);
   }
 
-  Timer& getTimer() override { return timer; }
+  Timer& getTimer() override { return eventPort.getTimer(); }
 
   UnixEventPort& getEventPort() { return eventPort; }
 
 private:
   UnixEventPort eventPort;
   EventLoop eventLoop;
-  TimerImpl timer;
   WaitScope waitScope;
 };
 

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -463,7 +463,8 @@ public:
         char buffer[INET6_ADDRSTRLEN];
         if (inet_ntop(addr.inet4.sin_family, &addr.inet4.sin_addr,
                       buffer, sizeof(buffer)) == nullptr) {
-          KJ_FAIL_SYSCALL("inet_ntop", errno) { return heapString("(inet_ntop error)"); }
+          KJ_FAIL_SYSCALL("inet_ntop", errno) { break; }
+          return heapString("(inet_ntop error)");
         }
         return str(buffer, ':', ntohs(addr.inet4.sin_port));
       }
@@ -471,7 +472,8 @@ public:
         char buffer[INET6_ADDRSTRLEN];
         if (inet_ntop(addr.inet6.sin6_family, &addr.inet6.sin6_addr,
                       buffer, sizeof(buffer)) == nullptr) {
-          KJ_FAIL_SYSCALL("inet_ntop", errno) { return heapString("(inet_ntop error)"); }
+          KJ_FAIL_SYSCALL("inet_ntop", errno) { break; }
+          return heapString("(inet_ntop error)");
         }
         return str('[', buffer, "]:", ntohs(addr.inet6.sin6_port));
       }

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -532,14 +532,16 @@ TEST(AsyncUnixTest, SteadyTimers) {
   EventLoop loop(port);
   WaitScope waitScope(loop);
 
-  auto start = port.steadyTime();
+  auto& timer = port.getTimer();
+
+  auto start = timer.now();
   kj::Vector<TimePoint> expected;
   kj::Vector<TimePoint> actual;
 
   auto addTimer = [&](Duration delay) {
     expected.add(max(start + delay, start));
-    port.atSteadyTime(start + delay).then([&]() {
-      actual.add(port.steadyTime());
+    timer.atTime(start + delay).then([&]() {
+      actual.add(timer.now());
     }).detach([](Exception&& e) { ADD_FAILURE() << str(e).cStr(); });
   };
 
@@ -550,7 +552,7 @@ TEST(AsyncUnixTest, SteadyTimers) {
   addTimer(-10 * MILLISECONDS);
 
   std::sort(expected.begin(), expected.end());
-  port.atSteadyTime(expected.back() + MILLISECONDS).wait(waitScope);
+  timer.atTime(expected.back() + MILLISECONDS).wait(waitScope);
 
   ASSERT_EQ(expected.size(), actual.size());
   for (int i = 0; i < expected.size(); ++i) {
@@ -574,7 +576,7 @@ TEST(AsyncUnixTest, Wake) {
   EXPECT_TRUE(port.wait());
 
   {
-    auto promise = port.atSteadyTime(port.steadyTime());
+    auto promise = port.getTimer().atTime(port.getTimer().now());
     EXPECT_FALSE(port.wait());
   }
 

--- a/c++/src/kj/async-unix-test.c++
+++ b/c++/src/kj/async-unix-test.c++
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !_WIN32
+
 #include "async-unix.h"
 #include "thread.h"
 #include "debug.h"
@@ -34,6 +36,7 @@
 #include <algorithm>
 
 namespace kj {
+namespace {
 
 inline void delay() { usleep(10000); }
 
@@ -585,4 +588,7 @@ TEST(AsyncUnixTest, Wake) {
   EXPECT_TRUE(port.wait());
 }
 
+}  // namespace
 }  // namespace kj
+
+#endif  // !_WIN32

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -28,7 +28,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits>
-#include <set>
 #include <chrono>
 #include <pthread.h>
 
@@ -46,62 +45,9 @@ namespace kj {
 // =======================================================================================
 // Timer code common to multiple implementations
 
-struct UnixEventPort::TimerSet {
-  struct TimerBefore {
-    bool operator()(TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs);
-  };
-  using Timers = std::multiset<TimerPromiseAdapter*, TimerBefore>;
-  Timers timers;
-};
-
-class UnixEventPort::TimerPromiseAdapter {
-public:
-  TimerPromiseAdapter(PromiseFulfiller<void>& fulfiller, UnixEventPort& port, TimePoint time)
-      : time(time), fulfiller(fulfiller), port(port) {
-    pos = port.timers->timers.insert(this);
-  }
-
-  ~TimerPromiseAdapter() {
-    if (pos != port.timers->timers.end()) {
-      port.timers->timers.erase(pos);
-    }
-  }
-
-  void fulfill() {
-    fulfiller.fulfill();
-    port.timers->timers.erase(pos);
-    pos = port.timers->timers.end();
-  }
-
-  const TimePoint time;
-  PromiseFulfiller<void>& fulfiller;
-  UnixEventPort& port;
-  TimerSet::Timers::const_iterator pos;
-};
-
-bool UnixEventPort::TimerSet::TimerBefore::operator()(
-    TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs) {
-  return lhs->time < rhs->time;
-}
-
-Promise<void> UnixEventPort::atSteadyTime(TimePoint time) {
-  return newAdaptedPromise<void, TimerPromiseAdapter>(*this, time);
-}
-
-TimePoint UnixEventPort::currentSteadyTime() {
+TimePoint UnixEventPort::readClock() {
   return origin<TimePoint>() + std::chrono::duration_cast<std::chrono::nanoseconds>(
       std::chrono::steady_clock::now().time_since_epoch()).count() * NANOSECONDS;
-}
-
-void UnixEventPort::processTimers() {
-  frozenSteadyTime = currentSteadyTime();
-  for (;;) {
-    auto front = timers->timers.begin();
-    if (front == timers->timers.end() || (*front)->time > frozenSteadyTime) {
-      break;
-    }
-    (*front)->fulfill();
-  }
 }
 
 // =======================================================================================
@@ -249,8 +195,7 @@ void UnixEventPort::gotSignal(const siginfo_t& siginfo) {
 // epoll FdObserver implementation
 
 UnixEventPort::UnixEventPort()
-    : timers(kj::heap<TimerSet>()),
-      frozenSteadyTime(currentSteadyTime()),
+    : timerImpl(readClock()),
       epollFd(-1),
       signalFd(-1),
       eventFd(-1) {
@@ -360,27 +305,10 @@ Promise<void> UnixEventPort::FdObserver::whenUrgentDataAvailable() {
 }
 
 bool UnixEventPort::wait() {
-  // epoll_wait()'s timeout is an `int` count of milliseconds, so truncate to that.
-  // Also, make sure that we aren't within a millisecond of overflowing a `Duration` since that
-  // will break the math below.
-  constexpr Duration MAX_TIMEOUT =
-      min(int(maxValue) * MILLISECONDS, Duration(maxValue) - MILLISECONDS);
-
-  int epollTimeout = -1;
-  auto timer = timers->timers.begin();
-  if (timer != timers->timers.end()) {
-    Duration timeout = (*timer)->time - currentSteadyTime();
-    if (timeout < 0 * SECONDS) {
-      epollTimeout = 0;
-    } else if (timeout < MAX_TIMEOUT) {
-      // Round up to the next millisecond
-      epollTimeout = (timeout + 1 * MILLISECONDS - unit<Duration>()) / MILLISECONDS;
-    } else {
-      epollTimeout = MAX_TIMEOUT / MILLISECONDS;
-    }
-  }
-
-  return doEpollWait(epollTimeout);
+  return doEpollWait(
+      timerImpl.timeoutToNextEvent(readClock(), MILLISECONDS, int(maxValue))
+          .map([](uint64_t t) -> int { return t; })
+          .orDefault(-1));
 }
 
 bool UnixEventPort::poll() {
@@ -554,7 +482,7 @@ bool UnixEventPort::doEpollWait(int timeout) {
     }
   }
 
-  processTimers();
+  timerImpl.advanceTo(readClock());
 
   return woken;
 }
@@ -568,8 +496,7 @@ bool UnixEventPort::doEpollWait(int timeout) {
 #endif
 
 UnixEventPort::UnixEventPort()
-    : timers(kj::heap<TimerSet>()),
-      frozenSteadyTime(currentSteadyTime()) {
+    : timerImpl(readClock()) {
   static_assert(sizeof(threadId) >= sizeof(pthread_t),
                 "pthread_t is larger than a long long on your platform.  Please port.");
   *reinterpret_cast<pthread_t*>(&threadId) = pthread_self();
@@ -771,33 +698,17 @@ bool UnixEventPort::wait() {
   threadCapture = &capture;
   sigprocmask(SIG_UNBLOCK, &newMask, &origMask);
 
-  // poll()'s timeout is an `int` count of milliseconds, so truncate to that.
-  // Also, make sure that we aren't within a millisecond of overflowing a `Duration` since that
-  // will break the math below.
-  constexpr Duration MAX_TIMEOUT =
-      min(int(maxValue) * MILLISECONDS, Duration(maxValue) - MILLISECONDS);
-
-  int pollTimeout = -1;
-  auto timer = timers->timers.begin();
-  if (timer != timers->timers.end()) {
-    Duration timeout = (*timer)->time - currentSteadyTime();
-    if (timeout < 0 * SECONDS) {
-      pollTimeout = 0;
-    } else if (timeout < MAX_TIMEOUT) {
-      // Round up to the next millisecond
-      pollTimeout = (timeout + 1 * MILLISECONDS - unit<Duration>()) / MILLISECONDS;
-    } else {
-      pollTimeout = MAX_TIMEOUT / MILLISECONDS;
-    }
-  }
-  pollContext.run(pollTimeout);
+  pollContext.run(
+      timerImpl.timeoutToNextEvent(readClock(), MILLISECONDS, int(maxValue))
+          .map([](uint64_t t) -> int { return t; })
+          .orDefault(-1));
 
   sigprocmask(SIG_SETMASK, &origMask, nullptr);
   threadCapture = nullptr;
 
   // Queue events.
   pollContext.processResults();
-  processTimers();
+  timerImpl.advanceTo(readClock());
 
   return false;
 }
@@ -859,7 +770,7 @@ bool UnixEventPort::poll() {
     pollContext.run(0);
     pollContext.processResults();
   }
-  processTimers();
+  timerImpl.advanceTo(readClock());
 
   return woken;
 }

--- a/c++/src/kj/async-unix.c++
+++ b/c++/src/kj/async-unix.c++
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !_WIN32
+
 #include "async-unix.h"
 #include "debug.h"
 #include "threadlocal.h"
@@ -872,3 +874,5 @@ void UnixEventPort::wake() const {
 #endif  // KJ_USE_EPOLL, else
 
 }  // namespace kj
+
+#endif  // !_WIN32

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -97,8 +97,7 @@ public:
   // needs to use SIGUSR1, call this at startup (before any calls to `captureSignal()` and before
   // constructing an `UnixEventPort`) to offer a different signal.
 
-  TimePoint steadyTime() { return frozenSteadyTime; }
-  Promise<void> atSteadyTime(TimePoint time);
+  Timer& getTimer() { return timerImpl; }
 
   // implements EventPort ------------------------------------------------------
   bool wait() override;
@@ -110,14 +109,12 @@ private:
   class TimerPromiseAdapter;
   class SignalPromiseAdapter;
 
-  Own<TimerSet> timers;
-  TimePoint frozenSteadyTime;
+  TimerImpl timerImpl;
 
   SignalPromiseAdapter* signalHead = nullptr;
   SignalPromiseAdapter** signalTail = &signalHead;
 
-  TimePoint currentSteadyTime();
-  void processTimers();
+  TimePoint readClock();
   void gotSignal(const siginfo_t& siginfo);
 
   friend class TimerPromiseAdapter;

--- a/c++/src/kj/async-unix.h
+++ b/c++/src/kj/async-unix.h
@@ -22,6 +22,10 @@
 #ifndef KJ_ASYNC_UNIX_H_
 #define KJ_ASYNC_UNIX_H_
 
+#if _WIN32
+#error "This file is Unix-specific. On Windows, include async-win32.h instead."
+#endif
+
 #if defined(__GNUC__) && !KJ_HEADER_WARNINGS
 #pragma GCC system_header
 #endif

--- a/c++/src/kj/async-win32-test.c++
+++ b/c++/src/kj/async-win32-test.c++
@@ -1,0 +1,143 @@
+// Copyright (c) 2013-2014 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if _WIN32
+
+#include "async-win32.h"
+#include "thread.h"
+#include "test.h"
+
+namespace kj {
+namespace {
+
+KJ_TEST("Win32IocpEventPort I/O operations") {
+  Win32IocpEventPort port;
+  EventLoop loop(port);
+  WaitScope waitScope(loop);
+
+  auto pipeName = kj::str("\\\\.\\Pipe\\kj-async-win32-test.", GetCurrentProcessId());
+
+  HANDLE readEnd_, writeEnd_;
+  KJ_WIN32(readEnd_ = CreateNamedPipeA(pipeName.cStr(),
+      PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+      PIPE_TYPE_BYTE | PIPE_WAIT,
+      1, 0, 0, 0, NULL));
+  AutoCloseHandle readEnd(readEnd_);
+
+  KJ_WIN32(writeEnd_ = CreateFileA(pipeName.cStr(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL, NULL));
+  AutoCloseHandle writeEnd(writeEnd_);
+
+  auto observer = port.observeIo(readEnd);
+  auto op = observer->newOperation(0);
+
+  byte buffer[256];
+
+  KJ_ASSERT(!ReadFile(readEnd, buffer, sizeof(buffer), NULL, op->getOverlapped()));
+  DWORD error = GetLastError();
+  if (error != ERROR_IO_PENDING) {
+    KJ_FAIL_WIN32("ReadFile()", error);
+  }
+
+  bool done = false;
+  auto promise = op->onComplete().then([&](Win32EventPort::IoResult result) {
+    done = true;
+    return result;
+  }).eagerlyEvaluate(nullptr);
+
+  KJ_EXPECT(!done);
+
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+
+  KJ_EXPECT(!done);
+
+  DWORD bytesWritten;
+  KJ_WIN32(WriteFile(writeEnd, "foo", 3, &bytesWritten, NULL));
+  KJ_EXPECT(bytesWritten == 3);
+
+  auto result = promise.wait(waitScope);
+  KJ_EXPECT(result.errorCode == ERROR_SUCCESS);
+  KJ_EXPECT(result.bytesTransferred == 3);
+
+  KJ_EXPECT(kj::str(kj::arrayPtr(buffer, 3).asChars()) == "foo");
+}
+
+KJ_TEST("Win32IocpEventPort::wake()") {
+  Win32IocpEventPort port;
+
+  Thread thread([&]() {
+    Sleep(10);
+    port.wake();
+  });
+
+  KJ_EXPECT(port.wait());
+}
+
+KJ_TEST("Win32IocpEventPort::wake() on poll()") {
+  Win32IocpEventPort port;
+  volatile bool woken = false;
+
+  Thread thread([&]() {
+    Sleep(10);
+    port.wake();
+    woken = true;
+  });
+
+  KJ_EXPECT(!port.poll());
+  while (!woken) Sleep(10);
+  KJ_EXPECT(port.poll());
+}
+
+KJ_TEST("Win32IocpEventPort timer") {
+  Win32IocpEventPort port;
+  EventLoop loop(port);
+  WaitScope waitScope(loop);
+
+  auto start = port.getTimer().now();
+
+  bool done = false;
+  auto promise = port.getTimer().afterDelay(10 * MILLISECONDS).then([&]() {
+    done = true;
+  }).eagerlyEvaluate(nullptr);
+
+  KJ_EXPECT(!done);
+
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+  evalLater([]() {}).wait(waitScope);
+
+  KJ_EXPECT(!done);
+
+  promise.wait(waitScope);
+  KJ_EXPECT(done);
+  KJ_EXPECT(port.getTimer().now() - start >= 10 * MILLISECONDS);
+}
+
+}  // namespace
+}  // namespace kj
+
+#endif  // _WIN32

--- a/c++/src/kj/async-win32.c++
+++ b/c++/src/kj/async-win32.c++
@@ -1,0 +1,255 @@
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if _WIN32
+
+// Request Vista-level APIs.
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+
+#include "async-win32.h"
+#include "debug.h"
+#include <chrono>
+#include "refcount.h"
+
+#undef ERROR  // dammit windows.h
+
+namespace kj {
+
+Win32IocpEventPort::Win32IocpEventPort()
+    : iocp(newIocpHandle()), thread(openCurrentThread()), timerImpl(readClock()) {}
+
+Win32IocpEventPort::~Win32IocpEventPort() noexcept(false) {}
+
+class Win32IocpEventPort::IoPromiseAdapter final: public OVERLAPPED {
+public:
+  IoPromiseAdapter(PromiseFulfiller<IoResult>& fulfiller, Win32IocpEventPort& port,
+                   uint64_t offset, IoPromiseAdapter** selfPtr)
+      : fulfiller(fulfiller), port(port) {
+    *selfPtr = this;
+
+    memset(implicitCast<OVERLAPPED*>(this), 0, sizeof(OVERLAPPED));
+    this->Offset = offset & 0x00000000FFFFFFFFull;
+    this->OffsetHigh = offset >> 32;
+  }
+
+  ~IoPromiseAdapter() {
+    if (handle != INVALID_HANDLE_VALUE) {
+      // Need to cancel the I/O.
+      //
+      // Note: Even if HasOverlappedIoCompleted(this) is true, CancelIoEx() still seems needed to
+      //   force the completion event.
+      if (!CancelIoEx(handle, this)) {
+        DWORD error = GetLastError();
+
+        // ERROR_NOT_FOUND probably means the operation already completed and is enqueued on the
+        // IOCP.
+        //
+        // ERROR_INVALID_HANDLE probably means that, amid a mass of destructors, the HANDLE was
+        // closed before all of the I/O promises were destroyed. We tolerate this so long as the
+        // I/O promises are also destroyed before returning to the event loop, hence the I/O
+        // tasks won't actually continue on a dead handle.
+        //
+        // TODO(cleanup): ERROR_INVALID_HANDLE really shouldn't be allowed. Unfortunately, the
+        //   refcounted nature of capabilities and the RPC system seems to mean that objects
+        //   are unwound in the wrong order in several of Cap'n Proto's tests. So we live with this
+        //   for now. Note that even if a new handle is opened with the same numeric value, it
+        //   should be hardless to call CancelIoEx() on it because it couldn't possibly be using
+        //   the same OVERLAPPED structure.
+        if (error != ERROR_NOT_FOUND && error != ERROR_INVALID_HANDLE) {
+          KJ_FAIL_WIN32("CancelIoEx()", error, handle);
+        }
+      }
+
+      // We have to wait for the IOCP to poop out the event, so that we can safely destroy the
+      // OVERLAPPED.
+      while (handle != INVALID_HANDLE_VALUE) {
+        port.waitIocp(INFINITE);
+      }
+    }
+  }
+
+  void start(HANDLE handle) {
+    KJ_ASSERT(this->handle == INVALID_HANDLE_VALUE);
+    this->handle = handle;
+  }
+
+  void done(IoResult result) {
+    KJ_ASSERT(handle != INVALID_HANDLE_VALUE);
+    handle = INVALID_HANDLE_VALUE;
+    fulfiller.fulfill(kj::mv(result));
+  }
+
+private:
+  PromiseFulfiller<IoResult>& fulfiller;
+  Win32IocpEventPort& port;
+
+  HANDLE handle = INVALID_HANDLE_VALUE;
+  // If an I/O operation is currently enqueued, the handle on which it is enqueued.
+};
+
+class Win32IocpEventPort::IoOperationImpl final: public Win32EventPort::IoOperation {
+public:
+  explicit IoOperationImpl(Win32IocpEventPort& port, HANDLE handle, uint64_t offset)
+      : handle(handle),
+        promise(newAdaptedPromise<IoResult, IoPromiseAdapter>(port, offset, &promiseAdapter)) {}
+
+  LPOVERLAPPED getOverlapped() override {
+    KJ_REQUIRE(promiseAdapter != nullptr, "already called onComplete()");
+    return promiseAdapter;
+  }
+
+  Promise<IoResult> onComplete() override {
+    KJ_REQUIRE(promiseAdapter != nullptr, "can only call onComplete() once");
+    promiseAdapter->start(handle);
+    promiseAdapter = nullptr;
+    return kj::mv(promise);
+  }
+
+private:
+  HANDLE handle;
+  IoPromiseAdapter* promiseAdapter;
+  Promise<IoResult> promise;
+};
+
+class Win32IocpEventPort::IoObserverImpl final: public Win32EventPort::IoObserver {
+public:
+  IoObserverImpl(Win32IocpEventPort& port, HANDLE handle)
+      : port(port), handle(handle) {
+    KJ_WIN32(CreateIoCompletionPort(handle, port.iocp, 0, 1), handle, port.iocp.get());
+  }
+
+  Own<IoOperation> newOperation(uint64_t offset) {
+    return heap<IoOperationImpl>(port, handle, offset);
+  }
+
+private:
+  Win32IocpEventPort& port;
+  HANDLE handle;
+};
+
+Own<Win32EventPort::IoObserver> Win32IocpEventPort::observeIo(HANDLE handle) {
+  return heap<IoObserverImpl>(*this, handle);
+}
+
+Own<Win32EventPort::SignalObserver> Win32IocpEventPort::observeSignalState(HANDLE handle) {
+  return waitThreads.observeSignalState(handle);
+}
+
+TimePoint Win32IocpEventPort::readClock() {
+  return origin<TimePoint>() + std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::steady_clock::now().time_since_epoch()).count() * NANOSECONDS;
+}
+
+bool Win32IocpEventPort::wait() {
+  waitIocp(timerImpl.timeoutToNextEvent(readClock(), MILLISECONDS, INFINITE - 1)
+      .map([](uint64_t t) -> DWORD { return t; })
+      .orDefault(INFINITE));
+
+  timerImpl.advanceTo(readClock());
+
+  return receivedWake();
+}
+
+bool Win32IocpEventPort::poll() {
+  waitIocp(0);
+
+  return receivedWake();
+}
+
+void Win32IocpEventPort::wake() const {
+  if (!__atomic_load_n(&sentWake, __ATOMIC_ACQUIRE)) {
+    __atomic_store_n(&sentWake, true, __ATOMIC_RELEASE);
+    KJ_WIN32(PostQueuedCompletionStatus(iocp, 0, 0, nullptr));
+  }
+}
+
+void Win32IocpEventPort::waitIocp(DWORD timeoutMs) {
+  DWORD bytesTransferred;
+  ULONG_PTR completionKey;
+  LPOVERLAPPED overlapped = nullptr;
+
+  // TODO(someday): Should we use GetQueuedCompletionStatusEx()? It would allow us to read multiple
+  //   events in one call and would let us wait in an alertable state, which would allow users to
+  //   use APCs. However, it currently isn't implemented on Wine (as of 1.9.22).
+
+  BOOL success = GetQueuedCompletionStatus(
+      iocp, &bytesTransferred, &completionKey, &overlapped, timeoutMs);
+
+  if (overlapped == nullptr) {
+    if (success) {
+      // wake() called in another thread.
+    } else {
+      DWORD error = GetLastError();
+      if (error == WAIT_TIMEOUT) {
+        // Great, nothing to do. (Why this is WAIT_TIMEOUT and not ERROR_TIMEOUT I'm not sure.)
+      } else {
+        KJ_FAIL_WIN32("GetQueuedCompletionStatus()", error, error, overlapped);
+      }
+    }
+  } else {
+    DWORD error = success ? ERROR_SUCCESS : GetLastError();
+    static_cast<IoPromiseAdapter*>(overlapped)->done(IoResult { error, bytesTransferred });
+  }
+}
+
+bool Win32IocpEventPort::receivedWake() {
+  if (__atomic_load_n(&sentWake, __ATOMIC_ACQUIRE)) {
+    __atomic_store_n(&sentWake, false, __ATOMIC_RELEASE);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+AutoCloseHandle Win32IocpEventPort::newIocpHandle() {
+  HANDLE h;
+  KJ_WIN32(h = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1));
+  return AutoCloseHandle(h);
+}
+
+AutoCloseHandle Win32IocpEventPort::openCurrentThread() {
+  HANDLE process = GetCurrentProcess();
+  HANDLE result;
+  KJ_WIN32(DuplicateHandle(process, GetCurrentThread(), process, &result,
+                           0, FALSE, DUPLICATE_SAME_ACCESS));
+  return AutoCloseHandle(result);
+}
+
+// =======================================================================================
+
+Win32WaitObjectThreadPool::Win32WaitObjectThreadPool(uint mainThreadCount) {}
+
+Own<Win32EventPort::SignalObserver> Win32WaitObjectThreadPool::observeSignalState(HANDLE handle) {
+  KJ_UNIMPLEMENTED("wait for win32 handles");
+}
+
+uint Win32WaitObjectThreadPool::prepareMainThreadWait(HANDLE* handles[]) {
+  KJ_UNIMPLEMENTED("wait for win32 handles");
+}
+
+bool Win32WaitObjectThreadPool::finishedMainThreadWait(DWORD returnCode) {
+  KJ_UNIMPLEMENTED("wait for win32 handles");
+}
+
+} // namespace kj
+
+#endif  // _WIN32

--- a/c++/src/kj/async-win32.h
+++ b/c++/src/kj/async-win32.h
@@ -1,0 +1,219 @@
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// Licensed under the MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef KJ_ASYNC_WIN32_H_
+#define KJ_ASYNC_WIN32_H_
+
+#if !_WIN32
+#error "This file is Windows-specific. On Unix, include async-unix.h instead."
+#endif
+
+#include "async.h"
+#include "time.h"
+#include "io.h"
+#include <inttypes.h>
+
+// Include windows.h as lean as possible. (If you need more of the Windows API for your app,
+// #include windows.h yourself before including this header.)
+#define WIN32_LEAN_AND_MEAN 1
+#define NOSERVICE 1
+#define NOMCX 1
+#define NOIME 1
+#include <windows.h>
+#include "windows-sanity.h"
+
+namespace kj {
+
+class Win32EventPort: public EventPort {
+  // Abstract base interface for EventPorts that can listen on Win32 event types. Due to the
+  // absurd complexity of the Win32 API, it's not possible to standardize on a single
+  // implementation of EventPort. In particular, there is no way for a single thread to use I/O
+  // completion ports (the most efficient way of handling I/O) while at the same time waiting for
+  // signalable handles or UI messages.
+  //
+  // Note that UI messages are not supported at all by this interface because the message queue
+  // is implemented by user32.dll and we want libkj to depend only on kernel32.dll. A separate
+  // compat library could provide a Win32EventPort implementation that works with the UI message
+  // queue.
+
+public:
+  // ---------------------------------------------------------------------------
+  // overlapped I/O
+
+  struct IoResult {
+    DWORD errorCode;
+    DWORD bytesTransferred;
+  };
+
+  class IoOperation {
+  public:
+    virtual LPOVERLAPPED getOverlapped() = 0;
+    // Gets the OVERLAPPED structure to pass to the Win32 I/O call. Do NOT modify it; just pass it
+    // on.
+
+    virtual Promise<IoResult> onComplete() = 0;
+    // After making the Win32 call, if the return value indicates that the operation was
+    // successfully queued (i.e. the completion event will definitely occur), call this to wait
+    // for completion.
+    //
+    // You MUST call this if the operation was successfully queued, and you MUST NOT call this
+    // otherwise. If the Win32 call failed (without queuing any operation or event) then you should
+    // simply drop the IoOperation object.
+    //
+    // Dropping the returned Promise cancels the operation via Win32's CancelIoEx(). The destructor
+    // will wait for the cancellation to complete, such that after dropping the proimse it is safe
+    // to free the buffer that the operation was reading from / writing to.
+    //
+    // You may safely drop the `IoOperation` while still waiting for this promise. You may not,
+    // however, drop the `IoObserver`.
+  };
+
+  class IoObserver {
+  public:
+    virtual Own<IoOperation> newOperation(uint64_t offset) = 0;
+    // Begin an I/O operation. For file operations, `offset` is the offset within the file at
+    // which the operation will start. For stream operations, `offset` is ignored.
+  };
+
+  virtual Own<IoObserver> observeIo(HANDLE handle) = 0;
+  // Given a handle which supports overlapped I/O, arrange to receive I/O completion events via
+  // this EventPort.
+  //
+  // Different Win32EventPort implementations may handle this in different ways, such as by using
+  // completion routines (APCs) or by using I/O completion ports. The caller should not assume
+  // any particular technique.
+  //
+  // WARNING: It is only safe to call observeIo() on a particular handle once during its lifetime.
+  //   You cannot observe the same handle from multiple Win32EventPorts, even if not at the same
+  //   time. This is because the Win32 API provides no way to disassociate a handle from an I/O
+  //   completion port once it is associated.
+
+  // ---------------------------------------------------------------------------
+  // signalable handles
+  //
+  // Warning: Due to limitations in the Win32 API, implementations of EventPort may be forced to
+  //   spawn additional threads to wait for signaled objects. This is necessary if the EventPort
+  //   implementation is based on I/O completion ports, or if you need to wait on more than 64
+  //   handles at once.
+
+  class SignalObserver {
+  public:
+    virtual Promise<void> onSignaled() = 0;
+    // Returns a promise that completes the next time the handle enters the signaled state.
+    //
+    // Depending on the type of handle, the handle may automatically be reset to a non-signaled
+    // state before the promise resolves. The underlying implementaiton uses WaitForSingleObject()
+    // or an equivalent wait call, so check the documentation for that to understand the semantics.
+    //
+    // If the handle is a mutex and it is abandoned without being unlocked, the promise breaks with
+    // an exception.
+
+    virtual Promise<bool> onSignaledOrAbandoned() = 0;
+    // Like onSingaled(), but instead of throwing when a mutex is abandoned, resolves to `true`.
+    // Resolves to `false` for non-abandoned signals.
+  };
+
+  virtual Own<SignalObserver> observeSignalState(HANDLE handle) = 0;
+  // Given a handle that supports waiting for it to become "signaled" via WaitForSingleObject(),
+  // return an object that can wait for this state using the EventPort.
+
+  // ---------------------------------------------------------------------------
+  // time
+
+  virtual Timer& getTimer() = 0;
+};
+
+class Win32WaitObjectThreadPool {
+  // Helper class that implements Win32EventPort::observeSignalState() by spawning additional
+  // threads as needed to perform the actual waiting.
+  //
+  // This class is intended to be used to assist in building Win32EventPort implementations.
+
+public:
+  Win32WaitObjectThreadPool(uint mainThreadCount = 0);
+  // `mainThreadCount` indicates the number of objects the main thread is able to listen on
+  // directly. Typically this would be zero (e.g. if the main thread watches an I/O completion
+  // port) or MAXIMUM_WAIT_OBJECTS (e.g. if the main thread is a UI thread but can use
+  // MsgWaitForMultipleObjectsEx() to wait on some handles at the same time as messages).
+
+  Own<Win32EventPort::SignalObserver> observeSignalState(HANDLE handle);
+  // Implemetns Win32EventPort::observeSignalState().
+
+  uint prepareMainThreadWait(HANDLE* handles[]);
+  // Call immediately before invoking WaitForMultipleObjects() or similar in the main thread.
+  // Fills in `handles` with the handle pointers to wait on, and returns the number of handles
+  // in this array. (The array should be allocated to be at least the size passed to the
+  // constructor).
+  //
+  // There's no need to call this if `mainThreadCount` as passed to the constructor was zero.
+
+  bool finishedMainThreadWait(DWORD returnCode);
+  // Call immediately after invoking WaitForMultipleObjects() or similar in the main thread,
+  // passing the value returend by that call. Returns true if the event indicated by `returnCode`
+  // has been handled (i.e. it was WAIT_OBJECT_n or WAIT_ABANDONED_n where n is in-range for the
+  // last call to prepareMainThreadWait()).
+};
+
+class Win32IocpEventPort final: public Win32EventPort {
+  // An EventPort implementation which uses Windows I/O completion ports to listen for events.
+  //
+  // With this implementation, observeSignalState() requires spawning a separate thread.
+
+public:
+  Win32IocpEventPort();
+  ~Win32IocpEventPort() noexcept(false);
+
+  // implements EventPort ------------------------------------------------------
+  bool wait() override;
+  bool poll() override;
+  void wake() const override;
+
+  // implements Win32IocpEventPort ---------------------------------------------
+  Own<IoObserver> observeIo(HANDLE handle) override;
+  Own<SignalObserver> observeSignalState(HANDLE handle) override;
+  Timer& getTimer() override { return timerImpl; }
+
+private:
+  class IoPromiseAdapter;
+  class IoOperationImpl;
+  class IoObserverImpl;
+
+  AutoCloseHandle iocp;
+  AutoCloseHandle thread;
+  Win32WaitObjectThreadPool waitThreads;
+  TimerImpl timerImpl;
+  mutable bool sentWake = false;
+
+  static TimePoint readClock();
+
+  void waitIocp(DWORD timeoutMs);
+  // Wait on the I/O completion port for up to timeoutMs and pump events. Does not advance the
+  // timer; caller must do that.
+
+  bool receivedWake();
+
+  static AutoCloseHandle newIocpHandle();
+  static AutoCloseHandle openCurrentThread();
+};
+
+} // namespace kj
+
+#endif // KJ_ASYNC_WIN32_H_

--- a/c++/src/kj/exception.h
+++ b/c++/src/kj/exception.h
@@ -323,6 +323,9 @@ String stringifyStackTrace(ArrayPtr<void* const>);
 // Convert the stack trace to a string with file names and line numbers. This may involve executing
 // suprocesses.
 
+String getStackTrace();
+// Get a stack trace right now and stringify it. Useful for debugging.
+
 void printStackTraceOnCrash();
 // Registers signal handlers on common "crash" signals like SIGSEGV that will (attempt to) print
 // a stack trace. You should call this as early as possible on program startup. Programs using

--- a/c++/src/kj/main.c++
+++ b/c++/src/kj/main.c++
@@ -30,9 +30,12 @@
 #include <limits.h>
 
 #if _WIN32
-#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX 1
+#endif
 #include <windows.h>
-#undef NOMINMAX
+#include "windows-sanity.h"
 #else
 #include <sys/uio.h>
 #endif

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -293,12 +293,24 @@ void RemoveE0(char* buffer) {
   // Remove redundant leading 0's after an e, e.g. 1e012. Seems to appear on
   // Windows.
 
-  for (;;) {
-    buffer = strstr(buffer, "e0");
-    if (buffer == NULL || buffer[2] < '0' || buffer[2] > '9') {
-      return;
-    }
-    memmove(buffer + 1, buffer + 2, strlen(buffer + 2) + 1);
+  // Find and skip 'e'.
+  char* ptr = strchr(buffer, 'e');
+  if (ptr == nullptr) return;
+  ++ptr;
+
+  // Skip '-'.
+  if (*ptr == '-') ++ptr;
+
+  // Skip '0's.
+  char* ptr2 = ptr;
+  while (*ptr2 == '0') ++ptr2;
+
+  // If we went past the last digit, back up one.
+  if (*ptr2 < '0' || *ptr2 > '9') --ptr2;
+
+  // Move bytes backwards.
+  if (ptr2 > ptr) {
+    memmove(ptr, ptr2, strlen(ptr2) + 1);
   }
 }
 #endif
@@ -398,6 +410,9 @@ char* FloatToBuffer(float value, char* buffer) {
 
   DelocalizeRadix(buffer);
   RemovePlus(buffer);
+#if _WIN32
+  RemoveE0(buffer);
+#endif // _WIN32
   return buffer;
 }
 

--- a/c++/src/kj/time.c++
+++ b/c++/src/kj/time.c++
@@ -22,11 +22,104 @@
 
 #include "time.h"
 #include "debug.h"
+#include <set>
 
 namespace kj {
 
 kj::Exception Timer::makeTimeoutException() {
   return KJ_EXCEPTION(OVERLOADED, "operation timed out");
+}
+
+struct TimerImpl::Impl {
+  struct TimerBefore {
+    bool operator()(TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs);
+  };
+  using Timers = std::multiset<TimerPromiseAdapter*, TimerBefore>;
+  Timers timers;
+};
+
+class TimerImpl::TimerPromiseAdapter {
+public:
+  TimerPromiseAdapter(PromiseFulfiller<void>& fulfiller, TimerImpl::Impl& impl, TimePoint time)
+      : time(time), fulfiller(fulfiller), impl(impl) {
+    pos = impl.timers.insert(this);
+  }
+
+  ~TimerPromiseAdapter() {
+    if (pos != impl.timers.end()) {
+      impl.timers.erase(pos);
+    }
+  }
+
+  void fulfill() {
+    fulfiller.fulfill();
+    impl.timers.erase(pos);
+    pos = impl.timers.end();
+  }
+
+  const TimePoint time;
+
+private:
+  PromiseFulfiller<void>& fulfiller;
+  TimerImpl::Impl& impl;
+  Impl::Timers::const_iterator pos;
+};
+
+inline bool TimerImpl::Impl::TimerBefore::operator()(
+    TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs) {
+  return lhs->time < rhs->time;
+}
+
+Promise<void> TimerImpl::atTime(TimePoint time) {
+  return newAdaptedPromise<void, TimerPromiseAdapter>(*impl, time);
+}
+
+Promise<void> TimerImpl::afterDelay(Duration delay) {
+  return newAdaptedPromise<void, TimerPromiseAdapter>(*impl, time + delay);
+}
+
+TimerImpl::TimerImpl(TimePoint startTime)
+    : time(startTime), impl(heap<Impl>()) {}
+
+TimerImpl::~TimerImpl() noexcept(false) {}
+
+Maybe<TimePoint> TimerImpl::nextEvent() {
+  auto iter = impl->timers.begin();
+  if (iter == impl->timers.end()) {
+    return nullptr;
+  } else {
+    return (*iter)->time;
+  }
+}
+
+Maybe<uint64_t> TimerImpl::timeoutToNextEvent(TimePoint start, Duration unit, uint64_t max) {
+  return nextEvent().map([&](TimePoint nextTime) -> uint64_t {
+    if (nextTime <= start) return 0;
+
+    Duration timeout = nextTime - start;
+
+    uint64_t result = timeout / unit;
+    bool roundUp = timeout % unit > 0 * SECONDS;
+
+    if (result >= max) {
+      return max;
+    } else {
+      return result + roundUp;
+    }
+  });
+}
+
+void TimerImpl::advanceTo(TimePoint newTime) {
+  KJ_REQUIRE(newTime >= time, "can't advance backwards in time") { return; }
+
+  time = newTime;
+  for (;;) {
+    auto front = impl->timers.begin();
+    if (front == impl->timers.end() || (*front)->time > time) {
+      break;
+    }
+    (*front)->fulfill();
+  }
 }
 
 }  // namespace kj

--- a/c++/src/kj/time.h
+++ b/c++/src/kj/time.h
@@ -97,6 +97,49 @@ private:
   static kj::Exception makeTimeoutException();
 };
 
+class TimerImpl final: public Timer {
+  // Implementation of Timer that expects an external caller -- usually, the EventPort
+  // implementation -- to tell it when time has advanced.
+
+public:
+  TimerImpl(TimePoint startTime);
+  ~TimerImpl() noexcept(false);
+
+  Maybe<TimePoint> nextEvent();
+  // Returns the time at which the next scheduled timer event will occur, or null if no timer
+  // events are scheduled.
+
+  Maybe<uint64_t> timeoutToNextEvent(TimePoint start, Duration unit, uint64_t max);
+  // Convenience method which computes a timeout value to pass to an event-waiting system call to
+  // cause it to time out when the next timer event occurs.
+  //
+  // `start` is the time at which the timeout starts counting. This is typically not the same as
+  // now() since some time may have passed since the last time advanceTo() was called.
+  //
+  // `unit` is the time unit in which the timeout is measured. This is often MILLISECONDS. Note
+  // that this method will fractional values *up*, to guarantee that the returned timeout waits
+  // until just *after* the time the event is scheduled.
+  //
+  // The timeout will be clamped to `max`. Use this to avoid an overflow if e.g. the OS wants a
+  // 32-bit value or a signed value.
+  //
+  // Returns nullptr if there are no future events.
+
+  void advanceTo(TimePoint newTime);
+  // Set the time to `time` and fire any at() events that have been passed.
+
+  // implements Timer ----------------------------------------------------------
+  TimePoint now() override;
+  Promise<void> atTime(TimePoint time) override;
+  Promise<void> afterDelay(Duration delay) override;
+
+private:
+  struct Impl;
+  class TimerPromiseAdapter;
+  TimePoint time;
+  Own<Impl> impl;
+};
+
 // =======================================================================================
 // inline implementation details
 
@@ -113,6 +156,8 @@ Promise<T> Timer::timeoutAfter(Duration delay, Promise<T>&& promise) {
     return makeTimeoutException();
   }));
 }
+
+inline TimePoint TimerImpl::now() { return time; }
 
 }  // namespace kj
 

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -264,9 +264,9 @@ public:
     return value / other.value;
   }
   template <typename OtherNumber>
-  inline constexpr decltype(Number(1) % OtherNumber(1))
+  inline constexpr Quantity<decltype(Number(1) % OtherNumber(1)), Unit>
       operator%(const Quantity<OtherNumber, Unit>& other) const {
-    return value % other.value;
+    return Quantity<decltype(Number(1) % OtherNumber(1)), Unit>(value % other.value);
   }
 
   template <typename OtherNumber, typename OtherUnit>


### PR DESCRIPTION
With these changes, all RPC tests work on Windows when compiling with MinGW.

The meat of this change is implementing EventPort and async-io in terms of Winsock and I/O completion ports.

Things still to do:
* Update cmake files.
* Make it compile in MSVC. (May or may not be a lot of work.)
* Support waiting on signalable HANDLEs (a la WaitForMultipleObjects()). This looks like it will require a thread pool since there's no way to wait on IOCP and objects in the same thread.
* The interface change to LowLevelAsyncIoProvider::wrapConnectingSocketFd() should perhaps be used on Unix too, so that they can be consistent. Maybe this method should change to `wrapSocketAndConnect()`.
* debug.c++ has some TODO(now)s.
* It looks like there is one spurious test failure when running on actual Windows rather than Wine. Just noticed this now and haven't had time to investigate.

@harrishancock Are you interested in getting this working in MSVC? If not I'll probably look into it later this month.