### PR TITLE
handle empty structs in isCanonical()

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -394,6 +394,7 @@ heavy_tests =                                                  \
   src/kj/parse/common-test.c++                                 \
   src/kj/parse/char-test.c++                                   \
   src/kj/std/iostream-test.c++                                 \
+  src/capnp/canonicalize-test.c++                              \
   src/capnp/capability-test.c++                                \
   src/capnp/membrane-test.c++                                  \
   src/capnp/schema-test.c++                                    \

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -2589,10 +2589,16 @@ bool PointerReader::isCanonical(const word **readHead) {
     case PointerType::NULL_:
       // The pointer is null, we are canonical and do not read
       return true;
-    case PointerType::STRUCT:
+    case PointerType::STRUCT: {
       bool dataTrunc, ptrTrunc;
-      return (this->getStruct(nullptr).isCanonical(readHead, readHead, &dataTrunc, &ptrTrunc)
-             && dataTrunc && ptrTrunc);
+      auto structReader = this->getStruct(nullptr);
+      if (structReader.getDataSectionSize() == 0 * BITS &&
+          structReader.getPointerSectionSize() == 0 * POINTERS) {
+        return reinterpret_cast<const word*>(this->pointer) == structReader.getLocation();
+      } else {
+        return structReader.isCanonical(readHead, readHead, &dataTrunc, &ptrTrunc) && dataTrunc && ptrTrunc;
+      }
+    }
     case PointerType::LIST:
       return this->getListAnySize(nullptr).isCanonical(readHead);
     case PointerType::CAPABILITY:


### PR DESCRIPTION
Fixes #394 and adds some tests that pass only after the fix is applied. 

The main problem was that `isCanonical()` did not consider the case when the struct is empty. This case is somewhat subtle, as [discussed here](https://groups.google.com/forum/#!msg/capnproto/3MIU8xZBX1Q/9oO1VouXDQAJ).

This pull request also fixes a couple other small issues: canonicalize-tests.c++ was not getting picked up by the autotools build, and the "isCanonical requires pointer preorder" test had some wrong constants.