### PR TITLE
Fix conversion build error when building with Clang 4.0

### DIFF
--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -126,7 +126,7 @@ template <> struct ElementSizeForType<Void> { static constexpr ElementSize value
 template <> struct ElementSizeForType<bool> { static constexpr ElementSize value = ElementSize::BIT; };
 
 // Lists and blobs are pointers, not structs.
-template <typename T, bool b> struct ElementSizeForType<List<T, b>> {
+template <typename T, Kind K> struct ElementSizeForType<List<T, K>> {
   static constexpr ElementSize value = ElementSize::POINTER;
 };
 template <> struct ElementSizeForType<Text> {


### PR DESCRIPTION
This patch fixes a build error with Clang 4.0. The emitted error is:

> /tmp/capnproto/c++/src/capnp/layout.h:129:65: error: value of type 'bool' is not implicitly convertible to 'capnp::Kind'

However I think this change is a general bug fix, since it appears that the `ElementSizeForType` specialization for `List` was incorrect, and should have always specialized the second parameter as type `Kind` not `bool`.