### PR TITLE
Add getFd method to FdInputStream and FdOutputStream

### DIFF
--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -304,6 +304,8 @@ public:
 
   size_t tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
 
+  inline int getFd() const { return fd; }
+
 private:
   int fd;
   AutoCloseFd autoclose;
@@ -320,6 +322,8 @@ public:
 
   void write(const void* buffer, size_t size) override;
   void write(ArrayPtr<const ArrayPtr<const byte>> pieces) override;
+
+  inline int getFd() const { return fd; }
 
 private:
   int fd;


### PR DESCRIPTION
These methods are useful if you're receiving a generic stream in application code and would like to check some non-stream behavior about the file (e.g. stat or isatty).  Of course, downcasting can fail and code should not rely on the file descriptor being available.

(Contribution is copyright Google Inc.)