### PR TITLE
Build samples with MSVC

### DIFF
--- a/c++/cmake/CapnProtoConfig.cmake.in
+++ b/c++/cmake/CapnProtoConfig.cmake.in
@@ -12,8 +12,10 @@
 
 set(CapnProto_VERSION @VERSION@)
 
-set(CAPNP_EXECUTABLE $<TARGET_FILE:CapnProto::capnp_tool>)
-set(CAPNPC_CXX_EXECUTABLE $<TARGET_FILE:CapnProto::capnpc_cpp>)
+if(@CAPNP_BUILD_TOOLS@)
+  set(CAPNP_EXECUTABLE $<TARGET_FILE:CapnProto::capnp_tool>)
+  set(CAPNPC_CXX_EXECUTABLE $<TARGET_FILE:CapnProto::capnpc_cpp>)
+endif()
 set(CAPNP_INCLUDE_DIRECTORY "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@")
 
 # work around http://public.kitware.com/Bug/view.php?id=15258

--- a/c++/samples/CMakeLists.txt
+++ b/c++/samples/CMakeLists.txt
@@ -1,0 +1,53 @@
+# A Cap'n Proto sample project.
+#
+# To build (non-MSVC):
+#   1. Install Cap'n Proto somewhere ($PREFIX below):
+#
+#      mkdir capnproto/build
+#      cd capnproto/build
+#      cmake ../c++ -DCMAKE_INSTALL_PREFIX=$PREFIX
+#      cmake --build . --target install
+#      export PATH=$PREFIX/bin:$PATH
+#
+#   2. Ensure Cap'n Proto's executables are on the PATH, then build the sample project:
+#
+#      export PATH=$PREFIX/bin:$PATH
+#      mkdir ../build-samples
+#      cd ../build-samples
+#      cmake ../c++/samples
+#      cmake --build .
+#
+# Caveat for MSVC:
+#
+#   MSVC cannot yet build the Cap'n Proto executables, so there won't be any `$PREFIX/bin` directory
+#   to put on the PATH. To work around this, you can use CMAKE_PREFIX_PATH or CMAKE_MODULE_PATH to
+#   find the installed MSVC-built Cap'n Proto package, and set CAPNP_EXECUTABLE and
+#   CAPNPC_CXX_EXECUTABLE to the MinGW-built executables manually.
+#
+#   Here's an example step 2, assuming a MinGW-built Cap'n Proto is installed at $PREFIX_MINGW and
+#   an MSVC-built Cap'n Proto is installed at $PREFIX_MSVC:
+#
+#      mkdir ../build-samples
+#      cd ../build-samples
+#      cmake ../c++/samples -DCMAKE_PREFIX_PATH=$PREFIX_MSVC \
+#          -DCAPNP_EXECUTABLE=$PREFIX_MINGW/bin/capnp.exe \
+#          -DCAPNPC_CXX_EXECUTABLE=$PREFIX_MINGW/bin/capnpc-c++.exe
+#      cmake --build .
+
+project("Cap'n Proto Samples" CXX)
+cmake_minimum_required(VERSION 3.0)
+
+find_package(CapnProto CONFIG REQUIRED)
+
+capnp_generate_cpp(addressbookSources addressbookHeaders addressbook.capnp)
+add_executable(addressbook addressbook.c++ ${addressbookSources})
+target_link_libraries(addressbook CapnProto::capnp)
+target_include_directories(addressbook PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+capnp_generate_cpp(calculatorSources calculatorHeaders calculator.capnp)
+add_executable(calculator-client calculator-client.c++ ${calculatorSources})
+add_executable(calculator-server calculator-server.c++ ${calculatorSources})
+target_link_libraries(calculator-client CapnProto::capnp-rpc)
+target_link_libraries(calculator-server CapnProto::capnp-rpc)
+target_include_directories(calculator-client PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(calculator-server PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/c++/samples/calculator-server.c++
+++ b/c++/samples/calculator-server.c++
@@ -74,7 +74,7 @@ kj::Promise<double> evaluateImpl(
           kj::joinPromises(kj::mv(paramPromises));
 
       // When the parameters are complete, call the function.
-      return joinedParams.then([func](kj::Array<double>&& paramValues) mutable {
+      return joinedParams.then([KJ_CPCAP(func)](kj::Array<double>&& paramValues) mutable {
         auto request = func.callRequest();
         request.setParams(paramValues);
         return request.send().then(
@@ -120,7 +120,7 @@ public:
     KJ_REQUIRE(params.size() == paramCount, "Wrong number of parameters.");
 
     return evaluateImpl(body.getRoot<Calculator::Expression>(), params)
-        .then([context](double value) mutable {
+        .then([KJ_CPCAP(context)](double value) mutable {
       context.getResults().setValue(value);
     });
   }
@@ -168,7 +168,7 @@ class CalculatorImpl final: public Calculator::Server {
 public:
   kj::Promise<void> evaluate(EvaluateContext context) override {
     return evaluateImpl(context.getParams().getExpression())
-        .then([context](double value) mutable {
+        .then([KJ_CPCAP(context)](double value) mutable {
       context.getResults().setValue(kj::heap<ValueImpl>(value));
     });
   }

--- a/c++/src/kj/test-helpers.c++
+++ b/c++/src/kj/test-helpers.c++
@@ -24,6 +24,8 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#else
+#include <process.h>
 #endif
 
 namespace kj {


### PR DESCRIPTION
This PR:

- Installs the external capnp tools if `CAPNP_BUILD_TOOLS=OFF`. This allows MSVC CMake builds to install complete, working distributions of Cap'n Proto.

- Adds a CMakeLists.txt and applies the mutable capture bug workaround for MSVC (`KJ_CPCAP`) to the C++ samples (`addressbook`, `calculator-{client,server}`).

This may resolve the immediate issue in #413, but it doesn't resolve the underlying problem, so I'm not sure if it should be closed yet.