### PR TITLE
fix bug in parsing of non-ascii constants

### DIFF
--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -748,6 +748,8 @@ const embeddedData :Data = embed "testdata/packed";
 const embeddedText :Text = embed "testdata/short.txt";
 const embeddedStruct :TestAllTypes = embed "testdata/binary";
 
+const nonAsciiText :Text = "♫ é ✓";
+
 struct TestAnyPointerConstants {
   anyKindAsStruct @0 :AnyPointer;
   anyStructAsStruct @1 :AnyStruct;

--- a/c++/src/kj/parse/char.h
+++ b/c++/src/kj/parse/char.h
@@ -107,7 +107,7 @@ public:
     return CharGroup_(~bits[0], ~bits[1], ~bits[2], ~bits[3]);
   }
 
-  constexpr inline bool contains(char c) const {
+  constexpr inline bool contains(unsigned char c) const {
     return (bits[c / 64] & (1ll << (c % 64))) != 0;
   }
 


### PR DESCRIPTION
`spk dev` currently fails on Wekan due to a [non-ascii character](https://github.com/wekan/wekan/blob/81de7bceecf96c31a49baee67abfd6e597652e18/sandstorm-pkgdef.capnp#L166) in its sandstorm-pkgdef.capnp file.

This problem was introduced in https://github.com/sandstorm-io/capnproto/commit/9182e67f146d81cbb6865230172ba6a7bbd81ec6.

This commit fixes the problem.