### PR TITLE
Make sure to clear tag word when upgrading a struct list.

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1360,7 +1360,8 @@ struct WireHelpers {
       }
 
       // Zero out old location.  See explanation in getWritableStructPointer().
-      memset(oldPtr, 0, oldStep * elementCount * BYTES_PER_WORD / BYTES);
+      // Make sure to include the tag word.
+      memset(oldPtr - 1, 0, (1 + oldStep * elementCount) * BYTES_PER_WORD / BYTES);
 
       return ListBuilder(origSegment, capTable, newPtr, newStep * BITS_PER_WORD, elementCount,
                          newDataSize * BITS_PER_WORD, newPointerCount, ElementSize::INLINE_COMPOSITE);

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1361,7 +1361,8 @@ struct WireHelpers {
 
       // Zero out old location.  See explanation in getWritableStructPointer().
       // Make sure to include the tag word.
-      memset(oldPtr - 1, 0, (1 + oldStep * elementCount) * BYTES_PER_WORD / BYTES);
+      memset(oldPtr - POINTER_SIZE_IN_WORDS, 0,
+             (POINTER_SIZE_IN_WORDS + oldStep * elementCount) * BYTES_PER_WORD / BYTES);
 
       return ListBuilder(origSegment, capTable, newPtr, newStep * BITS_PER_WORD, elementCount,
                          newDataSize * BITS_PER_WORD, newPointerCount, ElementSize::INLINE_COMPOSITE);


### PR DESCRIPTION
Fixes #419.