### PR TITLE
Edit error message for the case where copyPointer() hits a FAR pointer.

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -738,7 +738,7 @@ struct WireHelpers {
         break;
       }
       case WirePointer::FAR:
-        KJ_FAIL_ASSERT("Unexpected FAR pointer.") {
+        KJ_FAIL_REQUIRE("Unexpected FAR pointer.") {
           break;
         }
         break;
@@ -1872,7 +1872,7 @@ struct WireHelpers {
       }
 
       case WirePointer::FAR:
-        KJ_FAIL_ASSERT("Unexpected FAR pointer.") {
+        KJ_FAIL_REQUIRE("Unexpected FAR pointer.") {
           goto useDefault;
         }
 

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1872,7 +1872,7 @@ struct WireHelpers {
       }
 
       case WirePointer::FAR:
-        KJ_FAIL_ASSERT("Far pointer should have been handled above.") {
+        KJ_FAIL_ASSERT("Unexpected FAR pointer.") {
           goto useDefault;
         }
 


### PR DESCRIPTION
The existing error message suggests this case can only arise if there is a
a bug in the library. However, malformed input can trigger the error too.
In particular, the error gets thrown when a non-double far pointer resolves
to another far pointer.