### PR TITLE
omit needless memset

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1611,11 +1611,6 @@ struct WireHelpers {
       }
     } else {
       memcpy(ptr, value.data, dataSize / BYTES);
-      if (dataSize % BYTES_PER_WORD != 0 * BYTES) {
-        //Zero-pad the data if it didn't use the entire last word
-        byte* padStart = reinterpret_cast<byte*>(ptr) + (dataSize / BYTES);
-        memset(padStart, 0, (BYTES_PER_WORD * WORDS - (dataSize % BYTES_PER_WORD)) / BYTES);
-      }
     }
 
     WirePointer* pointerSection = reinterpret_cast<WirePointer*>(ptr + dataWords);


### PR DESCRIPTION
`ptr` is freshly allocated, so the memory it points to is already zeroed, so this `memset()` is always a no-op. For reference, it traces back to https://github.com/sandstorm-io/capnproto/commit/bd49b14a657664ddc714f905f2077e6ad99d52e1.

