### PR TITLE
doc/cxxrpc: Document lazy execution

### DIFF
--- a/doc/cxxrpc.md
+++ b/doc/cxxrpc.md
@@ -154,6 +154,18 @@ callbacks simply won't be executed.  If you need explicit notification when a pr
 you can use its `attach()` method to attach an object with a destructor -- the destructor will be
 called when the promise either completes or is canceled.
 
+### Lazy Execution
+
+Callbacks registered with `.then()` which aren't themselves asynchronous (i.e. they return a value,
+not a promise) won't be executed by default. There are several ways to force a promise to execute
+eagerly:
+
+* `.wait()` on it.
+* `.detach()` it.
+* Add it to a `kj::TaskSet` (this is a lot like `detach()`, except that you can cancel all tasks in
+  the set by destroying the set).
+* Call `.eagerlyEvaluate()` on it.
+
 ### Other Features
 
 KJ supports a number of primitive operations that can be performed on promises.  The complete API


### PR DESCRIPTION
This change takes a comment about lazy execution from
https://github.com/sandstorm-io/capnproto/issues/263#issuecomment-158564701 and
adds it to the C++ RPC documentation.

Although lazy execution is described in `Promise::then()` method documentation,
it's unfortunately buried in the *Advanced implementation tips* section, and
described as an optimization rather than as a more general feature of the
asynchronous execution model. Since I recently got tripped up by this behavior,
I thought it would be worth trying to document better.