### PR TITLE
Actually implement integer overflow guards

### DIFF
--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -45,7 +45,7 @@ kj::Own<ClientHook> AnyPointer::Reader::getPipelinedCap(
         break;
 
       case PipelineOp::Type::GET_POINTER_FIELD:
-        pointer = pointer.getStruct(nullptr).getPointerField(op.pointerIndex * POINTERS);
+        pointer = pointer.getStruct(nullptr).getPointerField(guarded(op.pointerIndex) * POINTERS);
         break;
     }
   }

--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -45,7 +45,7 @@ kj::Own<ClientHook> AnyPointer::Reader::getPipelinedCap(
         break;
 
       case PipelineOp::Type::GET_POINTER_FIELD:
-        pointer = pointer.getStruct(nullptr).getPointerField(guarded(op.pointerIndex) * POINTERS);
+        pointer = pointer.getStruct(nullptr).getPointerField(bounded(op.pointerIndex) * POINTERS);
         break;
     }
   }

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -398,10 +398,10 @@ struct List<AnyPointer, Kind::OTHER> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline AnyPointer::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return AnyPointer::Reader(reader.getPointerElement(guarded(index) * ELEMENTS));
+      return AnyPointer::Reader(reader.getPointerElement(bounded(index) * ELEMENTS));
     }
 
     typedef _::IndexingIterator<const Reader, typename AnyPointer::Reader> Iterator;
@@ -430,10 +430,10 @@ struct List<AnyPointer, Kind::OTHER> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline AnyPointer::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return AnyPointer::Builder(builder.getPointerElement(guarded(index) * ELEMENTS));
+      return AnyPointer::Builder(builder.getPointerElement(bounded(index) * ELEMENTS));
     }
 
     typedef _::IndexingIterator<Builder, typename AnyPointer::Builder> Iterator;
@@ -563,10 +563,10 @@ public:
   inline Reader(): reader(ElementSize::INLINE_COMPOSITE) {}
   inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-  inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+  inline uint size() const { return unbound(reader.size() / ELEMENTS); }
   inline AnyStruct::Reader operator[](uint index) const {
     KJ_IREQUIRE(index < size());
-    return AnyStruct::Reader(reader.getStructElement(guarded(index) * ELEMENTS));
+    return AnyStruct::Reader(reader.getStructElement(bounded(index) * ELEMENTS));
   }
 
   typedef _::IndexingIterator<const Reader, typename AnyStruct::Reader> Iterator;
@@ -595,10 +595,10 @@ public:
   inline operator Reader() const { return Reader(builder.asReader()); }
   inline Reader asReader() const { return Reader(builder.asReader()); }
 
-  inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+  inline uint size() const { return unbound(builder.size() / ELEMENTS); }
   inline AnyStruct::Builder operator[](uint index) {
     KJ_IREQUIRE(index < size());
-    return AnyStruct::Builder(builder.getStructElement(guarded(index) * ELEMENTS));
+    return AnyStruct::Builder(builder.getStructElement(bounded(index) * ELEMENTS));
   }
 
   typedef _::IndexingIterator<Builder, typename AnyStruct::Builder> Iterator;
@@ -628,7 +628,7 @@ public:
 #endif
 
   inline ElementSize getElementSize() { return _reader.getElementSize(); }
-  inline uint size() { return unguard(_reader.size() / ELEMENTS); }
+  inline uint size() { return unbound(_reader.size() / ELEMENTS); }
 
   inline kj::ArrayPtr<const byte> getRawBytes() { return _reader.asRawBytes(); }
 
@@ -664,7 +664,7 @@ public:
 #endif
 
   inline ElementSize getElementSize() { return _builder.getElementSize(); }
-  inline uint size() { return unguard(_builder.size() / ELEMENTS); }
+  inline uint size() { return unbound(_builder.size() / ELEMENTS); }
 
   Equality equals(AnyList::Reader right);
   inline bool operator==(AnyList::Reader right) {
@@ -781,21 +781,21 @@ inline BuilderFor<T> AnyPointer::Builder::initAs(uint elementCount) {
 
 inline AnyList::Builder AnyPointer::Builder::initAsAnyList(
     ElementSize elementSize, uint elementCount) {
-  return AnyList::Builder(builder.initList(elementSize, guarded(elementCount) * ELEMENTS));
+  return AnyList::Builder(builder.initList(elementSize, bounded(elementCount) * ELEMENTS));
 }
 
 inline List<AnyStruct>::Builder AnyPointer::Builder::initAsListOfAnyStruct(
     uint16_t dataWordCount, uint16_t pointerCount, uint elementCount) {
-  return List<AnyStruct>::Builder(builder.initStructList(guarded(elementCount) * ELEMENTS,
-      _::StructSize(guarded(dataWordCount) * WORDS,
-                    guarded(pointerCount) * POINTERS)));
+  return List<AnyStruct>::Builder(builder.initStructList(bounded(elementCount) * ELEMENTS,
+      _::StructSize(bounded(dataWordCount) * WORDS,
+                    bounded(pointerCount) * POINTERS)));
 }
 
 inline AnyStruct::Builder AnyPointer::Builder::initAsAnyStruct(
     uint16_t dataWordCount, uint16_t pointerCount) {
   return AnyStruct::Builder(builder.initStruct(
-      _::StructSize(guarded(dataWordCount) * WORDS,
-                    guarded(pointerCount) * POINTERS)));
+      _::StructSize(bounded(dataWordCount) * WORDS,
+                    bounded(pointerCount) * POINTERS)));
 }
 
 template <typename T>
@@ -971,8 +971,8 @@ struct PointerHelpers<AnyStruct, Kind::OTHER> {
   static inline AnyStruct::Builder init(
       PointerBuilder builder, uint16_t dataWordCount, uint16_t pointerCount) {
     return AnyStruct::Builder(builder.initStruct(
-        StructSize(guarded(dataWordCount) * WORDS,
-                   guarded(pointerCount) * POINTERS)));
+        StructSize(bounded(dataWordCount) * WORDS,
+                   bounded(pointerCount) * POINTERS)));
   }
 
   // TODO(soon): implement these
@@ -996,14 +996,14 @@ struct PointerHelpers<AnyList, Kind::OTHER> {
   static inline AnyList::Builder init(
       PointerBuilder builder, ElementSize elementSize, uint elementCount) {
     return AnyList::Builder(builder.initList(
-        elementSize, guarded(elementCount) * ELEMENTS));
+        elementSize, bounded(elementCount) * ELEMENTS));
   }
   static inline AnyList::Builder init(
       PointerBuilder builder, uint16_t dataWordCount, uint16_t pointerCount, uint elementCount) {
     return AnyList::Builder(builder.initStructList(
-        guarded(elementCount) * ELEMENTS,
-        StructSize(guarded(dataWordCount) * WORDS,
-                   guarded(pointerCount) * POINTERS)));
+        bounded(elementCount) * ELEMENTS,
+        StructSize(bounded(dataWordCount) * WORDS,
+                   bounded(pointerCount) * POINTERS)));
   }
 
   // TODO(soon): implement these

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -208,9 +208,9 @@ struct AnyPointer {
     // Note: Does not accept INLINE_COMPOSITE for elementSize.
 
     inline List<AnyStruct>::Builder initAsListOfAnyStruct(
-        uint dataWordCount, uint pointerCount, uint elementCount);
+        uint16_t dataWordCount, uint16_t pointerCount, uint elementCount);
 
-    inline AnyStruct::Builder initAsAnyStruct(uint dataWordCount, uint pointerCount);
+    inline AnyStruct::Builder initAsAnyStruct(uint16_t dataWordCount, uint16_t pointerCount);
 
     template <typename T>
     inline void setAs(ReaderFor<T> value);
@@ -398,10 +398,10 @@ struct List<AnyPointer, Kind::OTHER> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline AnyPointer::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return AnyPointer::Reader(reader.getPointerElement(index * ELEMENTS));
+      return AnyPointer::Reader(reader.getPointerElement(guarded(index) * ELEMENTS));
     }
 
     typedef _::IndexingIterator<const Reader, typename AnyPointer::Reader> Iterator;
@@ -430,10 +430,10 @@ struct List<AnyPointer, Kind::OTHER> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline AnyPointer::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return AnyPointer::Builder(builder.getPointerElement(index * ELEMENTS));
+      return AnyPointer::Builder(builder.getPointerElement(guarded(index) * ELEMENTS));
     }
 
     typedef _::IndexingIterator<Builder, typename AnyPointer::Builder> Iterator;
@@ -563,10 +563,10 @@ public:
   inline Reader(): reader(ElementSize::INLINE_COMPOSITE) {}
   inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-  inline uint size() const { return reader.size() / ELEMENTS; }
+  inline uint size() const { return unguard(reader.size() / ELEMENTS); }
   inline AnyStruct::Reader operator[](uint index) const {
     KJ_IREQUIRE(index < size());
-    return AnyStruct::Reader(reader.getStructElement(index * ELEMENTS));
+    return AnyStruct::Reader(reader.getStructElement(guarded(index) * ELEMENTS));
   }
 
   typedef _::IndexingIterator<const Reader, typename AnyStruct::Reader> Iterator;
@@ -595,10 +595,10 @@ public:
   inline operator Reader() const { return Reader(builder.asReader()); }
   inline Reader asReader() const { return Reader(builder.asReader()); }
 
-  inline uint size() const { return builder.size() / ELEMENTS; }
+  inline uint size() const { return unguard(builder.size() / ELEMENTS); }
   inline AnyStruct::Builder operator[](uint index) {
     KJ_IREQUIRE(index < size());
-    return AnyStruct::Builder(builder.getStructElement(index * ELEMENTS));
+    return AnyStruct::Builder(builder.getStructElement(guarded(index) * ELEMENTS));
   }
 
   typedef _::IndexingIterator<Builder, typename AnyStruct::Builder> Iterator;
@@ -628,7 +628,7 @@ public:
 #endif
 
   inline ElementSize getElementSize() { return _reader.getElementSize(); }
-  inline uint size() { return _reader.size() / ELEMENTS; }
+  inline uint size() { return unguard(_reader.size() / ELEMENTS); }
 
   inline kj::ArrayPtr<const byte> getRawBytes() { return _reader.asRawBytes(); }
 
@@ -664,7 +664,7 @@ public:
 #endif
 
   inline ElementSize getElementSize() { return _builder.getElementSize(); }
-  inline uint size() { return _builder.size() / ELEMENTS; }
+  inline uint size() { return unguard(_builder.size() / ELEMENTS); }
 
   Equality equals(AnyList::Reader right);
   inline bool operator==(AnyList::Reader right) {
@@ -781,18 +781,21 @@ inline BuilderFor<T> AnyPointer::Builder::initAs(uint elementCount) {
 
 inline AnyList::Builder AnyPointer::Builder::initAsAnyList(
     ElementSize elementSize, uint elementCount) {
-  return AnyList::Builder(builder.initList(elementSize, elementCount * ELEMENTS));
+  return AnyList::Builder(builder.initList(elementSize, guarded(elementCount) * ELEMENTS));
 }
 
 inline List<AnyStruct>::Builder AnyPointer::Builder::initAsListOfAnyStruct(
-    uint dataWordCount, uint pointerCount, uint elementCount) {
-  return List<AnyStruct>::Builder(builder.initStructList(elementCount * ELEMENTS,
-      _::StructSize(dataWordCount * WORDS, pointerCount * POINTERS)));
+    uint16_t dataWordCount, uint16_t pointerCount, uint elementCount) {
+  return List<AnyStruct>::Builder(builder.initStructList(guarded(elementCount) * ELEMENTS,
+      _::StructSize(guarded(dataWordCount) * WORDS,
+                    guarded(pointerCount) * POINTERS)));
 }
 
-inline AnyStruct::Builder AnyPointer::Builder::initAsAnyStruct(uint dataWordCount, uint pointerCount) {
+inline AnyStruct::Builder AnyPointer::Builder::initAsAnyStruct(
+    uint16_t dataWordCount, uint16_t pointerCount) {
   return AnyStruct::Builder(builder.initStruct(
-      _::StructSize(dataWordCount * WORDS, pointerCount * POINTERS)));
+      _::StructSize(guarded(dataWordCount) * WORDS,
+                    guarded(pointerCount) * POINTERS)));
 }
 
 template <typename T>
@@ -960,15 +963,16 @@ struct PointerHelpers<AnyStruct, Kind::OTHER> {
       PointerBuilder builder, const word* defaultValue = nullptr) {
     // TODO(someday): Allow specifying the size somehow?
     return AnyStruct::Builder(builder.getStruct(
-        _::StructSize(0 * WORDS, 0 * POINTERS), defaultValue));
+        _::StructSize(ZERO * WORDS, ZERO * POINTERS), defaultValue));
   }
   static inline void set(PointerBuilder builder, AnyStruct::Reader value) {
     builder.setStruct(value._reader);
   }
   static inline AnyStruct::Builder init(
-      PointerBuilder builder, uint dataWordCount, uint pointerCount) {
+      PointerBuilder builder, uint16_t dataWordCount, uint16_t pointerCount) {
     return AnyStruct::Builder(builder.initStruct(
-        StructSize(dataWordCount * WORDS, pointerCount * POINTERS)));
+        StructSize(guarded(dataWordCount) * WORDS,
+                   guarded(pointerCount) * POINTERS)));
   }
 
   // TODO(soon): implement these
@@ -991,12 +995,15 @@ struct PointerHelpers<AnyList, Kind::OTHER> {
   }
   static inline AnyList::Builder init(
       PointerBuilder builder, ElementSize elementSize, uint elementCount) {
-    return AnyList::Builder(builder.initList(elementSize, elementCount * ELEMENTS));
+    return AnyList::Builder(builder.initList(
+        elementSize, guarded(elementCount) * ELEMENTS));
   }
   static inline AnyList::Builder init(
-      PointerBuilder builder, uint dataWordCount, uint pointerCount, uint elementCount) {
+      PointerBuilder builder, uint16_t dataWordCount, uint16_t pointerCount, uint elementCount) {
     return AnyList::Builder(builder.initStructList(
-        elementCount * ELEMENTS, StructSize(dataWordCount * WORDS, pointerCount * POINTERS)));
+        guarded(elementCount) * ELEMENTS,
+        StructSize(guarded(dataWordCount) * WORDS,
+                   guarded(pointerCount) * POINTERS)));
   }
 
   // TODO(soon): implement these

--- a/c++/src/capnp/any.h
+++ b/c++/src/capnp/any.h
@@ -1014,13 +1014,13 @@ struct PointerHelpers<AnyList, Kind::OTHER> {
 template <>
 struct OrphanGetImpl<AnyStruct, Kind::OTHER> {
   static inline AnyStruct::Builder apply(_::OrphanBuilder& builder) {
-    return AnyStruct::Builder(builder.asStruct(_::StructSize(0 * WORDS, 0 * POINTERS)));
+    return AnyStruct::Builder(builder.asStruct(_::StructSize(ZERO * WORDS, ZERO * POINTERS)));
   }
   static inline AnyStruct::Reader applyReader(const _::OrphanBuilder& builder) {
-    return AnyStruct::Reader(builder.asStructReader(_::StructSize(0 * WORDS, 0 * POINTERS)));
+    return AnyStruct::Reader(builder.asStructReader(_::StructSize(ZERO * WORDS, ZERO * POINTERS)));
   }
   static inline void truncateListOf(_::OrphanBuilder& builder, ElementCount size) {
-    builder.truncate(size, _::StructSize(0 * WORDS, 0 * POINTERS));
+    builder.truncate(size, _::StructSize(ZERO * WORDS, ZERO * POINTERS));
   }
 };
 

--- a/c++/src/capnp/arena.c++
+++ b/c++/src/capnp/arena.c++
@@ -42,7 +42,7 @@ void ReadLimiter::unread(WordCount64 amount) {
   // the limit value was not updated correctly for one or more reads, and therefore unread() could
   // overflow it even if it is only unreading bytes that were actually read.
   uint64_t oldValue = limit;
-  uint64_t newValue = oldValue + amount / WORDS;
+  uint64_t newValue = oldValue + unguard(amount / WORDS);
   if (newValue > oldValue) {
     limit = newValue;
   }
@@ -57,10 +57,24 @@ void SegmentBuilder::throwNotWritable() {
 
 // =======================================================================================
 
-ReaderArena::ReaderArena(MessageReader* message)
+static SegmentWordCount verifySegmentSize(size_t size) {
+  auto gsize = guarded(size) * WORDS;
+  return assertMaxBits<SEGMENT_WORD_COUNT_BITS>(gsize, [&]() {
+    KJ_FAIL_REQUIRE("segment is too large", size);
+  });
+}
+
+inline ReaderArena::ReaderArena(MessageReader* message, const word* firstSegment,
+                                SegmentWordCount firstSegmentSize)
     : message(message),
-      readLimiter(message->getOptions().traversalLimitInWords * WORDS),
-      segment0(this, SegmentId(0), message->getSegment(0), &readLimiter) {}
+      readLimiter(guarded(message->getOptions().traversalLimitInWords) * WORDS),
+      segment0(this, SegmentId(0), firstSegment, firstSegmentSize, &readLimiter) {}
+
+inline ReaderArena::ReaderArena(MessageReader* message, kj::ArrayPtr<const word> firstSegment)
+    : ReaderArena(message, firstSegment.begin(), verifySegmentSize(firstSegment.size())) {}
+
+ReaderArena::ReaderArena(MessageReader* message)
+    : ReaderArena(message, message->getSegment(0)) {}
 
 ReaderArena::~ReaderArena() noexcept(false) {}
 
@@ -89,6 +103,8 @@ SegmentReader* ReaderArena::tryGetSegment(SegmentId id) {
     return nullptr;
   }
 
+  SegmentWordCount newSegmentSize = verifySegmentSize(newSegment.size());
+
   if (*lock == nullptr) {
     // OK, the segment exists, so allocate the map.
     auto s = kj::heap<SegmentMap>();
@@ -96,7 +112,8 @@ SegmentReader* ReaderArena::tryGetSegment(SegmentId id) {
     *lock = kj::mv(s);
   }
 
-  auto segment = kj::heap<SegmentReader>(this, id, newSegment, &readLimiter);
+  auto segment = kj::heap<SegmentReader>(
+      this, id, newSegment.begin(), newSegmentSize, &readLimiter);
   SegmentReader* result = segment;
   segments->insert(std::make_pair(id.value, mv(segment)));
   return result;
@@ -116,14 +133,17 @@ BuilderArena::BuilderArena(MessageBuilder* message)
 BuilderArena::BuilderArena(MessageBuilder* message,
                            kj::ArrayPtr<MessageBuilder::SegmentInit> segments)
     : message(message),
-      segment0(this, SegmentId(0), segments[0].space, &this->dummyLimiter, segments[0].wordsUsed) {
+      segment0(this, SegmentId(0), segments[0].space.begin(),
+               verifySegmentSize(segments[0].space.size()),
+               &this->dummyLimiter, verifySegmentSize(segments[0].wordsUsed)) {
   if (segments.size() > 1) {
     kj::Vector<kj::Own<SegmentBuilder>> builders(segments.size() - 1);
 
     uint i = 1;
     for (auto& segment: segments.slice(1, segments.size())) {
       builders.add(kj::heap<SegmentBuilder>(
-          this, SegmentId(i++), segment.space, &this->dummyLimiter, segment.wordsUsed));
+          this, SegmentId(i++), segment.space.begin(), verifySegmentSize(segment.space.size()),
+          &this->dummyLimiter, verifySegmentSize(segment.wordsUsed)));
     }
 
     kj::Vector<kj::ArrayPtr<const word>> forOutput;
@@ -155,15 +175,16 @@ SegmentBuilder* BuilderArena::getSegment(SegmentId id) {
   }
 }
 
-BuilderArena::AllocateResult BuilderArena::allocate(WordCount amount) {
+BuilderArena::AllocateResult BuilderArena::allocate(SegmentWordCount amount) {
   if (segment0.getArena() == nullptr) {
     // We're allocating the first segment.
-    kj::ArrayPtr<word> ptr = message->allocateSegment(amount / WORDS);
+    kj::ArrayPtr<word> ptr = message->allocateSegment(unguard(amount / WORDS));
+    auto actualSize = verifySegmentSize(ptr.size());
 
     // Re-allocate segment0 in-place.  This is a bit of a hack, but we have not returned any
     // pointers to this segment yet, so it should be fine.
     kj::dtor(segment0);
-    kj::ctor(segment0, this, SegmentId(0), ptr, &this->dummyLimiter);
+    kj::ctor(segment0, this, SegmentId(0), ptr.begin(), actualSize, &this->dummyLimiter);
 
     segmentWithSpace = &segment0;
     return AllocateResult { &segment0, segment0.allocate(amount) };
@@ -183,7 +204,7 @@ BuilderArena::AllocateResult BuilderArena::allocate(WordCount amount) {
     }
 
     // Need to allocate a new segment.
-    SegmentBuilder* result = addSegmentInternal(message->allocateSegment(amount / WORDS));
+    SegmentBuilder* result = addSegmentInternal(message->allocateSegment(unguard(amount / WORDS)));
 
     // Check this new segment first the next time we need to allocate.
     segmentWithSpace = result;
@@ -204,6 +225,8 @@ SegmentBuilder* BuilderArena::addSegmentInternal(kj::ArrayPtr<T> content) {
   KJ_REQUIRE(segment0.getArena() != nullptr,
       "Can't allocate external segments before allocating the root segment.");
 
+  auto contentSize = verifySegmentSize(content.size());
+
   MultiSegmentState* segmentState;
   KJ_IF_MAYBE(s, moreSegments) {
     segmentState = *s;
@@ -214,7 +237,8 @@ SegmentBuilder* BuilderArena::addSegmentInternal(kj::ArrayPtr<T> content) {
   }
 
   kj::Own<SegmentBuilder> newBuilder = kj::heap<SegmentBuilder>(
-      this, SegmentId(segmentState->builders.size() + 1), content, &this->dummyLimiter);
+      this, SegmentId(segmentState->builders.size() + 1),
+      content.begin(), contentSize, &this->dummyLimiter);
   SegmentBuilder* result = newBuilder.get();
   segmentState->builders.add(kj::mv(newBuilder));
 

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -34,6 +34,7 @@
 #include <kj/mutex.h>
 #include <kj/exception.h>
 #include <kj/vector.h>
+#include <kj/units.h>
 #include "common.h"
 #include "message.h"
 #include "layout.h"

--- a/c++/src/capnp/arena.h
+++ b/c++/src/capnp/arena.h
@@ -342,19 +342,19 @@ private:
 inline ReadLimiter::ReadLimiter()
     : limit(kj::maxValue) {}
 
-inline ReadLimiter::ReadLimiter(WordCount64 limit): limit(unguard(limit / WORDS)) {}
+inline ReadLimiter::ReadLimiter(WordCount64 limit): limit(unbound(limit / WORDS)) {}
 
-inline void ReadLimiter::reset(WordCount64 limit) { this->limit = unguard(limit / WORDS); }
+inline void ReadLimiter::reset(WordCount64 limit) { this->limit = unbound(limit / WORDS); }
 
 inline bool ReadLimiter::canRead(WordCount64 amount, Arena* arena) {
   // Be careful not to store an underflowed value into `limit`, even if multiple threads are
   // decrementing it.
   uint64_t current = limit;
-  if (KJ_UNLIKELY(unguard(amount / WORDS) > current)) {
+  if (KJ_UNLIKELY(unbound(amount / WORDS) > current)) {
     arena->reportReadLimitReached();
     return false;
   } else {
-    limit = current - unguard(amount / WORDS);
+    limit = current - unbound(amount / WORDS);
     return true;
   }
 }
@@ -363,7 +363,7 @@ inline bool ReadLimiter::canRead(WordCount64 amount, Arena* arena) {
 
 inline SegmentReader::SegmentReader(Arena* arena, SegmentId id, const word* ptr,
                                     SegmentWordCount size, ReadLimiter* readLimiter)
-    : arena(arena), id(id), ptr(kj::arrayPtr(ptr, unguard(size / WORDS))),
+    : arena(arena), id(id), ptr(kj::arrayPtr(ptr, unbound(size / WORDS))),
       readLimiter(readLimiter) {}
 
 inline bool SegmentReader::containsInterval(const void* from, const void* to) {

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -650,7 +650,7 @@ struct List<T, Kind::INTERFACE> {
     Reader() = default;
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline typename T::Client operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return typename T::Client(reader.getPointerElement(
@@ -683,7 +683,7 @@ struct List<T, Kind::INTERFACE> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline typename T::Client operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return typename T::Client(builder.getPointerElement(

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -650,11 +650,11 @@ struct List<T, Kind::INTERFACE> {
     Reader() = default;
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline typename T::Client operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return typename T::Client(reader.getPointerElement(
-          guarded(index) * ELEMENTS).getCapability());
+          bounded(index) * ELEMENTS).getCapability());
     }
 
     typedef _::IndexingIterator<const Reader, typename T::Client> Iterator;
@@ -683,23 +683,23 @@ struct List<T, Kind::INTERFACE> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline typename T::Client operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return typename T::Client(builder.getPointerElement(
-          guarded(index) * ELEMENTS).getCapability());
+          bounded(index) * ELEMENTS).getCapability());
     }
     inline void set(uint index, typename T::Client value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).setCapability(kj::mv(value.hook));
+      builder.getPointerElement(bounded(index) * ELEMENTS).setCapability(kj::mv(value.hook));
     }
     inline void adopt(uint index, Orphan<T>&& value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).adopt(kj::mv(value));
+      builder.getPointerElement(bounded(index) * ELEMENTS).adopt(kj::mv(value));
     }
     inline Orphan<T> disown(uint index) {
       KJ_IREQUIRE(index < size());
-      return Orphan<T>(builder.getPointerElement(guarded(index) * ELEMENTS).disown());
+      return Orphan<T>(builder.getPointerElement(bounded(index) * ELEMENTS).disown());
     }
 
     typedef _::IndexingIterator<Builder, typename T::Client> Iterator;
@@ -715,7 +715,7 @@ struct List<T, Kind::INTERFACE> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initList(ElementSize::POINTER, guarded(size) * ELEMENTS);
+    return builder.initList(ElementSize::POINTER, bounded(size) * ELEMENTS);
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getList(ElementSize::POINTER, defaultValue);

--- a/c++/src/capnp/capability.h
+++ b/c++/src/capnp/capability.h
@@ -653,7 +653,8 @@ struct List<T, Kind::INTERFACE> {
     inline uint size() const { return reader.size() / ELEMENTS; }
     inline typename T::Client operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return typename T::Client(reader.getPointerElement(index * ELEMENTS).getCapability());
+      return typename T::Client(reader.getPointerElement(
+          guarded(index) * ELEMENTS).getCapability());
     }
 
     typedef _::IndexingIterator<const Reader, typename T::Client> Iterator;
@@ -685,19 +686,20 @@ struct List<T, Kind::INTERFACE> {
     inline uint size() const { return builder.size() / ELEMENTS; }
     inline typename T::Client operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return typename T::Client(builder.getPointerElement(index * ELEMENTS).getCapability());
+      return typename T::Client(builder.getPointerElement(
+          guarded(index) * ELEMENTS).getCapability());
     }
     inline void set(uint index, typename T::Client value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(index * ELEMENTS).setCapability(kj::mv(value.hook));
+      builder.getPointerElement(guarded(index) * ELEMENTS).setCapability(kj::mv(value.hook));
     }
     inline void adopt(uint index, Orphan<T>&& value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(index * ELEMENTS).adopt(kj::mv(value));
+      builder.getPointerElement(guarded(index) * ELEMENTS).adopt(kj::mv(value));
     }
     inline Orphan<T> disown(uint index) {
       KJ_IREQUIRE(index < size());
-      return Orphan<T>(builder.getPointerElement(index * ELEMENTS).disown());
+      return Orphan<T>(builder.getPointerElement(guarded(index) * ELEMENTS).disown());
     }
 
     typedef _::IndexingIterator<Builder, typename T::Client> Iterator;
@@ -713,7 +715,7 @@ struct List<T, Kind::INTERFACE> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initList(ElementSize::POINTER, size * ELEMENTS);
+    return builder.initList(ElementSize::POINTER, guarded(size) * ELEMENTS);
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getList(ElementSize::POINTER, defaultValue);

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -346,15 +346,15 @@ static_assert(sizeof(word) == 8, "uint64_t is not 8 bytes?");
 namespace _ { class BitLabel; class ElementLabel; struct WirePointer; }
 
 template <uint width, typename T = uint>
-using BitCountN = kj::Quantity<kj::Guarded<kj::maxValueForBits<width>(), T>, _::BitLabel>;
+using BitCountN = kj::Quantity<kj::Bounded<kj::maxValueForBits<width>(), T>, _::BitLabel>;
 template <uint width, typename T = uint>
-using ByteCountN = kj::Quantity<kj::Guarded<kj::maxValueForBits<width>(), T>, byte>;
+using ByteCountN = kj::Quantity<kj::Bounded<kj::maxValueForBits<width>(), T>, byte>;
 template <uint width, typename T = uint>
-using WordCountN = kj::Quantity<kj::Guarded<kj::maxValueForBits<width>(), T>, word>;
+using WordCountN = kj::Quantity<kj::Bounded<kj::maxValueForBits<width>(), T>, word>;
 template <uint width, typename T = uint>
-using ElementCountN = kj::Quantity<kj::Guarded<kj::maxValueForBits<width>(), T>, _::ElementLabel>;
+using ElementCountN = kj::Quantity<kj::Bounded<kj::maxValueForBits<width>(), T>, _::ElementLabel>;
 template <uint width, typename T = uint>
-using WirePointerCountN = kj::Quantity<kj::Guarded<kj::maxValueForBits<width>(), T>, _::WirePointer>;
+using WirePointerCountN = kj::Quantity<kj::Bounded<kj::maxValueForBits<width>(), T>, _::WirePointer>;
 
 typedef BitCountN<8, uint8_t> BitCount8;
 typedef BitCountN<16, uint16_t> BitCount16;
@@ -395,14 +395,14 @@ using WordsPerElementN = decltype(WordCountN<width>() / ElementCountN<width>());
 template <uint width>
 using PointersPerElementN = decltype(WirePointerCountN<width>() / ElementCountN<width>());
 
-using kj::guarded;
-using kj::unguard;
-using kj::unguardAs;
-using kj::unguardMax;
-using kj::unguardMaxBits;
+using kj::bounded;
+using kj::unbound;
+using kj::unboundAs;
+using kj::unboundMax;
+using kj::unboundMaxBits;
 using kj::assertMax;
 using kj::assertMaxBits;
-using kj::upgradeGuard;
+using kj::upgradeBound;
 using kj::ThrowOverflow;
 using kj::assumeBits;
 using kj::assumeMax;
@@ -411,36 +411,36 @@ using kj::trySubtract;
 
 template <typename T, typename U>
 inline constexpr U* operator+(U* ptr, kj::Quantity<T, U> offset) {
-  return ptr + unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr + unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr const U* operator+(const U* ptr, kj::Quantity<T, U> offset) {
-  return ptr + unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr + unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr U* operator+=(U*& ptr, kj::Quantity<T, U> offset) {
-  return ptr = ptr + unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr = ptr + unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr const U* operator+=(const U*& ptr, kj::Quantity<T, U> offset) {
-  return ptr = ptr + unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr = ptr + unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 
 template <typename T, typename U>
 inline constexpr U* operator-(U* ptr, kj::Quantity<T, U> offset) {
-  return ptr - unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr - unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr const U* operator-(const U* ptr, kj::Quantity<T, U> offset) {
-  return ptr - unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr - unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr U* operator-=(U*& ptr, kj::Quantity<T, U> offset) {
-  return ptr = ptr - unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr = ptr - unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 template <typename T, typename U>
 inline constexpr const U* operator-=(const U*& ptr, kj::Quantity<T, U> offset) {
-  return ptr = ptr - unguard(offset / kj::unit<kj::Quantity<T, U>>());
+  return ptr = ptr - unbound(offset / kj::unit<kj::Quantity<T, U>>());
 }
 
 constexpr auto BITS = kj::unit<BitCountN<1>>();
@@ -449,16 +449,16 @@ constexpr auto WORDS = kj::unit<WordCountN<1>>();
 constexpr auto ELEMENTS = kj::unit<ElementCountN<1>>();
 constexpr auto POINTERS = kj::unit<WirePointerCountN<1>>();
 
-constexpr auto ZERO = kj::guarded<0>();
-constexpr auto ONE = kj::guarded<1>();
+constexpr auto ZERO = kj::bounded<0>();
+constexpr auto ONE = kj::bounded<1>();
 
 // GCC 4.7 actually gives unused warnings on these constants in opt mode...
-constexpr auto BITS_PER_BYTE KJ_UNUSED = guarded<8>() * BITS / BYTES;
-constexpr auto BITS_PER_WORD KJ_UNUSED = guarded<64>() * BITS / WORDS;
-constexpr auto BYTES_PER_WORD KJ_UNUSED = guarded<8>() * BYTES / WORDS;
+constexpr auto BITS_PER_BYTE KJ_UNUSED = bounded<8>() * BITS / BYTES;
+constexpr auto BITS_PER_WORD KJ_UNUSED = bounded<64>() * BITS / WORDS;
+constexpr auto BYTES_PER_WORD KJ_UNUSED = bounded<8>() * BYTES / WORDS;
 
-constexpr auto BITS_PER_POINTER KJ_UNUSED = guarded<64>() * BITS / POINTERS;
-constexpr auto BYTES_PER_POINTER KJ_UNUSED = guarded<8>() * BYTES / POINTERS;
+constexpr auto BITS_PER_POINTER KJ_UNUSED = bounded<64>() * BITS / POINTERS;
+constexpr auto BYTES_PER_POINTER KJ_UNUSED = bounded<8>() * BYTES / POINTERS;
 constexpr auto WORDS_PER_POINTER KJ_UNUSED = ONE * WORDS / POINTERS;
 
 constexpr auto POINTER_SIZE_IN_WORDS = ONE * POINTERS * WORDS_PER_POINTER;
@@ -476,13 +476,13 @@ typedef WirePointerCountN<STRUCT_POINTER_COUNT_BITS, uint16_t> StructPointerCoun
 typedef ByteCountN<BLOB_SIZE_BITS> BlobSize;
 
 constexpr auto MAX_SEGMENT_WORDS =
-    guarded<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>()>() * WORDS;
+    bounded<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>()>() * WORDS;
 constexpr auto MAX_LIST_ELEMENTS =
-    guarded<kj::maxValueForBits<LIST_ELEMENT_COUNT_BITS>()>() * ELEMENTS;
+    bounded<kj::maxValueForBits<LIST_ELEMENT_COUNT_BITS>()>() * ELEMENTS;
 constexpr auto MAX_STUCT_DATA_WORDS =
-    guarded<kj::maxValueForBits<STRUCT_DATA_WORD_COUNT_BITS>()>() * WORDS;
+    bounded<kj::maxValueForBits<STRUCT_DATA_WORD_COUNT_BITS>()>() * WORDS;
 constexpr auto MAX_STRUCT_POINTER_COUNT =
-    guarded<kj::maxValueForBits<STRUCT_POINTER_COUNT_BITS>()>() * POINTERS;
+    bounded<kj::maxValueForBits<STRUCT_POINTER_COUNT_BITS>()>() * POINTERS;
 
 using StructDataBitCount = decltype(WordCountN<STRUCT_POINTER_COUNT_BITS>() * BITS_PER_WORD);
 // Number of bits in a Struct data segment (should come out to BitCountN<22>).
@@ -493,40 +493,40 @@ using StructPointerOffset = StructPointerCount;
 
 inline StructDataOffset assumeDataOffset(uint32_t offset) {
   return assumeMax(MAX_STUCT_DATA_WORDS * BITS_PER_WORD * (ONE * ELEMENTS / BITS),
-                   guarded(offset) * ELEMENTS);
+                   bounded(offset) * ELEMENTS);
 }
 
 inline StructPointerOffset assumePointerOffset(uint32_t offset) {
-  return assumeMax(MAX_STRUCT_POINTER_COUNT, guarded(offset) * POINTERS);
+  return assumeMax(MAX_STRUCT_POINTER_COUNT, bounded(offset) * POINTERS);
 }
 
 constexpr uint MAX_TEXT_SIZE = kj::maxValueForBits<BLOB_SIZE_BITS>() - 1;
-typedef kj::Quantity<kj::Guarded<MAX_TEXT_SIZE, uint>, byte> TextSize;
+typedef kj::Quantity<kj::Bounded<MAX_TEXT_SIZE, uint>, byte> TextSize;
 // Not including NUL terminator.
 
 template <typename T>
-inline KJ_CONSTEXPR() decltype(guarded<sizeof(T)>() * BYTES / ELEMENTS) bytesPerElement() {
-  return guarded<sizeof(T)>() * BYTES / ELEMENTS;
+inline KJ_CONSTEXPR() decltype(bounded<sizeof(T)>() * BYTES / ELEMENTS) bytesPerElement() {
+  return bounded<sizeof(T)>() * BYTES / ELEMENTS;
 }
 
 template <typename T>
-inline KJ_CONSTEXPR() decltype(guarded<sizeof(T) * 8>() * BITS / ELEMENTS) bitsPerElement() {
-  return guarded<sizeof(T) * 8>() * BITS / ELEMENTS;
+inline KJ_CONSTEXPR() decltype(bounded<sizeof(T) * 8>() * BITS / ELEMENTS) bitsPerElement() {
+  return bounded<sizeof(T) * 8>() * BITS / ELEMENTS;
 }
 
 template <typename T, uint maxN>
-inline constexpr kj::Quantity<kj::Guarded<maxN, size_t>, T>
-intervalLength(const T* a, const T* b, kj::Quantity<kj::GuardedConst<maxN>, T>) {
-  return kj::assumeMax<maxN>(b - a) * kj::unit<kj::Quantity<kj::GuardedConst<1u>, T>>();
+inline constexpr kj::Quantity<kj::Bounded<maxN, size_t>, T>
+intervalLength(const T* a, const T* b, kj::Quantity<kj::BoundedConst<maxN>, T>) {
+  return kj::assumeMax<maxN>(b - a) * kj::unit<kj::Quantity<kj::BoundedConst<1u>, T>>();
 }
 
 template <typename T, typename U>
 inline constexpr kj::ArrayPtr<const U> arrayPtr(const U* ptr, kj::Quantity<T, U> size) {
-  return kj::ArrayPtr<const U>(ptr, unguard(size / kj::unit<kj::Quantity<T, U>>()));
+  return kj::ArrayPtr<const U>(ptr, unbound(size / kj::unit<kj::Quantity<T, U>>()));
 }
 template <typename T, typename U>
 inline constexpr kj::ArrayPtr<U> arrayPtr(U* ptr, kj::Quantity<T, U> size) {
-  return kj::ArrayPtr<U>(ptr, unguard(size / kj::unit<kj::Quantity<T, U>>()));
+  return kj::ArrayPtr<U>(ptr, unbound(size / kj::unit<kj::Quantity<T, U>>()));
 }
 
 #else
@@ -586,14 +586,14 @@ using PointersPerElementN = decltype(WirePointerCountN<width>() / ElementCountN<
 using kj::ThrowOverflow;
 // YYY
 
-template <uint i> inline constexpr uint guarded() { return i; }
-template <typename T> inline constexpr T guarded(T i) { return i; }
-template <typename T> inline constexpr T unguard(T i) { return i; }
+template <uint i> inline constexpr uint bounded() { return i; }
+template <typename T> inline constexpr T bounded(T i) { return i; }
+template <typename T> inline constexpr T unbound(T i) { return i; }
 
-template <typename T, typename U> inline constexpr T unguardAs(U i) { return i; }
+template <typename T, typename U> inline constexpr T unboundAs(U i) { return i; }
 
-template <uint64_t requestedMax, typename T> inline constexpr uint unguardMax(T i) { return i; }
-template <uint bits, typename T> inline constexpr uint unguardMaxBits(T i) { return i; }
+template <uint64_t requestedMax, typename T> inline constexpr uint unboundMax(T i) { return i; }
+template <uint bits, typename T> inline constexpr uint unboundMaxBits(T i) { return i; }
 
 template <uint newMax, typename T, typename ErrorFunc>
 inline constexpr T assertMax(T value, ErrorFunc&& func) {
@@ -619,7 +619,7 @@ inline constexpr T assertMaxBits(uint bits, T value, ErrorFunc&& func = ErrorFun
   return value;
 }
 
-template <typename T, typename U> inline constexpr T upgradeGuard(U i) { return i; }
+template <typename T, typename U> inline constexpr T upgradeBound(U i) { return i; }
 
 template <uint bits, typename T> inline constexpr T assumeBits(T i) { return i; }
 template <uint64_t max, typename T> inline constexpr T assumeMax(T i) { return i; }

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -599,25 +599,25 @@ template <uint64_t requestedMax, typename T> inline constexpr uint unboundMax(T 
 template <uint bits, typename T> inline constexpr uint unboundMaxBits(T i) { return i; }
 
 template <uint newMax, typename T, typename ErrorFunc>
-inline constexpr T assertMax(T value, ErrorFunc&& func) {
+inline T assertMax(T value, ErrorFunc&& func) {
   if (KJ_UNLIKELY(value > newMax)) func();
   return value;
 }
 
 template <typename T, typename ErrorFunc>
-inline constexpr T assertMax(uint newMax, T value, ErrorFunc&& func) {
+inline T assertMax(uint newMax, T value, ErrorFunc&& func) {
   if (KJ_UNLIKELY(value > newMax)) func();
   return value;
 }
 
 template <uint bits, typename T, typename ErrorFunc = ThrowOverflow>
-inline constexpr T assertMaxBits(T value, ErrorFunc&& func = ErrorFunc()) {
+inline T assertMaxBits(T value, ErrorFunc&& func = ErrorFunc()) {
   if (KJ_UNLIKELY(value > kj::maxValueForBits<bits>())) func();
   return value;
 }
 
 template <typename T, typename ErrorFunc = ThrowOverflow>
-inline constexpr T assertMaxBits(uint bits, T value, ErrorFunc&& func = ErrorFunc()) {
+inline T assertMaxBits(uint bits, T value, ErrorFunc&& func = ErrorFunc()) {
   if (KJ_UNLIKELY(value > (1ull << bits) - 1)) func();
   return value;
 }

--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -30,10 +30,13 @@
 #pragma GCC system_header
 #endif
 
-#include <kj/units.h>
 #include <inttypes.h>
 #include <kj/string.h>
 #include <kj/memory.h>
+
+#if CAPNP_DEBUG_TYPES
+#include <kj/units.h>
+#endif
 
 namespace capnp {
 

--- a/c++/src/capnp/compat/json.capnp.h
+++ b/c++/src/capnp/compat/json.capnp.h
@@ -413,11 +413,11 @@ private:
 
 inline  ::capnp::JsonValue::Which JsonValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::JsonValue::Which JsonValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Reader::isNull() const {
@@ -430,20 +430,20 @@ inline  ::capnp::Void JsonValue::Reader::getNull() const {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void JsonValue::Builder::getNull() {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNull( ::capnp::Void value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NULL_);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::NULL_);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isBoolean() const {
@@ -456,20 +456,20 @@ inline bool JsonValue::Reader::getBoolean() const {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Builder::getBoolean() {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setBoolean(bool value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
   _builder.setDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isNumber() const {
@@ -482,20 +482,20 @@ inline double JsonValue::Reader::getNumber() const {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double JsonValue::Builder::getNumber() {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNumber(double value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NUMBER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::NUMBER);
   _builder.setDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isString() const {
@@ -507,49 +507,49 @@ inline bool JsonValue::Builder::isString() {
 inline bool JsonValue::Reader::hasString() const {
   if (which() != JsonValue::STRING) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasString() {
   if (which() != JsonValue::STRING) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Reader::getString() const {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::getString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::initString(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Builder::disownString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isArray() const {
@@ -561,49 +561,49 @@ inline bool JsonValue::Builder::isArray() {
 inline bool JsonValue::Reader::hasArray() const {
   if (which() != JsonValue::ARRAY) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasArray() {
   if (which() != JsonValue::ARRAY) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Reader::getArray() const {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::getArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setArray( ::capnp::List< ::capnp::JsonValue>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::initArray(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptArray(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Builder::disownArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isObject() const {
@@ -615,49 +615,49 @@ inline bool JsonValue::Builder::isObject() {
 inline bool JsonValue::Reader::hasObject() const {
   if (which() != JsonValue::OBJECT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasObject() {
   if (which() != JsonValue::OBJECT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Reader JsonValue::Reader::getObject() const {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::getObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setObject( ::capnp::List< ::capnp::JsonValue::Field>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::initObject(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptObject(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>> JsonValue::Builder::disownObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isCall() const {
@@ -669,100 +669,100 @@ inline bool JsonValue::Builder::isCall() {
 inline bool JsonValue::Reader::hasCall() const {
   if (which() != JsonValue::CALL) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasCall() {
   if (which() != JsonValue::CALL) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Call::Reader JsonValue::Reader::getCall() const {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::getCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setCall( ::capnp::JsonValue::Call::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::initCall() {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::JsonValue::Call>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue::Call> JsonValue::Builder::disownCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Field::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Field::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Reader JsonValue::Field::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
@@ -771,88 +771,88 @@ inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void JsonValue::Field::Builder::setValue( ::capnp::JsonValue::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::JsonValue>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::JsonValue>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::JsonValue>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue> JsonValue::Field::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasFunction() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasFunction() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Call::Reader::getFunction() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::getFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setFunction( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::initFunction(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Call::Builder::disownFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Call::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setParams( ::capnp::List< ::capnp::JsonValue>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::initParams(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Call::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compat/json.capnp.h
+++ b/c++/src/capnp/compat/json.capnp.h
@@ -413,11 +413,11 @@ private:
 
 inline  ::capnp::JsonValue::Which JsonValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::JsonValue::Which JsonValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Reader::isNull() const {
@@ -430,20 +430,20 @@ inline  ::capnp::Void JsonValue::Reader::getNull() const {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void JsonValue::Builder::getNull() {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNull( ::capnp::Void value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NULL_);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NULL_);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isBoolean() const {
@@ -456,20 +456,20 @@ inline bool JsonValue::Reader::getBoolean() const {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Builder::getBoolean() {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setBoolean(bool value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
   _builder.setDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isNumber() const {
@@ -482,20 +482,20 @@ inline double JsonValue::Reader::getNumber() const {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double JsonValue::Builder::getNumber() {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNumber(double value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NUMBER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NUMBER);
   _builder.setDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isString() const {
@@ -507,49 +507,49 @@ inline bool JsonValue::Builder::isString() {
 inline bool JsonValue::Reader::hasString() const {
   if (which() != JsonValue::STRING) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasString() {
   if (which() != JsonValue::STRING) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Reader::getString() const {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::getString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::initString(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Builder::disownString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isArray() const {
@@ -561,49 +561,49 @@ inline bool JsonValue::Builder::isArray() {
 inline bool JsonValue::Reader::hasArray() const {
   if (which() != JsonValue::ARRAY) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasArray() {
   if (which() != JsonValue::ARRAY) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Reader::getArray() const {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::getArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setArray( ::capnp::List< ::capnp::JsonValue>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::initArray(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptArray(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Builder::disownArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isObject() const {
@@ -615,49 +615,49 @@ inline bool JsonValue::Builder::isObject() {
 inline bool JsonValue::Reader::hasObject() const {
   if (which() != JsonValue::OBJECT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasObject() {
   if (which() != JsonValue::OBJECT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Reader JsonValue::Reader::getObject() const {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::getObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setObject( ::capnp::List< ::capnp::JsonValue::Field>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::initObject(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptObject(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>> JsonValue::Builder::disownObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isCall() const {
@@ -669,100 +669,100 @@ inline bool JsonValue::Builder::isCall() {
 inline bool JsonValue::Reader::hasCall() const {
   if (which() != JsonValue::CALL) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasCall() {
   if (which() != JsonValue::CALL) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Call::Reader JsonValue::Reader::getCall() const {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::getCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setCall( ::capnp::JsonValue::Call::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::initCall() {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::JsonValue::Call>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
   ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue::Call> JsonValue::Builder::disownCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Field::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Field::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Reader JsonValue::Field::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
@@ -771,88 +771,88 @@ inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void JsonValue::Field::Builder::setValue( ::capnp::JsonValue::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::JsonValue>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::JsonValue>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::JsonValue>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue> JsonValue::Field::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasFunction() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasFunction() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Call::Reader::getFunction() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::getFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setFunction( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::initFunction(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Call::Builder::disownFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Call::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setParams( ::capnp::List< ::capnp::JsonValue>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::initParams(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Call::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compat/json.capnp.h
+++ b/c++/src/capnp/compat/json.capnp.h
@@ -412,10 +412,12 @@ private:
 // =======================================================================================
 
 inline  ::capnp::JsonValue::Which JsonValue::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::JsonValue::Which JsonValue::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Reader::isNull() const {
@@ -428,20 +430,20 @@ inline  ::capnp::Void JsonValue::Reader::getNull() const {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void JsonValue::Builder::getNull() {
   KJ_IREQUIRE((which() == JsonValue::NULL_),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNull( ::capnp::Void value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::NULL_);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NULL_);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isBoolean() const {
@@ -454,20 +456,20 @@ inline bool JsonValue::Reader::getBoolean() const {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      16 * ::capnp::ELEMENTS);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool JsonValue::Builder::getBoolean() {
   KJ_IREQUIRE((which() == JsonValue::BOOLEAN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      16 * ::capnp::ELEMENTS);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setBoolean(bool value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::BOOLEAN);
   _builder.setDataField<bool>(
-      16 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isNumber() const {
@@ -480,20 +482,20 @@ inline double JsonValue::Reader::getNumber() const {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double JsonValue::Builder::getNumber() {
   KJ_IREQUIRE((which() == JsonValue::NUMBER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void JsonValue::Builder::setNumber(double value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::NUMBER);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::NUMBER);
   _builder.setDataField<double>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JsonValue::Reader::isString() const {
@@ -504,48 +506,50 @@ inline bool JsonValue::Builder::isString() {
 }
 inline bool JsonValue::Reader::hasString() const {
   if (which() != JsonValue::STRING) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasString() {
   if (which() != JsonValue::STRING) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Reader::getString() const {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::getString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::STRING);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Builder::initString(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::STRING);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::STRING);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::STRING);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Builder::disownString() {
   KJ_IREQUIRE((which() == JsonValue::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isArray() const {
@@ -556,48 +560,50 @@ inline bool JsonValue::Builder::isArray() {
 }
 inline bool JsonValue::Reader::hasArray() const {
   if (which() != JsonValue::ARRAY) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasArray() {
   if (which() != JsonValue::ARRAY) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Reader::getArray() const {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::getArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setArray( ::capnp::List< ::capnp::JsonValue>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::ARRAY);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Builder::initArray(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::ARRAY);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptArray(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::ARRAY);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::ARRAY);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Builder::disownArray() {
   KJ_IREQUIRE((which() == JsonValue::ARRAY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isObject() const {
@@ -608,48 +614,50 @@ inline bool JsonValue::Builder::isObject() {
 }
 inline bool JsonValue::Reader::hasObject() const {
   if (which() != JsonValue::OBJECT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasObject() {
   if (which() != JsonValue::OBJECT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Reader JsonValue::Reader::getObject() const {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::getObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setObject( ::capnp::List< ::capnp::JsonValue::Field>::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::OBJECT);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue::Field>::Builder JsonValue::Builder::initObject(unsigned int size) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::OBJECT);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Builder::adoptObject(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::OBJECT);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::OBJECT);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue::Field>> JsonValue::Builder::disownObject() {
   KJ_IREQUIRE((which() == JsonValue::OBJECT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue::Field>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Reader::isCall() const {
@@ -660,95 +668,101 @@ inline bool JsonValue::Builder::isCall() {
 }
 inline bool JsonValue::Reader::hasCall() const {
   if (which() != JsonValue::CALL) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Builder::hasCall() {
   if (which() != JsonValue::CALL) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Call::Reader JsonValue::Reader::getCall() const {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::getCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::setCall( ::capnp::JsonValue::Call::Reader value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::CALL);
-  ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+  ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Call::Builder JsonValue::Builder::initCall() {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::CALL);
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::JsonValue::Call>&& value) {
   _builder.setDataField<JsonValue::Which>(
-      0 * ::capnp::ELEMENTS, JsonValue::CALL);
-  ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, JsonValue::CALL);
+  ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue::Call> JsonValue::Builder::disownCall() {
   KJ_IREQUIRE((which() == JsonValue::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue::Call>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Field::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Field::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Field::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Field::Reader::hasValue() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Field::Builder::hasValue() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::JsonValue::Reader JsonValue::Field::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
@@ -756,85 +770,89 @@ inline  ::capnp::JsonValue::Pipeline JsonValue::Field::Pipeline::getValue() {
 }
 #endif  // !CAPNP_LITE
 inline void JsonValue::Field::Builder::setValue( ::capnp::JsonValue::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::JsonValue>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::JsonValue>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::JsonValue::Builder JsonValue::Field::Builder::initValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Field::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::JsonValue>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::JsonValue>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::JsonValue>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::JsonValue> JsonValue::Field::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::JsonValue>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasFunction() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasFunction() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader JsonValue::Call::Reader::getFunction() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::getFunction() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setFunction( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder JsonValue::Call::Builder::initFunction(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> JsonValue::Call::Builder::disownFunction() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool JsonValue::Call::Reader::hasParams() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool JsonValue::Call::Builder::hasParams() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Reader JsonValue::Call::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::getParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void JsonValue::Call::Builder::setParams( ::capnp::List< ::capnp::JsonValue>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::JsonValue>::Builder JsonValue::Call::Builder::initParams(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void JsonValue::Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::JsonValue>> JsonValue::Call::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::JsonValue>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1082,7 +1082,7 @@ private:
             "              \"Must check which() before get()ing a union member.\");\n"),
         kj::str(
             "  _builder.setDataField<", scope, "Which>(\n"
-            "      ", discrimOffset, " * ::capnp::ELEMENTS, ",
+            "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS, ",
                       scope, upperCase, ");\n"),
         kj::strTree("  inline bool is", titleCase, "() const;\n"),
         kj::strTree("  inline bool is", titleCase, "();\n"),
@@ -1180,12 +1180,12 @@ private:
                       return kj::strTree();
                     case Section::DATA:
                       return kj::strTree(
-                          "  _builder.setDataField<", maskType(slot.whichType), ">(",
-                              slot.offset, " * ::capnp::ELEMENTS, 0);\n");
+                          "  _builder.setDataField<", maskType(slot.whichType), ">(::kj::guarded<",
+                              slot.offset, ">() * ::capnp::ELEMENTS, 0);\n");
                     case Section::POINTERS:
                       return kj::strTree(
-                          "  _builder.getPointerField(", slot.offset,
-                              " * ::capnp::POINTERS).clear();\n");
+                          "  _builder.getPointerField(::kj::guarded<", slot.offset,
+                              ">() * ::capnp::POINTERS).clear();\n");
                   }
                   KJ_UNREACHABLE;
                 },
@@ -1344,20 +1344,20 @@ private:
             "inline ", type, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return _reader.getDataField<", type, ">(\n"
-            "      ", offset, " * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n"
             "\n",
             templateContext.allDecls(),
             "inline ", type, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return _builder.getDataField<", type, ">(\n"
-            "      ", offset, " * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", type, " value) {\n",
             unionDiscrim.set,
             "  _builder.setDataField<", type, ">(\n"
-            "      ", offset, " * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
+            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
             "}\n"
             "\n")
       };
@@ -1396,25 +1396,27 @@ private:
             templateContext.allDecls(),
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
-            "  return !_reader.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
-            "  return !_builder.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n"
             "#if !CAPNP_LITE\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::get(\n"
-            "      _reader.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::get(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             hasDiscriminantValue(proto) ? kj::strTree() : kj::strTree(
               templateContext.allDecls(),
@@ -1424,27 +1426,27 @@ private:
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "&& cap) {\n",
             unionDiscrim.set,
-            "  ::capnp::_::PointerHelpers<", type, ">::set(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), kj::mv(cap));\n"
+            "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(cap));\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "& cap) {\n",
             unionDiscrim.set,
-            "  ::capnp::_::PointerHelpers<", type, ">::set(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), cap);\n"
+            "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), cap);\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
-            "  ::capnp::_::PointerHelpers<", type, ">::adopt(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), kj::mv(value));\n"
+            "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::disown(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n"
             "#endif  // !CAPNP_LITE\n"
             "\n")
@@ -1472,30 +1474,32 @@ private:
             templateContext.allDecls(),
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
-            "  return !_reader.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
-            "  return !_builder.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Reader ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
-            "  return ::capnp::AnyPointer::Reader(\n"
-            "      _reader.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::AnyPointer::Reader(_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
-            "  return ::capnp::AnyPointer::Builder(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::init", titleCase, "() {\n",
             unionDiscrim.set,
-            "  auto result = ::capnp::AnyPointer::Builder(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "  result.clear();\n"
             "  return result;\n"
             "}\n"
@@ -1639,25 +1643,27 @@ private:
             templateContext.allDecls(),
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
-            "  return !_reader.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
-            "  return !_builder.getPointerField(", offset, " * ::capnp::POINTERS).isNull();\n"
+            "  return !_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             COND(shouldExcludeInLiteMode, "#if !CAPNP_LITE\n"),
             templateContext.allDecls(),
             "inline ", readerType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::get(\n"
-            "      _reader.getPointerField(", offset, " * ::capnp::POINTERS)", defaultParam, ");\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", builderType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::get(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS)", defaultParam, ");\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             COND(shouldIncludePipelineGetter,
               "#if !CAPNP_LITE\n",
@@ -1669,15 +1675,15 @@ private:
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", readerType, " value) {\n",
             unionDiscrim.set,
-            "  ::capnp::_::PointerHelpers<", type, ">::set(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), value);\n"
+            "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
             "}\n",
             COND(shouldIncludeArrayInitializer,
               templateContext.allDecls(),
               "inline void ", scope, "Builder::set", titleCase, "(::kj::ArrayPtr<const ", elementReaderType, "> value) {\n",
               unionDiscrim.set,
-              "  ::capnp::_::PointerHelpers<", type, ">::set(\n"
-              "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), value);\n"
+              "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
               "}\n"),
             COND(shouldIncludeStructInit,
               COND(shouldTemplatizeInit,
@@ -1687,15 +1693,15 @@ private:
                 "  static_assert(::capnp::kind<T_>() == ::capnp::Kind::STRUCT,\n"
                 "                \"", proto.getName(), " must be a struct\");\n",
                 unionDiscrim.set,
-                "  return ::capnp::_::PointerHelpers<T_>::init(\n"
-                "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+                "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
+                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "() {\n",
                 unionDiscrim.set,
-                "  return ::capnp::_::PointerHelpers<", type, ">::init(\n"
-                "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+                "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
+                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n")),
             COND(shouldIncludeSizedInit,
               COND(shouldTemplatizeInit,
@@ -1705,22 +1711,22 @@ private:
                 "  static_assert(::capnp::kind<T_>() == ::capnp::Kind::LIST,\n"
                 "                \"", proto.getName(), " must be a list\");\n",
                 unionDiscrim.set,
-                "  return ::capnp::_::PointerHelpers<T_>::init(\n"
-                "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), size);\n"
+                "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
+                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "(unsigned int size) {\n",
                 unionDiscrim.set,
-                "  return ::capnp::_::PointerHelpers<", type, ">::init(\n"
-                "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), size);\n"
+                "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
+                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n")),
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
-            "  ::capnp::_::PointerHelpers<", type, ">::adopt(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS), kj::mv(value));\n"
+            "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(),
                 "#ifndef _MSC_VER\n"
@@ -1728,8 +1734,8 @@ private:
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
-            "  return ::capnp::_::PointerHelpers<", type, ">::disown(\n"
-            "      _builder.getPointerField(", offset, " * ::capnp::POINTERS));\n"
+            "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
+            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(), "#endif  // !_MSC_VER\n"),
             COND(shouldExcludeInLiteMode, "#endif  // !CAPNP_LITE\n"),
@@ -2048,11 +2054,13 @@ private:
           structNode.getDiscriminantCount() == 0 ? kj::strTree() : kj::strTree(
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Reader::which() const {\n"
-              "  return _reader.getDataField<Which>(", discrimOffset, " * ::capnp::ELEMENTS);\n"
+              "  return _reader.getDataField<Which>(\n"
+              "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n",
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Builder::which() {\n"
-              "  return _builder.getDataField<Which>(", discrimOffset, " * ::capnp::ELEMENTS);\n"
+              "  return _builder.getDataField<Which>(\n"
+              "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n"
               "\n"),
           KJ_MAP(f, fieldTexts) { return kj::mv(f.inlineMethodDefs); }),

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1082,7 +1082,7 @@ private:
             "              \"Must check which() before get()ing a union member.\");\n"),
         kj::str(
             "  _builder.setDataField<", scope, "Which>(\n"
-            "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS, ",
+            "      ::capnp::bounded<", discrimOffset, ">() * ::capnp::ELEMENTS, ",
                       scope, upperCase, ");\n"),
         kj::strTree("  inline bool is", titleCase, "() const;\n"),
         kj::strTree("  inline bool is", titleCase, "();\n"),
@@ -1180,11 +1180,11 @@ private:
                       return kj::strTree();
                     case Section::DATA:
                       return kj::strTree(
-                          "  _builder.setDataField<", maskType(slot.whichType), ">(::capnp::guarded<",
+                          "  _builder.setDataField<", maskType(slot.whichType), ">(::capnp::bounded<",
                               slot.offset, ">() * ::capnp::ELEMENTS, 0);\n");
                     case Section::POINTERS:
                       return kj::strTree(
-                          "  _builder.getPointerField(::capnp::guarded<", slot.offset,
+                          "  _builder.getPointerField(::capnp::bounded<", slot.offset,
                               ">() * ::capnp::POINTERS).clear();\n");
                   }
                   KJ_UNREACHABLE;
@@ -1344,20 +1344,20 @@ private:
             "inline ", type, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return _reader.getDataField<", type, ">(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::capnp::bounded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n"
             "\n",
             templateContext.allDecls(),
             "inline ", type, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return _builder.getDataField<", type, ">(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::capnp::bounded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", type, " value) {\n",
             unionDiscrim.set,
             "  _builder.setDataField<", type, ">(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
+            "      ::capnp::bounded<", offset, ">() * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
             "}\n"
             "\n")
       };
@@ -1397,26 +1397,26 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n"
             "#if !CAPNP_LITE\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             hasDiscriminantValue(proto) ? kj::strTree() : kj::strTree(
               templateContext.allDecls(),
@@ -1427,26 +1427,26 @@ private:
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "&& cap) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(cap));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), kj::mv(cap));\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "& cap) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), cap);\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), cap);\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n"
             "#endif  // !CAPNP_LITE\n"
             "\n")
@@ -1475,31 +1475,31 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Reader ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::AnyPointer::Reader(_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::init", titleCase, "() {\n",
             unionDiscrim.set,
             "  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "  result.clear();\n"
             "  return result;\n"
             "}\n"
@@ -1644,26 +1644,26 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             COND(shouldExcludeInLiteMode, "#if !CAPNP_LITE\n"),
             templateContext.allDecls(),
             "inline ", readerType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", builderType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             COND(shouldIncludePipelineGetter,
               "#if !CAPNP_LITE\n",
@@ -1676,14 +1676,14 @@ private:
             "inline void ", scope, "Builder::set", titleCase, "(", readerType, " value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), value);\n"
             "}\n",
             COND(shouldIncludeArrayInitializer,
               templateContext.allDecls(),
               "inline void ", scope, "Builder::set", titleCase, "(::kj::ArrayPtr<const ", elementReaderType, "> value) {\n",
               unionDiscrim.set,
               "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), value);\n"
               "}\n"),
             COND(shouldIncludeStructInit,
               COND(shouldTemplatizeInit,
@@ -1694,14 +1694,14 @@ private:
                 "                \"", proto.getName(), " must be a struct\");\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
-                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+                "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "() {\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
-                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+                "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n")),
             COND(shouldIncludeSizedInit,
               COND(shouldTemplatizeInit,
@@ -1712,21 +1712,21 @@ private:
                 "                \"", proto.getName(), " must be a list\");\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
-                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
+                "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "(unsigned int size) {\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
-                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
+                "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n")),
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(),
                 "#ifndef _MSC_VER\n"
@@ -1735,7 +1735,7 @@ private:
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
-            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::bounded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(), "#endif  // !_MSC_VER\n"),
             COND(shouldExcludeInLiteMode, "#endif  // !CAPNP_LITE\n"),
@@ -2055,12 +2055,12 @@ private:
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Reader::which() const {\n"
               "  return _reader.getDataField<Which>(\n"
-              "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
+              "      ::capnp::bounded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n",
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Builder::which() {\n"
               "  return _builder.getDataField<Which>(\n"
-              "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
+              "      ::capnp::bounded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n"
               "\n"),
           KJ_MAP(f, fieldTexts) { return kj::mv(f.inlineMethodDefs); }),

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -1082,7 +1082,7 @@ private:
             "              \"Must check which() before get()ing a union member.\");\n"),
         kj::str(
             "  _builder.setDataField<", scope, "Which>(\n"
-            "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS, ",
+            "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS, ",
                       scope, upperCase, ");\n"),
         kj::strTree("  inline bool is", titleCase, "() const;\n"),
         kj::strTree("  inline bool is", titleCase, "();\n"),
@@ -1180,11 +1180,11 @@ private:
                       return kj::strTree();
                     case Section::DATA:
                       return kj::strTree(
-                          "  _builder.setDataField<", maskType(slot.whichType), ">(::kj::guarded<",
+                          "  _builder.setDataField<", maskType(slot.whichType), ">(::capnp::guarded<",
                               slot.offset, ">() * ::capnp::ELEMENTS, 0);\n");
                     case Section::POINTERS:
                       return kj::strTree(
-                          "  _builder.getPointerField(::kj::guarded<", slot.offset,
+                          "  _builder.getPointerField(::capnp::guarded<", slot.offset,
                               ">() * ::capnp::POINTERS).clear();\n");
                   }
                   KJ_UNREACHABLE;
@@ -1344,20 +1344,20 @@ private:
             "inline ", type, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return _reader.getDataField<", type, ">(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n"
             "\n",
             templateContext.allDecls(),
             "inline ", type, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return _builder.getDataField<", type, ">(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
+            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS", defaultMaskParam, ");\n",
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", type, " value) {\n",
             unionDiscrim.set,
             "  _builder.setDataField<", type, ">(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
+            "      ::capnp::guarded<", offset, ">() * ::capnp::ELEMENTS, value", defaultMaskParam, ");\n",
             "}\n"
             "\n")
       };
@@ -1397,26 +1397,26 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n"
             "#if !CAPNP_LITE\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", clientType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             hasDiscriminantValue(proto) ? kj::strTree() : kj::strTree(
               templateContext.allDecls(),
@@ -1427,26 +1427,26 @@ private:
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "&& cap) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(cap));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(cap));\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::set", titleCase, "(", clientType, "& cap) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), cap);\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), cap);\n"
             "}\n",
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n"
             "#endif  // !CAPNP_LITE\n"
             "\n")
@@ -1475,31 +1475,31 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Reader ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::AnyPointer::Reader(_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             templateContext.allDecls(),
             "inline ::capnp::AnyPointer::Builder ", scope, "Builder::init", titleCase, "() {\n",
             unionDiscrim.set,
             "  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "  result.clear();\n"
             "  return result;\n"
             "}\n"
@@ -1644,26 +1644,26 @@ private:
             "inline bool ", scope, "Reader::has", titleCase, "() const {\n",
             unionDiscrim.has,
             "  return !_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             templateContext.allDecls(),
             "inline bool ", scope, "Builder::has", titleCase, "() {\n",
             unionDiscrim.has,
             "  return !_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS).isNull();\n"
             "}\n",
             COND(shouldExcludeInLiteMode, "#if !CAPNP_LITE\n"),
             templateContext.allDecls(),
             "inline ", readerType, " ", scope, "Reader::get", titleCase, "() const {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_reader.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             templateContext.allDecls(),
             "inline ", builderType, " ", scope, "Builder::get", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::get(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS)", defaultParam, ");\n"
             "}\n",
             COND(shouldIncludePipelineGetter,
               "#if !CAPNP_LITE\n",
@@ -1676,14 +1676,14 @@ private:
             "inline void ", scope, "Builder::set", titleCase, "(", readerType, " value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
             "}\n",
             COND(shouldIncludeArrayInitializer,
               templateContext.allDecls(),
               "inline void ", scope, "Builder::set", titleCase, "(::kj::ArrayPtr<const ", elementReaderType, "> value) {\n",
               unionDiscrim.set,
               "  ::capnp::_::PointerHelpers<", type, ">::set(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), value);\n"
               "}\n"),
             COND(shouldIncludeStructInit,
               COND(shouldTemplatizeInit,
@@ -1694,14 +1694,14 @@ private:
                 "                \"", proto.getName(), " must be a struct\");\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
-                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "() {\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
-                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
                 "}\n")),
             COND(shouldIncludeSizedInit,
               COND(shouldTemplatizeInit,
@@ -1712,21 +1712,21 @@ private:
                 "                \"", proto.getName(), " must be a list\");\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<T_>::init(_builder.getPointerField(\n"
-                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
+                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n"),
               COND(!shouldTemplatizeInit,
                 templateContext.allDecls(),
                 "inline ", builderType, " ", scope, "Builder::init", titleCase, "(unsigned int size) {\n",
                 unionDiscrim.set,
                 "  return ::capnp::_::PointerHelpers<", type, ">::init(_builder.getPointerField(\n"
-                "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
+                "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), size);\n"
                 "}\n")),
             templateContext.allDecls(),
             "inline void ", scope, "Builder::adopt", titleCase, "(\n"
             "    ::capnp::Orphan<", type, ">&& value) {\n",
             unionDiscrim.set,
             "  ::capnp::_::PointerHelpers<", type, ">::adopt(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS), kj::mv(value));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(),
                 "#ifndef _MSC_VER\n"
@@ -1735,7 +1735,7 @@ private:
             "inline ::capnp::Orphan<", type, "> ", scope, "Builder::disown", titleCase, "() {\n",
             unionDiscrim.check,
             "  return ::capnp::_::PointerHelpers<", type, ">::disown(_builder.getPointerField(\n"
-            "      ::kj::guarded<", offset, ">() * ::capnp::POINTERS));\n"
+            "      ::capnp::guarded<", offset, ">() * ::capnp::POINTERS));\n"
             "}\n",
             COND(type.hasDisambiguatedTemplate(), "#endif  // !_MSC_VER\n"),
             COND(shouldExcludeInLiteMode, "#endif  // !CAPNP_LITE\n"),
@@ -2055,12 +2055,12 @@ private:
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Reader::which() const {\n"
               "  return _reader.getDataField<Which>(\n"
-              "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
+              "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n",
               templateContext.allDecls(),
               "inline ", whichName, " ", fullName, "::Builder::which() {\n"
               "  return _builder.getDataField<Which>(\n"
-              "      ::kj::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
+              "      ::capnp::guarded<", discrimOffset, ">() * ::capnp::ELEMENTS);\n"
               "}\n"
               "\n"),
           KJ_MAP(f, fieldTexts) { return kj::mv(f.inlineMethodDefs); }),

--- a/c++/src/capnp/compiler/grammar.capnp.h
+++ b/c++/src/capnp/compiler/grammar.capnp.h
@@ -3204,157 +3204,157 @@ private:
 
 inline bool LocatedText::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LocatedText::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader LocatedText::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void LocatedText::Builder::setValue( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::initValue(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void LocatedText::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> LocatedText::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t LocatedText::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedText::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t LocatedInteger::Reader::getValue() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t LocatedInteger::Builder::getValue() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setValue( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline double LocatedFloat::Reader::getValue() const {
   return _reader.getDataField<double>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline double LocatedFloat::Builder::getValue() {
   return _builder.getDataField<double>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setValue(double value) {
   _builder.setDataField<double>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Expression::Which Expression::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Which Expression::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Reader::isUnknown() const {
@@ -3367,20 +3367,20 @@ inline  ::capnp::Void Expression::Reader::getUnknown() const {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Builder::getUnknown() {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setUnknown( ::capnp::Void value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::UNKNOWN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::UNKNOWN);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isPositiveInt() const {
@@ -3393,20 +3393,20 @@ inline  ::uint64_t Expression::Reader::getPositiveInt() const {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getPositiveInt() {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setPositiveInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isNegativeInt() const {
@@ -3419,20 +3419,20 @@ inline  ::uint64_t Expression::Reader::getNegativeInt() const {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getNegativeInt() {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setNegativeInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isFloat() const {
@@ -3445,20 +3445,20 @@ inline double Expression::Reader::getFloat() const {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Expression::Builder::getFloat() {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setFloat(double value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::FLOAT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::FLOAT);
   _builder.setDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isString() const {
@@ -3470,49 +3470,49 @@ inline bool Expression::Builder::isString() {
 inline bool Expression::Reader::hasString() const {
   if (which() != Expression::STRING) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasString() {
   if (which() != Expression::STRING) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Expression::Reader::getString() const {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Expression::Builder::getString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Expression::Builder::initString(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Expression::Builder::disownString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isRelativeName() const {
@@ -3524,49 +3524,49 @@ inline bool Expression::Builder::isRelativeName() {
 inline bool Expression::Reader::hasRelativeName() const {
   if (which() != Expression::RELATIVE_NAME) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasRelativeName() {
   if (which() != Expression::RELATIVE_NAME) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getRelativeName() const {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setRelativeName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initRelativeName() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptRelativeName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isList() const {
@@ -3578,49 +3578,49 @@ inline bool Expression::Builder::isList() {
 inline bool Expression::Reader::hasList() const {
   if (which() != Expression::LIST) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasList() {
   if (which() != Expression::LIST) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Expression::Reader::getList() const {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::getList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setList( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::initList(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Expression::Builder::disownList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isTuple() const {
@@ -3632,77 +3632,77 @@ inline bool Expression::Builder::isTuple() {
 inline bool Expression::Reader::hasTuple() const {
   if (which() != Expression::TUPLE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasTuple() {
   if (which() != Expression::TUPLE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Reader::getTuple() const {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::getTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setTuple( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::initTuple(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptTuple(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Builder::disownTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Expression::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Expression::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isBinary() const {
@@ -3714,49 +3714,49 @@ inline bool Expression::Builder::isBinary() {
 inline bool Expression::Reader::hasBinary() const {
   if (which() != Expression::BINARY) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasBinary() {
   if (which() != Expression::BINARY) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Expression::Reader::getBinary() const {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Expression::Builder::getBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setBinary( ::capnp::Data::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Expression::Builder::initBinary(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptBinary(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Expression::Builder::disownBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isApplication() const {
@@ -3777,9 +3777,9 @@ inline typename Expression::Application::Builder Expression::Builder::getApplica
 }
 inline typename Expression::Application::Builder Expression::Builder::initApplication() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::APPLICATION);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::APPLICATION);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Application::Builder(_builder);
 }
 inline bool Expression::Reader::isMember() const {
@@ -3800,9 +3800,9 @@ inline typename Expression::Member::Builder Expression::Builder::getMember() {
 }
 inline typename Expression::Member::Builder Expression::Builder::initMember() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::MEMBER);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::MEMBER);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Member::Builder(_builder);
 }
 inline bool Expression::Reader::isAbsoluteName() const {
@@ -3814,49 +3814,49 @@ inline bool Expression::Builder::isAbsoluteName() {
 inline bool Expression::Reader::hasAbsoluteName() const {
   if (which() != Expression::ABSOLUTE_NAME) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasAbsoluteName() {
   if (which() != Expression::ABSOLUTE_NAME) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getAbsoluteName() const {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setAbsoluteName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initAbsoluteName() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptAbsoluteName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isImport() const {
@@ -3868,49 +3868,49 @@ inline bool Expression::Builder::isImport() {
 inline bool Expression::Reader::hasImport() const {
   if (which() != Expression::IMPORT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasImport() {
   if (which() != Expression::IMPORT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getImport() const {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setImport( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initImport() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptImport(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isEmbed() const {
@@ -3922,58 +3922,58 @@ inline bool Expression::Builder::isEmbed() {
 inline bool Expression::Reader::hasEmbed() const {
   if (which() != Expression::EMBED) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasEmbed() {
   if (which() != Expression::EMBED) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getEmbed() const {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setEmbed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initEmbed() {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptEmbed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Param::Reader::isUnnamed() const {
@@ -3986,20 +3986,20 @@ inline  ::capnp::Void Expression::Param::Reader::getUnnamed() const {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Param::Builder::getUnnamed() {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Param::Builder::setUnnamed( ::capnp::Void value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Param::Reader::isNamed() const {
@@ -4011,66 +4011,66 @@ inline bool Expression::Param::Builder::isNamed() {
 inline bool Expression::Param::Reader::hasNamed() const {
   if (which() != Expression::Param::NAMED) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasNamed() {
   if (which() != Expression::Param::NAMED) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Param::Reader::getNamed() const {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::getNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::setNamed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::initNamed() {
   _builder.setDataField<Expression::Param::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptNamed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Param::Builder::disownNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Param::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Param::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::getValue() {
@@ -4079,37 +4079,37 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::get
 #endif  // !CAPNP_LITE
 inline void Expression::Param::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Param::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasFunction() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasFunction() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Application::Reader::getFunction() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::getFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipeline::getFunction() {
@@ -4118,71 +4118,71 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipelin
 #endif  // !CAPNP_LITE
 inline void Expression::Application::Builder::setFunction( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::initFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Application::Builder::disownFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Application::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::setParams( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::initParams(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Application::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Application::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasParent() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasParent() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Member::Reader::getParent() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::getParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::getParent() {
@@ -4191,37 +4191,37 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setParent( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::initParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptParent(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Member::Builder::disownParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Member::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::getName() {
@@ -4230,46 +4230,46 @@ inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::g
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Member::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Which Declaration::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Which Declaration::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName() {
@@ -4278,20 +4278,20 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName(
 #endif  // !CAPNP_LITE
 inline void Declaration::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Id::Reader Declaration::Reader::getId() const {
@@ -4306,138 +4306,138 @@ inline typename Declaration::Id::Pipeline Declaration::Pipeline::getId() {
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Id::Builder Declaration::Builder::initId() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::Id::Builder(_builder);
 }
 inline bool Declaration::Reader::hasNestedDecls() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNestedDecls() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Reader Declaration::Reader::getNestedDecls() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::getNestedDecls() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNestedDecls( ::capnp::List< ::capnp::compiler::Declaration>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::initNestedDecls(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptNestedDecls(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>> Declaration::Builder::disownNestedDecls() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasDocComment() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasDocComment() {
   return !_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::Reader::getDocComment() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::Builder::getDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setDocComment( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::Builder::initDocComment(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::Builder::disownDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isFile() const {
@@ -4450,20 +4450,20 @@ inline  ::capnp::Void Declaration::Reader::getFile() const {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getFile() {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::FILE);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::FILE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isUsing() const {
@@ -4484,8 +4484,8 @@ inline typename Declaration::Using::Builder Declaration::Builder::getUsing() {
 }
 inline typename Declaration::Using::Builder Declaration::Builder::initUsing() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::USING);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::USING);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Using::Builder(_builder);
 }
 inline bool Declaration::Reader::isConst() const {
@@ -4506,9 +4506,9 @@ inline typename Declaration::Const::Builder Declaration::Builder::getConst() {
 }
 inline typename Declaration::Const::Builder Declaration::Builder::initConst() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::CONST);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::CONST);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Const::Builder(_builder);
 }
 inline bool Declaration::Reader::isEnum() const {
@@ -4521,20 +4521,20 @@ inline  ::capnp::Void Declaration::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnum() {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnum( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUM);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::ENUM);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isEnumerant() const {
@@ -4547,20 +4547,20 @@ inline  ::capnp::Void Declaration::Reader::getEnumerant() const {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnumerant() {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnumerant( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUMERANT);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::ENUMERANT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isStruct() const {
@@ -4573,20 +4573,20 @@ inline  ::capnp::Void Declaration::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getStruct() {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::STRUCT);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isField() const {
@@ -4607,10 +4607,10 @@ inline typename Declaration::Field::Builder Declaration::Builder::getField() {
 }
 inline typename Declaration::Field::Builder Declaration::Builder::initField() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::FIELD);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::FIELD);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::Builder(_builder);
 }
 inline bool Declaration::Reader::isUnion() const {
@@ -4623,20 +4623,20 @@ inline  ::capnp::Void Declaration::Reader::getUnion() const {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getUnion() {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setUnion( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::UNION);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::UNION);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isGroup() const {
@@ -4649,20 +4649,20 @@ inline  ::capnp::Void Declaration::Reader::getGroup() const {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getGroup() {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setGroup( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::GROUP);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::GROUP);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isInterface() const {
@@ -4683,8 +4683,8 @@ inline typename Declaration::Interface::Builder Declaration::Builder::getInterfa
 }
 inline typename Declaration::Interface::Builder Declaration::Builder::initInterface() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::INTERFACE);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::INTERFACE);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Interface::Builder(_builder);
 }
 inline bool Declaration::Reader::isMethod() const {
@@ -4705,10 +4705,10 @@ inline typename Declaration::Method::Builder Declaration::Builder::getMethod() {
 }
 inline typename Declaration::Method::Builder Declaration::Builder::initMethod() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::METHOD);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::METHOD);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Builder(_builder);
 }
 inline bool Declaration::Reader::isAnnotation() const {
@@ -4729,20 +4729,20 @@ inline typename Declaration::Annotation::Builder Declaration::Builder::getAnnota
 }
 inline typename Declaration::Annotation::Builder Declaration::Builder::initAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ANNOTATION);
-  _builder.setDataField<bool>(::capnp::guarded<96>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<97>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<98>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<99>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<100>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<101>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<102>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<103>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<104>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<105>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<106>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<107>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::ANNOTATION);
+  _builder.setDataField<bool>(::capnp::bounded<96>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<97>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<98>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<99>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<100>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<101>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<102>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<103>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<104>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<105>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<106>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<107>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Annotation::Builder(_builder);
 }
 inline bool Declaration::Reader::isNakedId() const {
@@ -4754,49 +4754,49 @@ inline bool Declaration::Builder::isNakedId() {
 inline bool Declaration::Reader::hasNakedId() const {
   if (which() != Declaration::NAKED_ID) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedId() {
   if (which() != Declaration::NAKED_ID) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Reader::getNakedId() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::getNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedId( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::initNakedId() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedId(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Builder::disownNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isNakedAnnotation() const {
@@ -4808,49 +4808,49 @@ inline bool Declaration::Builder::isNakedAnnotation() {
 inline bool Declaration::Reader::hasNakedAnnotation() const {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedAnnotation() {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Reader Declaration::Reader::getNakedAnnotation() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::getNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedAnnotation( ::capnp::compiler::Declaration::AnnotationApplication::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::initNakedAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedAnnotation(
     ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication>&& value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication> Declaration::Builder::disownNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinVoid() const {
@@ -4863,20 +4863,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinVoid() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinVoid() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinVoid( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinBool() const {
@@ -4889,20 +4889,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinBool() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinBool() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinBool( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt8() const {
@@ -4915,20 +4915,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt16() const {
@@ -4941,20 +4941,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt32() const {
@@ -4967,20 +4967,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt64() const {
@@ -4993,20 +4993,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt8() const {
@@ -5019,20 +5019,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt16() const {
@@ -5045,20 +5045,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt32() const {
@@ -5071,20 +5071,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt64() const {
@@ -5097,20 +5097,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat32() const {
@@ -5123,20 +5123,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat64() const {
@@ -5149,20 +5149,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinText() const {
@@ -5175,20 +5175,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinText() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinText() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinText( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinData() const {
@@ -5201,20 +5201,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinData() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinData() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinData( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinList() const {
@@ -5227,20 +5227,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinObject() const {
@@ -5253,20 +5253,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinObject() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinObject() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinObject( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyPointer() const {
@@ -5279,54 +5279,54 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyPointer() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyPointer() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyPointer( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasParameters() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<7>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasParameters() {
   return !_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<7>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader Declaration::Reader::getParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_reader.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::bounded<7>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::getParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::bounded<7>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setParameters( ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::set(_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<7>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::initParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::init(_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<7>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<7>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>> Declaration::Builder::disownParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::disown(_builder.getPointerField(
-      ::capnp::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::bounded<7>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinAnyStruct() const {
@@ -5339,20 +5339,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyStruct() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyStruct() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyList() const {
@@ -5365,20 +5365,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinCapability() const {
@@ -5391,99 +5391,99 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinCapability() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinCapability() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinCapability( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::BrandParameter::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::BrandParameter::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::BrandParameter::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::BrandParameter::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::BrandParameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::BrandParameter::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplication::Pipeline::getName() {
@@ -5492,20 +5492,20 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplicati
 #endif  // !CAPNP_LITE
 inline void Declaration::AnnotationApplication::Builder::setName( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::AnnotationApplication::Value::Reader Declaration::AnnotationApplication::Reader::getValue() const {
@@ -5520,17 +5520,17 @@ inline typename Declaration::AnnotationApplication::Value::Pipeline Declaration:
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::AnnotationApplication::Value::Builder Declaration::AnnotationApplication::Builder::initValue() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::AnnotationApplication::Value::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isNone() const {
@@ -5543,20 +5543,20 @@ inline  ::capnp::Void Declaration::AnnotationApplication::Value::Reader::getNone
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::AnnotationApplication::Value::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isExpression() const {
@@ -5568,58 +5568,58 @@ inline bool Declaration::AnnotationApplication::Value::Builder::isExpression() {
 inline bool Declaration::AnnotationApplication::Value::Reader::hasExpression() const {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Value::Builder::hasExpression() {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Value::Reader::getExpression() const {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::getExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setExpression( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::initExpression() {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::adoptExpression(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Value::Builder::disownExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::ParamList::Reader::isNamedList() const {
@@ -5631,49 +5631,49 @@ inline bool Declaration::ParamList::Builder::isNamedList() {
 inline bool Declaration::ParamList::Reader::hasNamedList() const {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasNamedList() {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader Declaration::ParamList::Reader::getNamedList() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::getNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setNamedList( ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::initNamedList(unsigned int size) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::ParamList::Builder::adoptNamedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>> Declaration::ParamList::Builder::disownNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::ParamList::Reader::isType() const {
@@ -5685,94 +5685,94 @@ inline bool Declaration::ParamList::Builder::isType() {
 inline bool Declaration::ParamList::Reader::hasType() const {
   if (which() != Declaration::ParamList::TYPE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasType() {
   if (which() != Declaration::ParamList::TYPE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::ParamList::Reader::getType() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::getType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::initType() {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::ParamList::Builder::disownType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Param::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::getName() {
@@ -5781,37 +5781,37 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::g
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Param::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::getType() {
@@ -5820,54 +5820,54 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Param::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Param::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Param::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Param::DefaultValue::Reader Declaration::Param::Reader::getDefaultValue() const {
@@ -5882,45 +5882,45 @@ inline typename Declaration::Param::DefaultValue::Pipeline Declaration::Param::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Param::DefaultValue::Builder Declaration::Param::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
   return typename Declaration::Param::DefaultValue::Builder(_builder);
 }
 inline  ::uint32_t Declaration::Param::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Param::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isNone() const {
@@ -5933,20 +5933,20 @@ inline  ::capnp::Void Declaration::Param::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Param::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isValue() const {
@@ -5958,58 +5958,58 @@ inline bool Declaration::Param::DefaultValue::Builder::isValue() {
 inline bool Declaration::Param::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Id::Reader::isUnspecified() const {
@@ -6022,20 +6022,20 @@ inline  ::capnp::Void Declaration::Id::Reader::getUnspecified() const {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Id::Builder::getUnspecified() {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Id::Builder::setUnspecified( ::capnp::Void value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Id::Reader::isUid() const {
@@ -6047,49 +6047,49 @@ inline bool Declaration::Id::Builder::isUid() {
 inline bool Declaration::Id::Reader::hasUid() const {
   if (which() != Declaration::Id::UID) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasUid() {
   if (which() != Declaration::Id::UID) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getUid() const {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setUid( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initUid() {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptUid(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Id::Reader::isOrdinal() const {
@@ -6101,66 +6101,66 @@ inline bool Declaration::Id::Builder::isOrdinal() {
 inline bool Declaration::Id::Reader::hasOrdinal() const {
   if (which() != Declaration::Id::ORDINAL) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasOrdinal() {
   if (which() != Declaration::Id::ORDINAL) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getOrdinal() const {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setOrdinal( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initOrdinal() {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptOrdinal(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Using::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Using::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Using::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::getTarget() {
@@ -6169,37 +6169,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Using::Builder::setTarget( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Using::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Using::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getType() {
@@ -6208,37 +6208,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getValue() {
@@ -6247,37 +6247,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Field::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::getType() {
@@ -6286,20 +6286,20 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Field::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Field::DefaultValue::Reader Declaration::Field::Reader::getDefaultValue() const {
@@ -6314,17 +6314,17 @@ inline typename Declaration::Field::DefaultValue::Pipeline Declaration::Field::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Field::DefaultValue::Builder Declaration::Field::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::DefaultValue::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isNone() const {
@@ -6337,20 +6337,20 @@ inline  ::capnp::Void Declaration::Field::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Field::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Field::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isValue() const {
@@ -6362,100 +6362,100 @@ inline bool Declaration::Field::DefaultValue::Builder::isValue() {
 inline bool Declaration::Field::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Interface::Reader::hasSuperclasses() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Interface::Builder::hasSuperclasses() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Declaration::Interface::Reader::getSuperclasses() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::getSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::initSuperclasses(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Declaration::Interface::Builder::disownSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Method::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method::Pipeline::getParams() {
@@ -6464,20 +6464,20 @@ inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method:
 #endif  // !CAPNP_LITE
 inline void Declaration::Method::Builder::setParams( ::capnp::compiler::Declaration::ParamList::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::initParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Method::Results::Reader Declaration::Method::Reader::getResults() const {
@@ -6492,17 +6492,17 @@ inline typename Declaration::Method::Results::Pipeline Declaration::Method::Pipe
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Method::Results::Builder Declaration::Method::Builder::initResults() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Results::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Method::Results::Reader::isNone() const {
@@ -6515,20 +6515,20 @@ inline  ::capnp::Void Declaration::Method::Results::Reader::getNone() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Method::Results::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Method::Results::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Method::Results::Reader::isExplicit() const {
@@ -6540,66 +6540,66 @@ inline bool Declaration::Method::Results::Builder::isExplicit() {
 inline bool Declaration::Method::Results::Reader::hasExplicit() const {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Results::Builder::hasExplicit() {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Results::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::setExplicit( ::capnp::compiler::Declaration::ParamList::Reader value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::initExplicit() {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::adoptExplicit(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Results::Builder::disownExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
-      ::capnp::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::bounded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Annotation::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Annotation::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipeline::getType() {
@@ -6608,205 +6608,205 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipelin
 #endif  // !CAPNP_LITE
 inline void Declaration::Annotation::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Annotation::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<96>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<96>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<96>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<96>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<96>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<96>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<97>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<97>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<97>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<97>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<97>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<97>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<98>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<98>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<98>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<98>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<98>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<98>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<99>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<99>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<99>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<99>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<99>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<99>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<100>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<100>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<100>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<100>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<100>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<100>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<101>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<101>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<101>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<101>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<101>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<101>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<102>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<102>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<102>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<102>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<102>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<102>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<103>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<103>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<103>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<103>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<103>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<103>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<104>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<104>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<104>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<104>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<104>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<104>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<105>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<105>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<105>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<105>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<105>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<105>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<106>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<106>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<106>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<106>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<106>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<106>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<107>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<107>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<107>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<107>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<107>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<107>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ParsedFile::Reader::hasRoot() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ParsedFile::Builder::hasRoot() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::Reader ParsedFile::Reader::getRoot() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::getRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot() {
@@ -6815,20 +6815,20 @@ inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot()
 #endif  // !CAPNP_LITE
 inline void ParsedFile::Builder::setRoot( ::capnp::compiler::Declaration::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::initRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void ParsedFile::Builder::adoptRoot(
     ::capnp::Orphan< ::capnp::compiler::Declaration>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration> ParsedFile::Builder::disownRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/grammar.capnp.h
+++ b/c++/src/capnp/compiler/grammar.capnp.h
@@ -3203,154 +3203,158 @@ private:
 // =======================================================================================
 
 inline bool LocatedText::Reader::hasValue() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LocatedText::Builder::hasValue() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader LocatedText::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LocatedText::Builder::setValue( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::initValue(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LocatedText::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> LocatedText::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t LocatedText::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedText::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t LocatedInteger::Reader::getValue() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t LocatedInteger::Builder::getValue() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setValue( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline double LocatedFloat::Reader::getValue() const {
   return _reader.getDataField<double>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline double LocatedFloat::Builder::getValue() {
   return _builder.getDataField<double>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setValue(double value) {
   _builder.setDataField<double>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      3 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Expression::Which Expression::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Which Expression::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Reader::isUnknown() const {
@@ -3363,20 +3367,20 @@ inline  ::capnp::Void Expression::Reader::getUnknown() const {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Builder::getUnknown() {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setUnknown( ::capnp::Void value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::UNKNOWN);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::UNKNOWN);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isPositiveInt() const {
@@ -3389,20 +3393,20 @@ inline  ::uint64_t Expression::Reader::getPositiveInt() const {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getPositiveInt() {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setPositiveInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isNegativeInt() const {
@@ -3415,20 +3419,20 @@ inline  ::uint64_t Expression::Reader::getNegativeInt() const {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getNegativeInt() {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setNegativeInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isFloat() const {
@@ -3441,20 +3445,20 @@ inline double Expression::Reader::getFloat() const {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Expression::Builder::getFloat() {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setFloat(double value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::FLOAT);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::FLOAT);
   _builder.setDataField<double>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isString() const {
@@ -3465,48 +3469,50 @@ inline bool Expression::Builder::isString() {
 }
 inline bool Expression::Reader::hasString() const {
   if (which() != Expression::STRING) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasString() {
   if (which() != Expression::STRING) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Expression::Reader::getString() const {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Expression::Builder::getString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::STRING);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Expression::Builder::initString(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::STRING);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::STRING);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Expression::Builder::disownString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isRelativeName() const {
@@ -3517,48 +3523,50 @@ inline bool Expression::Builder::isRelativeName() {
 }
 inline bool Expression::Reader::hasRelativeName() const {
   if (which() != Expression::RELATIVE_NAME) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasRelativeName() {
   if (which() != Expression::RELATIVE_NAME) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getRelativeName() const {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setRelativeName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initRelativeName() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptRelativeName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isList() const {
@@ -3569,48 +3577,50 @@ inline bool Expression::Builder::isList() {
 }
 inline bool Expression::Reader::hasList() const {
   if (which() != Expression::LIST) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasList() {
   if (which() != Expression::LIST) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Expression::Reader::getList() const {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::getList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setList( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::initList(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::LIST);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Expression::Builder::disownList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isTuple() const {
@@ -3621,76 +3631,78 @@ inline bool Expression::Builder::isTuple() {
 }
 inline bool Expression::Reader::hasTuple() const {
   if (which() != Expression::TUPLE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasTuple() {
   if (which() != Expression::TUPLE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Reader::getTuple() const {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::getTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setTuple( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::TUPLE);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::initTuple(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::TUPLE);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptTuple(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::TUPLE);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Builder::disownTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Expression::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Expression::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isBinary() const {
@@ -3701,48 +3713,50 @@ inline bool Expression::Builder::isBinary() {
 }
 inline bool Expression::Reader::hasBinary() const {
   if (which() != Expression::BINARY) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasBinary() {
   if (which() != Expression::BINARY) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Expression::Reader::getBinary() const {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Expression::Builder::getBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setBinary( ::capnp::Data::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::BINARY);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Expression::Builder::initBinary(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::BINARY);
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptBinary(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::BINARY);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Expression::Builder::disownBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isApplication() const {
@@ -3763,9 +3777,9 @@ inline typename Expression::Application::Builder Expression::Builder::getApplica
 }
 inline typename Expression::Application::Builder Expression::Builder::initApplication() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::APPLICATION);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(1 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::APPLICATION);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Application::Builder(_builder);
 }
 inline bool Expression::Reader::isMember() const {
@@ -3786,9 +3800,9 @@ inline typename Expression::Member::Builder Expression::Builder::getMember() {
 }
 inline typename Expression::Member::Builder Expression::Builder::initMember() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::MEMBER);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(1 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::MEMBER);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Member::Builder(_builder);
 }
 inline bool Expression::Reader::isAbsoluteName() const {
@@ -3799,48 +3813,50 @@ inline bool Expression::Builder::isAbsoluteName() {
 }
 inline bool Expression::Reader::hasAbsoluteName() const {
   if (which() != Expression::ABSOLUTE_NAME) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasAbsoluteName() {
   if (which() != Expression::ABSOLUTE_NAME) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getAbsoluteName() const {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setAbsoluteName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initAbsoluteName() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptAbsoluteName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isImport() const {
@@ -3851,48 +3867,50 @@ inline bool Expression::Builder::isImport() {
 }
 inline bool Expression::Reader::hasImport() const {
   if (which() != Expression::IMPORT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasImport() {
   if (which() != Expression::IMPORT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getImport() const {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setImport( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::IMPORT);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initImport() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::IMPORT);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptImport(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::IMPORT);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isEmbed() const {
@@ -3903,55 +3921,59 @@ inline bool Expression::Builder::isEmbed() {
 }
 inline bool Expression::Reader::hasEmbed() const {
   if (which() != Expression::EMBED) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasEmbed() {
   if (which() != Expression::EMBED) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getEmbed() const {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setEmbed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::EMBED);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initEmbed() {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::EMBED);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptEmbed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      0 * ::capnp::ELEMENTS, Expression::EMBED);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Param::Reader::isUnnamed() const {
@@ -3964,20 +3986,20 @@ inline  ::capnp::Void Expression::Param::Reader::getUnnamed() const {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Param::Builder::getUnnamed() {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Param::Builder::setUnnamed( ::capnp::Void value) {
   _builder.setDataField<Expression::Param::Which>(
-      0 * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Param::Reader::isNamed() const {
@@ -3988,63 +4010,67 @@ inline bool Expression::Param::Builder::isNamed() {
 }
 inline bool Expression::Param::Reader::hasNamed() const {
   if (which() != Expression::Param::NAMED) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasNamed() {
   if (which() != Expression::Param::NAMED) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Param::Reader::getNamed() const {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::getNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::setNamed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Param::Which>(
-      0 * ::capnp::ELEMENTS, Expression::Param::NAMED);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::initNamed() {
   _builder.setDataField<Expression::Param::Which>(
-      0 * ::capnp::ELEMENTS, Expression::Param::NAMED);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptNamed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Param::Which>(
-      0 * ::capnp::ELEMENTS, Expression::Param::NAMED);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Param::Builder::disownNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Param::Reader::hasValue() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasValue() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Param::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::getValue() {
@@ -4052,36 +4078,38 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::get
 }
 #endif  // !CAPNP_LITE
 inline void Expression::Param::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::initValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Param::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasFunction() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasFunction() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Application::Reader::getFunction() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::getFunction() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipeline::getFunction() {
@@ -4089,68 +4117,72 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipelin
 }
 #endif  // !CAPNP_LITE
 inline void Expression::Application::Builder::setFunction( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::initFunction() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Application::Builder::disownFunction() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasParams() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasParams() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Application::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::getParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::setParams( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::initParams(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Application::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Application::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasParent() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasParent() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Member::Reader::getParent() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::getParent() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::getParent() {
@@ -4158,36 +4190,38 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setParent( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::initParent() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptParent(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Member::Builder::disownParent() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasName() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasName() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Member::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::getName() {
@@ -4195,43 +4229,47 @@ inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::g
 }
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::initName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Member::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Which Declaration::Reader::which() const {
-  return _reader.getDataField<Which>(1 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Which Declaration::Builder::which() {
-  return _builder.getDataField<Which>(1 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName() {
@@ -4239,21 +4277,21 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName(
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::initName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Id::Reader Declaration::Reader::getId() const {
@@ -4268,132 +4306,138 @@ inline typename Declaration::Id::Pipeline Declaration::Pipeline::getId() {
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Id::Builder Declaration::Builder::initId() {
-  _builder.setDataField< ::uint16_t>(0 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(1 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::Id::Builder(_builder);
 }
 inline bool Declaration::Reader::hasNestedDecls() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNestedDecls() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Reader Declaration::Reader::getNestedDecls() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::getNestedDecls() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNestedDecls( ::capnp::List< ::capnp::compiler::Declaration>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::initNestedDecls(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptNestedDecls(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>> Declaration::Builder::disownNestedDecls() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasAnnotations() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasDocComment() const {
-  return !_reader.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasDocComment() {
-  return !_builder.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::Reader::getDocComment() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::Builder::getDocComment() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setDocComment( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(4 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::Builder::initDocComment(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(4 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(4 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::Builder::disownDocComment() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isFile() const {
@@ -4406,20 +4450,20 @@ inline  ::capnp::Void Declaration::Reader::getFile() const {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getFile() {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::FILE);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::FILE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isUsing() const {
@@ -4440,8 +4484,8 @@ inline typename Declaration::Using::Builder Declaration::Builder::getUsing() {
 }
 inline typename Declaration::Using::Builder Declaration::Builder::initUsing() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::USING);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::USING);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Using::Builder(_builder);
 }
 inline bool Declaration::Reader::isConst() const {
@@ -4462,9 +4506,9 @@ inline typename Declaration::Const::Builder Declaration::Builder::getConst() {
 }
 inline typename Declaration::Const::Builder Declaration::Builder::initConst() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::CONST);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(6 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::CONST);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Const::Builder(_builder);
 }
 inline bool Declaration::Reader::isEnum() const {
@@ -4477,20 +4521,20 @@ inline  ::capnp::Void Declaration::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnum() {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnum( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::ENUM);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUM);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isEnumerant() const {
@@ -4503,20 +4547,20 @@ inline  ::capnp::Void Declaration::Reader::getEnumerant() const {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnumerant() {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnumerant( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::ENUMERANT);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUMERANT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isStruct() const {
@@ -4529,20 +4573,20 @@ inline  ::capnp::Void Declaration::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getStruct() {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::STRUCT);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isField() const {
@@ -4563,10 +4607,10 @@ inline typename Declaration::Field::Builder Declaration::Builder::getField() {
 }
 inline typename Declaration::Field::Builder Declaration::Builder::initField() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::FIELD);
-  _builder.setDataField< ::uint16_t>(6 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(6 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::FIELD);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::Builder(_builder);
 }
 inline bool Declaration::Reader::isUnion() const {
@@ -4579,20 +4623,20 @@ inline  ::capnp::Void Declaration::Reader::getUnion() const {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getUnion() {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setUnion( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::UNION);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::UNION);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isGroup() const {
@@ -4605,20 +4649,20 @@ inline  ::capnp::Void Declaration::Reader::getGroup() const {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getGroup() {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setGroup( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::GROUP);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::GROUP);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isInterface() const {
@@ -4639,8 +4683,8 @@ inline typename Declaration::Interface::Builder Declaration::Builder::getInterfa
 }
 inline typename Declaration::Interface::Builder Declaration::Builder::initInterface() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::INTERFACE);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::INTERFACE);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Interface::Builder(_builder);
 }
 inline bool Declaration::Reader::isMethod() const {
@@ -4661,10 +4705,10 @@ inline typename Declaration::Method::Builder Declaration::Builder::getMethod() {
 }
 inline typename Declaration::Method::Builder Declaration::Builder::initMethod() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::METHOD);
-  _builder.setDataField< ::uint16_t>(6 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(6 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::METHOD);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Builder(_builder);
 }
 inline bool Declaration::Reader::isAnnotation() const {
@@ -4685,20 +4729,20 @@ inline typename Declaration::Annotation::Builder Declaration::Builder::getAnnota
 }
 inline typename Declaration::Annotation::Builder Declaration::Builder::initAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::ANNOTATION);
-  _builder.setDataField<bool>(96 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(97 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(98 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(99 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(100 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(101 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(102 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(103 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(104 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(105 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(106 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(107 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(5 * ::capnp::POINTERS).clear();
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ANNOTATION);
+  _builder.setDataField<bool>(::kj::guarded<96>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<97>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<98>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<99>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<100>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<101>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<102>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<103>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<104>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<105>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<106>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<107>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Annotation::Builder(_builder);
 }
 inline bool Declaration::Reader::isNakedId() const {
@@ -4709,48 +4753,50 @@ inline bool Declaration::Builder::isNakedId() {
 }
 inline bool Declaration::Reader::hasNakedId() const {
   if (which() != Declaration::NAKED_ID) return false;
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedId() {
   if (which() != Declaration::NAKED_ID) return false;
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Reader::getNakedId() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::getNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedId( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ID);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::initNakedId() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ID);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedId(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ID);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Builder::disownNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isNakedAnnotation() const {
@@ -4761,48 +4807,50 @@ inline bool Declaration::Builder::isNakedAnnotation() {
 }
 inline bool Declaration::Reader::hasNakedAnnotation() const {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedAnnotation() {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Reader Declaration::Reader::getNakedAnnotation() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::getNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedAnnotation( ::capnp::compiler::Declaration::AnnotationApplication::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::initNakedAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedAnnotation(
     ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication>&& value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication> Declaration::Builder::disownNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinVoid() const {
@@ -4815,20 +4863,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinVoid() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinVoid() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinVoid( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinBool() const {
@@ -4841,20 +4889,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinBool() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinBool() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinBool( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt8() const {
@@ -4867,20 +4915,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt16() const {
@@ -4893,20 +4941,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt32() const {
@@ -4919,20 +4967,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt64() const {
@@ -4945,20 +4993,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt8() const {
@@ -4971,20 +5019,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt16() const {
@@ -4997,20 +5045,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt32() const {
@@ -5023,20 +5071,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt64() const {
@@ -5049,20 +5097,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat32() const {
@@ -5075,20 +5123,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat64() const {
@@ -5101,20 +5149,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinText() const {
@@ -5127,20 +5175,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinText() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinText() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinText( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinData() const {
@@ -5153,20 +5201,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinData() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinData() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinData( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinList() const {
@@ -5179,20 +5227,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinObject() const {
@@ -5205,20 +5253,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinObject() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinObject() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinObject( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyPointer() const {
@@ -5231,52 +5279,54 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyPointer() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyPointer() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyPointer( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasParameters() const {
-  return !_reader.getPointerField(7 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasParameters() {
-  return !_builder.getPointerField(7 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader Declaration::Reader::getParameters() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(
-      _reader.getPointerField(7 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_reader.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::getParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(
-      _builder.getPointerField(7 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setParameters( ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::set(
-      _builder.getPointerField(7 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::set(_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::initParameters(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::init(
-      _builder.getPointerField(7 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::init(_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::adopt(
-      _builder.getPointerField(7 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::adopt(_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>> Declaration::Builder::disownParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::disown(
-      _builder.getPointerField(7 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::disown(_builder.getPointerField(
+      ::kj::guarded<7>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinAnyStruct() const {
@@ -5289,20 +5339,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyStruct() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyStruct() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyList() const {
@@ -5315,20 +5365,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinCapability() const {
@@ -5341,95 +5391,99 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinCapability() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinCapability() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinCapability( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      1 * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::BrandParameter::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::BrandParameter::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::BrandParameter::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::BrandParameter::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::BrandParameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::BrandParameter::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplication::Pipeline::getName() {
@@ -5437,21 +5491,21 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplicati
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::AnnotationApplication::Builder::setName( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::initName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::AnnotationApplication::Value::Reader Declaration::AnnotationApplication::Reader::getValue() const {
@@ -5466,15 +5520,17 @@ inline typename Declaration::AnnotationApplication::Value::Pipeline Declaration:
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::AnnotationApplication::Value::Builder Declaration::AnnotationApplication::Builder::initValue() {
-  _builder.setDataField< ::uint16_t>(0 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(1 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::AnnotationApplication::Value::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isNone() const {
@@ -5487,20 +5543,20 @@ inline  ::capnp::Void Declaration::AnnotationApplication::Value::Reader::getNone
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::AnnotationApplication::Value::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isExpression() const {
@@ -5511,55 +5567,59 @@ inline bool Declaration::AnnotationApplication::Value::Builder::isExpression() {
 }
 inline bool Declaration::AnnotationApplication::Value::Reader::hasExpression() const {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Value::Builder::hasExpression() {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Value::Reader::getExpression() const {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::getExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setExpression( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::initExpression() {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::adoptExpression(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Value::Builder::disownExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::ParamList::Reader::isNamedList() const {
@@ -5570,48 +5630,50 @@ inline bool Declaration::ParamList::Builder::isNamedList() {
 }
 inline bool Declaration::ParamList::Reader::hasNamedList() const {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasNamedList() {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader Declaration::ParamList::Reader::getNamedList() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::getNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setNamedList( ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::initNamedList(unsigned int size) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::ParamList::Builder::adoptNamedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>> Declaration::ParamList::Builder::disownNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::ParamList::Reader::isType() const {
@@ -5622,91 +5684,95 @@ inline bool Declaration::ParamList::Builder::isType() {
 }
 inline bool Declaration::ParamList::Reader::hasType() const {
   if (which() != Declaration::ParamList::TYPE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasType() {
   if (which() != Declaration::ParamList::TYPE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::ParamList::Reader::getType() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::getType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::initType() {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::ParamList::Builder::disownType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Param::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::getName() {
@@ -5714,36 +5780,38 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::g
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::initName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Param::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasType() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasType() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::getType() {
@@ -5751,53 +5819,55 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setType( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasAnnotations() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Param::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Param::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Param::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Param::DefaultValue::Reader Declaration::Param::Reader::getDefaultValue() const {
@@ -5812,43 +5882,45 @@ inline typename Declaration::Param::DefaultValue::Pipeline Declaration::Param::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Param::DefaultValue::Builder Declaration::Param::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(0 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Declaration::Param::DefaultValue::Builder(_builder);
 }
 inline  ::uint32_t Declaration::Param::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Param::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isNone() const {
@@ -5861,20 +5933,20 @@ inline  ::capnp::Void Declaration::Param::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Param::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isValue() const {
@@ -5885,55 +5957,59 @@ inline bool Declaration::Param::DefaultValue::Builder::isValue() {
 }
 inline bool Declaration::Param::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Id::Reader::isUnspecified() const {
@@ -5946,20 +6022,20 @@ inline  ::capnp::Void Declaration::Id::Reader::getUnspecified() const {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Id::Builder::getUnspecified() {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Id::Builder::setUnspecified( ::capnp::Void value) {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Id::Reader::isUid() const {
@@ -5970,48 +6046,50 @@ inline bool Declaration::Id::Builder::isUid() {
 }
 inline bool Declaration::Id::Reader::hasUid() const {
   if (which() != Declaration::Id::UID) return false;
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasUid() {
   if (which() != Declaration::Id::UID) return false;
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getUid() const {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setUid( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::UID);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initUid() {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::UID);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptUid(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::UID);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Id::Reader::isOrdinal() const {
@@ -6022,63 +6100,67 @@ inline bool Declaration::Id::Builder::isOrdinal() {
 }
 inline bool Declaration::Id::Reader::hasOrdinal() const {
   if (which() != Declaration::Id::ORDINAL) return false;
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasOrdinal() {
   if (which() != Declaration::Id::ORDINAL) return false;
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getOrdinal() const {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setOrdinal( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initOrdinal() {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptOrdinal(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      0 * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Using::Reader::hasTarget() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Using::Builder::hasTarget() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Using::Reader::getTarget() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::getTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::getTarget() {
@@ -6086,36 +6168,38 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Using::Builder::setTarget( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::initTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Using::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Using::Builder::disownTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasType() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasType() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getType() {
@@ -6123,36 +6207,38 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setType( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasValue() const {
-  return !_reader.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasValue() {
-  return !_builder.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getValue() {
@@ -6160,36 +6246,38 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(6 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(6 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Field::Reader::hasType() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::Builder::hasType() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::getType() {
@@ -6197,21 +6285,21 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::ge
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Field::Builder::setType( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Field::DefaultValue::Reader Declaration::Field::Reader::getDefaultValue() const {
@@ -6226,15 +6314,17 @@ inline typename Declaration::Field::DefaultValue::Pipeline Declaration::Field::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Field::DefaultValue::Builder Declaration::Field::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(6 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(6 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::DefaultValue::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Reader::which() const {
-  return _reader.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Builder::which() {
-  return _builder.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isNone() const {
@@ -6247,20 +6337,20 @@ inline  ::capnp::Void Declaration::Field::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Field::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Field::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isValue() const {
@@ -6271,95 +6361,101 @@ inline bool Declaration::Field::DefaultValue::Builder::isValue() {
 }
 inline bool Declaration::Field::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
-  return !_reader.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
-  return !_builder.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(6 * ::capnp::POINTERS), value);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(6 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Interface::Reader::hasSuperclasses() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Interface::Builder::hasSuperclasses() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Declaration::Interface::Reader::getSuperclasses() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::getSuperclasses() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::initSuperclasses(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Declaration::Interface::Builder::disownSuperclasses() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Method::Reader::hasParams() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Builder::hasParams() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::getParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method::Pipeline::getParams() {
@@ -6367,21 +6463,21 @@ inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method:
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Method::Builder::setParams( ::capnp::compiler::Declaration::ParamList::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::initParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Method::Results::Reader Declaration::Method::Reader::getResults() const {
@@ -6396,15 +6492,17 @@ inline typename Declaration::Method::Results::Pipeline Declaration::Method::Pipe
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Method::Results::Builder Declaration::Method::Builder::initResults() {
-  _builder.setDataField< ::uint16_t>(6 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(6 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Results::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Reader::which() const {
-  return _reader.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Builder::which() {
-  return _builder.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Method::Results::Reader::isNone() const {
@@ -6417,20 +6515,20 @@ inline  ::capnp::Void Declaration::Method::Results::Reader::getNone() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Method::Results::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Method::Results::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Method::Results::Reader::isExplicit() const {
@@ -6441,63 +6539,67 @@ inline bool Declaration::Method::Results::Builder::isExplicit() {
 }
 inline bool Declaration::Method::Results::Reader::hasExplicit() const {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
-  return !_reader.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Results::Builder::hasExplicit() {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
-  return !_builder.getPointerField(6 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Results::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(
-      _reader.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::setExplicit( ::capnp::compiler::Declaration::ParamList::Reader value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(
-      _builder.getPointerField(6 * ::capnp::POINTERS), value);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::initExplicit() {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::adoptExplicit(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      6 * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(
-      _builder.getPointerField(6 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Results::Builder::disownExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(
-      _builder.getPointerField(6 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
+      ::kj::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::hasType() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Annotation::Builder::hasType() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Annotation::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipeline::getType() {
@@ -6505,204 +6607,206 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipelin
 }
 #endif  // !CAPNP_LITE
 inline void Declaration::Annotation::Builder::setType( ::capnp::compiler::Expression::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Annotation::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      96 * ::capnp::ELEMENTS);
+      ::kj::guarded<96>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      96 * ::capnp::ELEMENTS);
+      ::kj::guarded<96>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      96 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<96>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      97 * ::capnp::ELEMENTS);
+      ::kj::guarded<97>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      97 * ::capnp::ELEMENTS);
+      ::kj::guarded<97>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      97 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<97>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      98 * ::capnp::ELEMENTS);
+      ::kj::guarded<98>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      98 * ::capnp::ELEMENTS);
+      ::kj::guarded<98>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      98 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<98>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      99 * ::capnp::ELEMENTS);
+      ::kj::guarded<99>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      99 * ::capnp::ELEMENTS);
+      ::kj::guarded<99>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      99 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<99>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      100 * ::capnp::ELEMENTS);
+      ::kj::guarded<100>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      100 * ::capnp::ELEMENTS);
+      ::kj::guarded<100>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      100 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<100>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      101 * ::capnp::ELEMENTS);
+      ::kj::guarded<101>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      101 * ::capnp::ELEMENTS);
+      ::kj::guarded<101>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      101 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<101>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      102 * ::capnp::ELEMENTS);
+      ::kj::guarded<102>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      102 * ::capnp::ELEMENTS);
+      ::kj::guarded<102>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      102 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<102>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      103 * ::capnp::ELEMENTS);
+      ::kj::guarded<103>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      103 * ::capnp::ELEMENTS);
+      ::kj::guarded<103>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      103 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<103>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      104 * ::capnp::ELEMENTS);
+      ::kj::guarded<104>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      104 * ::capnp::ELEMENTS);
+      ::kj::guarded<104>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      104 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<104>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      105 * ::capnp::ELEMENTS);
+      ::kj::guarded<105>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      105 * ::capnp::ELEMENTS);
+      ::kj::guarded<105>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      105 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<105>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      106 * ::capnp::ELEMENTS);
+      ::kj::guarded<106>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      106 * ::capnp::ELEMENTS);
+      ::kj::guarded<106>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      106 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<106>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      107 * ::capnp::ELEMENTS);
+      ::kj::guarded<107>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      107 * ::capnp::ELEMENTS);
+      ::kj::guarded<107>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      107 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<107>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ParsedFile::Reader::hasRoot() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ParsedFile::Builder::hasRoot() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::Reader ParsedFile::Reader::getRoot() const {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::getRoot() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot() {
@@ -6710,21 +6814,21 @@ inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot()
 }
 #endif  // !CAPNP_LITE
 inline void ParsedFile::Builder::setRoot( ::capnp::compiler::Declaration::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::initRoot() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void ParsedFile::Builder::adoptRoot(
     ::capnp::Orphan< ::capnp::compiler::Declaration>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration> ParsedFile::Builder::disownRoot() {
-  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/grammar.capnp.h
+++ b/c++/src/capnp/compiler/grammar.capnp.h
@@ -3204,157 +3204,157 @@ private:
 
 inline bool LocatedText::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LocatedText::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader LocatedText::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LocatedText::Builder::setValue( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder LocatedText::Builder::initValue(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LocatedText::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> LocatedText::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t LocatedText::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedText::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedText::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void LocatedText::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t LocatedInteger::Reader::getValue() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t LocatedInteger::Builder::getValue() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setValue( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedInteger::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedInteger::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedInteger::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline double LocatedFloat::Reader::getValue() const {
   return _reader.getDataField<double>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline double LocatedFloat::Builder::getValue() {
   return _builder.getDataField<double>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setValue(double value) {
   _builder.setDataField<double>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t LocatedFloat::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t LocatedFloat::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void LocatedFloat::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Expression::Which Expression::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Which Expression::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Reader::isUnknown() const {
@@ -3367,20 +3367,20 @@ inline  ::capnp::Void Expression::Reader::getUnknown() const {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Builder::getUnknown() {
   KJ_IREQUIRE((which() == Expression::UNKNOWN),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setUnknown( ::capnp::Void value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::UNKNOWN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::UNKNOWN);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isPositiveInt() const {
@@ -3393,20 +3393,20 @@ inline  ::uint64_t Expression::Reader::getPositiveInt() const {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getPositiveInt() {
   KJ_IREQUIRE((which() == Expression::POSITIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setPositiveInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::POSITIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isNegativeInt() const {
@@ -3419,20 +3419,20 @@ inline  ::uint64_t Expression::Reader::getNegativeInt() const {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Expression::Builder::getNegativeInt() {
   KJ_IREQUIRE((which() == Expression::NEGATIVE_INT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setNegativeInt( ::uint64_t value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::NEGATIVE_INT);
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isFloat() const {
@@ -3445,20 +3445,20 @@ inline double Expression::Reader::getFloat() const {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Expression::Builder::getFloat() {
   KJ_IREQUIRE((which() == Expression::FLOAT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setFloat(double value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::FLOAT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::FLOAT);
   _builder.setDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isString() const {
@@ -3470,49 +3470,49 @@ inline bool Expression::Builder::isString() {
 inline bool Expression::Reader::hasString() const {
   if (which() != Expression::STRING) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasString() {
   if (which() != Expression::STRING) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Expression::Reader::getString() const {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Expression::Builder::getString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setString( ::capnp::Text::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Expression::Builder::initString(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptString(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::STRING);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Expression::Builder::disownString() {
   KJ_IREQUIRE((which() == Expression::STRING),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isRelativeName() const {
@@ -3524,49 +3524,49 @@ inline bool Expression::Builder::isRelativeName() {
 inline bool Expression::Reader::hasRelativeName() const {
   if (which() != Expression::RELATIVE_NAME) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasRelativeName() {
   if (which() != Expression::RELATIVE_NAME) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getRelativeName() const {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setRelativeName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initRelativeName() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptRelativeName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::RELATIVE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownRelativeName() {
   KJ_IREQUIRE((which() == Expression::RELATIVE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isList() const {
@@ -3578,49 +3578,49 @@ inline bool Expression::Builder::isList() {
 inline bool Expression::Reader::hasList() const {
   if (which() != Expression::LIST) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasList() {
   if (which() != Expression::LIST) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Expression::Reader::getList() const {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::getList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setList( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Expression::Builder::initList(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Expression::Builder::disownList() {
   KJ_IREQUIRE((which() == Expression::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isTuple() const {
@@ -3632,77 +3632,77 @@ inline bool Expression::Builder::isTuple() {
 inline bool Expression::Reader::hasTuple() const {
   if (which() != Expression::TUPLE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasTuple() {
   if (which() != Expression::TUPLE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Reader::getTuple() const {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::getTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setTuple( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Builder::initTuple(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptTuple(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::TUPLE);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Builder::disownTuple() {
   KJ_IREQUIRE((which() == Expression::TUPLE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Expression::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Expression::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Expression::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Reader::isBinary() const {
@@ -3714,49 +3714,49 @@ inline bool Expression::Builder::isBinary() {
 inline bool Expression::Reader::hasBinary() const {
   if (which() != Expression::BINARY) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasBinary() {
   if (which() != Expression::BINARY) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Expression::Reader::getBinary() const {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Expression::Builder::getBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setBinary( ::capnp::Data::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Expression::Builder::initBinary(unsigned int size) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Builder::adoptBinary(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::BINARY);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Expression::Builder::disownBinary() {
   KJ_IREQUIRE((which() == Expression::BINARY),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isApplication() const {
@@ -3777,9 +3777,9 @@ inline typename Expression::Application::Builder Expression::Builder::getApplica
 }
 inline typename Expression::Application::Builder Expression::Builder::initApplication() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::APPLICATION);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::APPLICATION);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Application::Builder(_builder);
 }
 inline bool Expression::Reader::isMember() const {
@@ -3800,9 +3800,9 @@ inline typename Expression::Member::Builder Expression::Builder::getMember() {
 }
 inline typename Expression::Member::Builder Expression::Builder::initMember() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::MEMBER);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::MEMBER);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Expression::Member::Builder(_builder);
 }
 inline bool Expression::Reader::isAbsoluteName() const {
@@ -3814,49 +3814,49 @@ inline bool Expression::Builder::isAbsoluteName() {
 inline bool Expression::Reader::hasAbsoluteName() const {
   if (which() != Expression::ABSOLUTE_NAME) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasAbsoluteName() {
   if (which() != Expression::ABSOLUTE_NAME) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getAbsoluteName() const {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setAbsoluteName( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initAbsoluteName() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptAbsoluteName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::ABSOLUTE_NAME);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownAbsoluteName() {
   KJ_IREQUIRE((which() == Expression::ABSOLUTE_NAME),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isImport() const {
@@ -3868,49 +3868,49 @@ inline bool Expression::Builder::isImport() {
 inline bool Expression::Reader::hasImport() const {
   if (which() != Expression::IMPORT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasImport() {
   if (which() != Expression::IMPORT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getImport() const {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setImport( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initImport() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptImport(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::IMPORT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownImport() {
   KJ_IREQUIRE((which() == Expression::IMPORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Reader::isEmbed() const {
@@ -3922,58 +3922,58 @@ inline bool Expression::Builder::isEmbed() {
 inline bool Expression::Reader::hasEmbed() const {
   if (which() != Expression::EMBED) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Builder::hasEmbed() {
   if (which() != Expression::EMBED) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Reader::getEmbed() const {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::getEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::setEmbed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Builder::initEmbed() {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Builder::adoptEmbed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::EMBED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Builder::disownEmbed() {
   KJ_IREQUIRE((which() == Expression::EMBED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Expression::Param::Which Expression::Param::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Expression::Param::Reader::isUnnamed() const {
@@ -3986,20 +3986,20 @@ inline  ::capnp::Void Expression::Param::Reader::getUnnamed() const {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Expression::Param::Builder::getUnnamed() {
   KJ_IREQUIRE((which() == Expression::Param::UNNAMED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Expression::Param::Builder::setUnnamed( ::capnp::Void value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::UNNAMED);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Expression::Param::Reader::isNamed() const {
@@ -4011,66 +4011,66 @@ inline bool Expression::Param::Builder::isNamed() {
 inline bool Expression::Param::Reader::hasNamed() const {
   if (which() != Expression::Param::NAMED) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasNamed() {
   if (which() != Expression::Param::NAMED) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Param::Reader::getNamed() const {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::getNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::setNamed( ::capnp::compiler::LocatedText::Reader value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Param::Builder::initNamed() {
   _builder.setDataField<Expression::Param::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptNamed(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   _builder.setDataField<Expression::Param::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Expression::Param::NAMED);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Param::Builder::disownNamed() {
   KJ_IREQUIRE((which() == Expression::Param::NAMED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Param::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Param::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Param::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::getValue() {
@@ -4079,37 +4079,37 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Param::Pipeline::get
 #endif  // !CAPNP_LITE
 inline void Expression::Param::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Param::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Param::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Param::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasFunction() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasFunction() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Application::Reader::getFunction() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::getFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipeline::getFunction() {
@@ -4118,71 +4118,71 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Application::Pipelin
 #endif  // !CAPNP_LITE
 inline void Expression::Application::Builder::setFunction( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Application::Builder::initFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::adoptFunction(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Application::Builder::disownFunction() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Application::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Application::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Reader Expression::Application::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Application::Builder::setParams( ::capnp::List< ::capnp::compiler::Expression::Param>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression::Param>::Builder Expression::Application::Builder::initParams(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Expression::Application::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression::Param>> Expression::Application::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression::Param>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasParent() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasParent() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Expression::Member::Reader::getParent() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::getParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::getParent() {
@@ -4191,37 +4191,37 @@ inline  ::capnp::compiler::Expression::Pipeline Expression::Member::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setParent( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Expression::Member::Builder::initParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptParent(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Expression::Member::Builder::disownParent() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Expression::Member::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Expression::Member::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Expression::Member::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::getName() {
@@ -4230,46 +4230,46 @@ inline  ::capnp::compiler::LocatedText::Pipeline Expression::Member::Pipeline::g
 #endif  // !CAPNP_LITE
 inline void Expression::Member::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Expression::Member::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Expression::Member::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Expression::Member::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Which Declaration::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Which Declaration::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName() {
@@ -4278,20 +4278,20 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Pipeline::getName(
 #endif  // !CAPNP_LITE
 inline void Declaration::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Id::Reader Declaration::Reader::getId() const {
@@ -4306,138 +4306,138 @@ inline typename Declaration::Id::Pipeline Declaration::Pipeline::getId() {
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Id::Builder Declaration::Builder::initId() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::Id::Builder(_builder);
 }
 inline bool Declaration::Reader::hasNestedDecls() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNestedDecls() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Reader Declaration::Reader::getNestedDecls() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::getNestedDecls() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNestedDecls( ::capnp::List< ::capnp::compiler::Declaration>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration>::Builder Declaration::Builder::initNestedDecls(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptNestedDecls(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration>> Declaration::Builder::disownNestedDecls() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration>>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasDocComment() const {
   return !_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasDocComment() {
   return !_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::Reader::getDocComment() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::Builder::getDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setDocComment( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::Builder::initDocComment(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::Builder::disownDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isFile() const {
@@ -4450,20 +4450,20 @@ inline  ::capnp::Void Declaration::Reader::getFile() const {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getFile() {
   KJ_IREQUIRE((which() == Declaration::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::FILE);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::FILE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isUsing() const {
@@ -4484,8 +4484,8 @@ inline typename Declaration::Using::Builder Declaration::Builder::getUsing() {
 }
 inline typename Declaration::Using::Builder Declaration::Builder::initUsing() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::USING);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::USING);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Using::Builder(_builder);
 }
 inline bool Declaration::Reader::isConst() const {
@@ -4506,9 +4506,9 @@ inline typename Declaration::Const::Builder Declaration::Builder::getConst() {
 }
 inline typename Declaration::Const::Builder Declaration::Builder::initConst() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::CONST);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::CONST);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Const::Builder(_builder);
 }
 inline bool Declaration::Reader::isEnum() const {
@@ -4521,20 +4521,20 @@ inline  ::capnp::Void Declaration::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnum() {
   KJ_IREQUIRE((which() == Declaration::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnum( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUM);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUM);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isEnumerant() const {
@@ -4547,20 +4547,20 @@ inline  ::capnp::Void Declaration::Reader::getEnumerant() const {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getEnumerant() {
   KJ_IREQUIRE((which() == Declaration::ENUMERANT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setEnumerant( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUMERANT);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ENUMERANT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isStruct() const {
@@ -4573,20 +4573,20 @@ inline  ::capnp::Void Declaration::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getStruct() {
   KJ_IREQUIRE((which() == Declaration::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::STRUCT);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isField() const {
@@ -4607,10 +4607,10 @@ inline typename Declaration::Field::Builder Declaration::Builder::getField() {
 }
 inline typename Declaration::Field::Builder Declaration::Builder::initField() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::FIELD);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::FIELD);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::Builder(_builder);
 }
 inline bool Declaration::Reader::isUnion() const {
@@ -4623,20 +4623,20 @@ inline  ::capnp::Void Declaration::Reader::getUnion() const {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getUnion() {
   KJ_IREQUIRE((which() == Declaration::UNION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setUnion( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::UNION);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::UNION);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isGroup() const {
@@ -4649,20 +4649,20 @@ inline  ::capnp::Void Declaration::Reader::getGroup() const {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getGroup() {
   KJ_IREQUIRE((which() == Declaration::GROUP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setGroup( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::GROUP);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::GROUP);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isInterface() const {
@@ -4683,8 +4683,8 @@ inline typename Declaration::Interface::Builder Declaration::Builder::getInterfa
 }
 inline typename Declaration::Interface::Builder Declaration::Builder::initInterface() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::INTERFACE);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::INTERFACE);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Interface::Builder(_builder);
 }
 inline bool Declaration::Reader::isMethod() const {
@@ -4705,10 +4705,10 @@ inline typename Declaration::Method::Builder Declaration::Builder::getMethod() {
 }
 inline typename Declaration::Method::Builder Declaration::Builder::initMethod() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::METHOD);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::METHOD);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Builder(_builder);
 }
 inline bool Declaration::Reader::isAnnotation() const {
@@ -4729,20 +4729,20 @@ inline typename Declaration::Annotation::Builder Declaration::Builder::getAnnota
 }
 inline typename Declaration::Annotation::Builder Declaration::Builder::initAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::ANNOTATION);
-  _builder.setDataField<bool>(::kj::guarded<96>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<97>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<98>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<99>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<100>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<101>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<102>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<103>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<104>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<105>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<106>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<107>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<5>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::ANNOTATION);
+  _builder.setDataField<bool>(::capnp::guarded<96>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<97>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<98>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<99>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<100>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<101>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<102>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<103>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<104>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<105>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<106>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<107>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<5>() * ::capnp::POINTERS).clear();
   return typename Declaration::Annotation::Builder(_builder);
 }
 inline bool Declaration::Reader::isNakedId() const {
@@ -4754,49 +4754,49 @@ inline bool Declaration::Builder::isNakedId() {
 inline bool Declaration::Reader::hasNakedId() const {
   if (which() != Declaration::NAKED_ID) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedId() {
   if (which() != Declaration::NAKED_ID) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Reader::getNakedId() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::getNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedId( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Builder::initNakedId() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedId(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Builder::disownNakedId() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isNakedAnnotation() const {
@@ -4808,49 +4808,49 @@ inline bool Declaration::Builder::isNakedAnnotation() {
 inline bool Declaration::Reader::hasNakedAnnotation() const {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasNakedAnnotation() {
   if (which() != Declaration::NAKED_ANNOTATION) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Reader Declaration::Reader::getNakedAnnotation() const {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::getNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setNakedAnnotation( ::capnp::compiler::Declaration::AnnotationApplication::Reader value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Builder Declaration::Builder::initNakedAnnotation() {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::adoptNakedAnnotation(
     ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication>&& value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::NAKED_ANNOTATION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::AnnotationApplication> Declaration::Builder::disownNakedAnnotation() {
   KJ_IREQUIRE((which() == Declaration::NAKED_ANNOTATION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::AnnotationApplication>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinVoid() const {
@@ -4863,20 +4863,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinVoid() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinVoid() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinVoid( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinBool() const {
@@ -4889,20 +4889,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinBool() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinBool() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinBool( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_BOOL);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt8() const {
@@ -4915,20 +4915,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt16() const {
@@ -4941,20 +4941,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt32() const {
@@ -4967,20 +4967,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinInt64() const {
@@ -4993,20 +4993,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt8() const {
@@ -5019,20 +5019,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt8() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt8() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt8( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt16() const {
@@ -5045,20 +5045,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt16() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt16() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt16( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt32() const {
@@ -5071,20 +5071,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinUInt64() const {
@@ -5097,20 +5097,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinUInt64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinUInt64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_U_INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinUInt64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_U_INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat32() const {
@@ -5123,20 +5123,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat32() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat32() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat32( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinFloat64() const {
@@ -5149,20 +5149,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinFloat64() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinFloat64() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinFloat64( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinText() const {
@@ -5175,20 +5175,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinText() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinText() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinText( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_TEXT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinData() const {
@@ -5201,20 +5201,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinData() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinData() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinData( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_DATA);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinList() const {
@@ -5227,20 +5227,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinObject() const {
@@ -5253,20 +5253,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinObject() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinObject() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_OBJECT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinObject( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_OBJECT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyPointer() const {
@@ -5279,54 +5279,54 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyPointer() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyPointer() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyPointer( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_POINTER);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::hasParameters() const {
   return !_reader.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<7>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Builder::hasParameters() {
   return !_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<7>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader Declaration::Reader::getParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_reader.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::guarded<7>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::getParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::get(_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::guarded<7>() * ::capnp::POINTERS));
 }
 inline void Declaration::Builder::setParameters( ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::set(_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<7>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>::Builder Declaration::Builder::initParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::init(_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<7>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::adopt(_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<7>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>> Declaration::Builder::disownParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::BrandParameter>>::disown(_builder.getPointerField(
-      ::kj::guarded<7>() * ::capnp::POINTERS));
+      ::capnp::guarded<7>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Reader::isBuiltinAnyStruct() const {
@@ -5339,20 +5339,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyStruct() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyStruct() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyStruct( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinAnyList() const {
@@ -5365,20 +5365,20 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinAnyList() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinAnyList() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_ANY_LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinAnyList( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_ANY_LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Reader::isBuiltinCapability() const {
@@ -5391,99 +5391,99 @@ inline  ::capnp::Void Declaration::Reader::getBuiltinCapability() const {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Builder::getBuiltinCapability() {
   KJ_IREQUIRE((which() == Declaration::BUILTIN_CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Builder::setBuiltinCapability( ::capnp::Void value) {
   _builder.setDataField<Declaration::Which>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, Declaration::BUILTIN_CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::BrandParameter::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::BrandParameter::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Declaration::BrandParameter::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::BrandParameter::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Declaration::BrandParameter::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::BrandParameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Declaration::BrandParameter::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::BrandParameter::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::BrandParameter::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplication::Pipeline::getName() {
@@ -5492,20 +5492,20 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::AnnotationApplicati
 #endif  // !CAPNP_LITE
 inline void Declaration::AnnotationApplication::Builder::setName( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::AnnotationApplication::Value::Reader Declaration::AnnotationApplication::Reader::getValue() const {
@@ -5520,17 +5520,17 @@ inline typename Declaration::AnnotationApplication::Value::Pipeline Declaration:
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::AnnotationApplication::Value::Builder Declaration::AnnotationApplication::Builder::initValue() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<1>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<1>() * ::capnp::POINTERS).clear();
   return typename Declaration::AnnotationApplication::Value::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::AnnotationApplication::Value::Which Declaration::AnnotationApplication::Value::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isNone() const {
@@ -5543,20 +5543,20 @@ inline  ::capnp::Void Declaration::AnnotationApplication::Value::Reader::getNone
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::AnnotationApplication::Value::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::AnnotationApplication::Value::Reader::isExpression() const {
@@ -5568,58 +5568,58 @@ inline bool Declaration::AnnotationApplication::Value::Builder::isExpression() {
 inline bool Declaration::AnnotationApplication::Value::Reader::hasExpression() const {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::AnnotationApplication::Value::Builder::hasExpression() {
   if (which() != Declaration::AnnotationApplication::Value::EXPRESSION) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::AnnotationApplication::Value::Reader::getExpression() const {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::getExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::setExpression( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::AnnotationApplication::Value::Builder::initExpression() {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::AnnotationApplication::Value::Builder::adoptExpression(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::AnnotationApplication::Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::AnnotationApplication::Value::EXPRESSION);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::AnnotationApplication::Value::Builder::disownExpression() {
   KJ_IREQUIRE((which() == Declaration::AnnotationApplication::Value::EXPRESSION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Which Declaration::ParamList::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::ParamList::Reader::isNamedList() const {
@@ -5631,49 +5631,49 @@ inline bool Declaration::ParamList::Builder::isNamedList() {
 inline bool Declaration::ParamList::Reader::hasNamedList() const {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasNamedList() {
   if (which() != Declaration::ParamList::NAMED_LIST) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader Declaration::ParamList::Reader::getNamedList() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::getNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setNamedList( ::capnp::List< ::capnp::compiler::Declaration::Param>::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::Param>::Builder Declaration::ParamList::Builder::initNamedList(unsigned int size) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::ParamList::Builder::adoptNamedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::NAMED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::Param>> Declaration::ParamList::Builder::disownNamedList() {
   KJ_IREQUIRE((which() == Declaration::ParamList::NAMED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::Param>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::ParamList::Reader::isType() const {
@@ -5685,94 +5685,94 @@ inline bool Declaration::ParamList::Builder::isType() {
 inline bool Declaration::ParamList::Reader::hasType() const {
   if (which() != Declaration::ParamList::TYPE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::ParamList::Builder::hasType() {
   if (which() != Declaration::ParamList::TYPE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::ParamList::Reader::getType() const {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::getType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::ParamList::Builder::initType() {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::ParamList::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::ParamList::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::ParamList::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::ParamList::Builder::disownType() {
   KJ_IREQUIRE((which() == Declaration::ParamList::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::ParamList::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::ParamList::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::ParamList::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedText::Reader Declaration::Param::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::getName() {
@@ -5781,37 +5781,37 @@ inline  ::capnp::compiler::LocatedText::Pipeline Declaration::Param::Pipeline::g
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setName( ::capnp::compiler::LocatedText::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedText::Builder Declaration::Param::Builder::initName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptName(
     ::capnp::Orphan< ::capnp::compiler::LocatedText>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedText> Declaration::Param::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedText>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::getType() {
@@ -5820,54 +5820,54 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Param::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Param::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Param::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader Declaration::Param::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::Builder::setAnnotations( ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>::Builder Declaration::Param::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Param::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>> Declaration::Param::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Declaration::AnnotationApplication>>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Param::DefaultValue::Reader Declaration::Param::Reader::getDefaultValue() const {
@@ -5882,45 +5882,45 @@ inline typename Declaration::Param::DefaultValue::Pipeline Declaration::Param::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Param::DefaultValue::Builder Declaration::Param::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Declaration::Param::DefaultValue::Builder(_builder);
 }
 inline  ::uint32_t Declaration::Param::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Declaration::Param::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Declaration::Param::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Param::DefaultValue::Which Declaration::Param::DefaultValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isNone() const {
@@ -5933,20 +5933,20 @@ inline  ::capnp::Void Declaration::Param::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Param::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Param::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Param::DefaultValue::Reader::isValue() const {
@@ -5958,58 +5958,58 @@ inline bool Declaration::Param::DefaultValue::Builder::isValue() {
 inline bool Declaration::Param::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Param::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Param::DefaultValue::VALUE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Param::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Param::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Declaration::Param::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Param::DefaultValue::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Param::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Param::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Param::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Id::Which Declaration::Id::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Id::Reader::isUnspecified() const {
@@ -6022,20 +6022,20 @@ inline  ::capnp::Void Declaration::Id::Reader::getUnspecified() const {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Id::Builder::getUnspecified() {
   KJ_IREQUIRE((which() == Declaration::Id::UNSPECIFIED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Id::Builder::setUnspecified( ::capnp::Void value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UNSPECIFIED);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Id::Reader::isUid() const {
@@ -6047,49 +6047,49 @@ inline bool Declaration::Id::Builder::isUid() {
 inline bool Declaration::Id::Reader::hasUid() const {
   if (which() != Declaration::Id::UID) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasUid() {
   if (which() != Declaration::Id::UID) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getUid() const {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setUid( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initUid() {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptUid(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::UID);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownUid() {
   KJ_IREQUIRE((which() == Declaration::Id::UID),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Id::Reader::isOrdinal() const {
@@ -6101,66 +6101,66 @@ inline bool Declaration::Id::Builder::isOrdinal() {
 inline bool Declaration::Id::Reader::hasOrdinal() const {
   if (which() != Declaration::Id::ORDINAL) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Id::Builder::hasOrdinal() {
   if (which() != Declaration::Id::ORDINAL) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::LocatedInteger::Reader Declaration::Id::Reader::getOrdinal() const {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::getOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::setOrdinal( ::capnp::compiler::LocatedInteger::Reader value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::LocatedInteger::Builder Declaration::Id::Builder::initOrdinal() {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Declaration::Id::Builder::adoptOrdinal(
     ::capnp::Orphan< ::capnp::compiler::LocatedInteger>&& value) {
   _builder.setDataField<Declaration::Id::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Declaration::Id::ORDINAL);
   ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::LocatedInteger> Declaration::Id::Builder::disownOrdinal() {
   KJ_IREQUIRE((which() == Declaration::Id::ORDINAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::LocatedInteger>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Using::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Using::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Using::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::getTarget() {
@@ -6169,37 +6169,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Using::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Using::Builder::setTarget( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Using::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Using::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Using::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getType() {
@@ -6208,37 +6208,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Const::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Const::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Const::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::getValue() {
@@ -6247,37 +6247,37 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Const::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Const::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Const::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Const::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Field::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::getType() {
@@ -6286,20 +6286,20 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Field::Pipeline::ge
 #endif  // !CAPNP_LITE
 inline void Declaration::Field::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Field::DefaultValue::Reader Declaration::Field::Reader::getDefaultValue() const {
@@ -6314,17 +6314,17 @@ inline typename Declaration::Field::DefaultValue::Pipeline Declaration::Field::P
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Field::DefaultValue::Builder Declaration::Field::Builder::initDefaultValue() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Field::DefaultValue::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Field::DefaultValue::Which Declaration::Field::DefaultValue::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isNone() const {
@@ -6337,20 +6337,20 @@ inline  ::capnp::Void Declaration::Field::DefaultValue::Reader::getNone() const 
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Field::DefaultValue::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Field::DefaultValue::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Field::DefaultValue::Reader::isValue() const {
@@ -6362,100 +6362,100 @@ inline bool Declaration::Field::DefaultValue::Builder::isValue() {
 inline bool Declaration::Field::DefaultValue::Reader::hasValue() const {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Field::DefaultValue::Builder::hasValue() {
   if (which() != Declaration::Field::DefaultValue::VALUE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Field::DefaultValue::Reader::getValue() const {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::getValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::setValue( ::capnp::compiler::Expression::Reader value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Field::DefaultValue::Builder::initValue() {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Field::DefaultValue::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   _builder.setDataField<Declaration::Field::DefaultValue::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Field::DefaultValue::VALUE);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Field::DefaultValue::Builder::disownValue() {
   KJ_IREQUIRE((which() == Declaration::Field::DefaultValue::VALUE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Interface::Reader::hasSuperclasses() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Interface::Builder::hasSuperclasses() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Reader Declaration::Interface::Reader::getSuperclasses() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::getSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::compiler::Expression>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Expression>::Builder Declaration::Interface::Builder::initSuperclasses(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), size);
 }
 inline void Declaration::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Expression>> Declaration::Interface::Builder::disownSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Expression>>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Method::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method::Pipeline::getParams() {
@@ -6464,20 +6464,20 @@ inline  ::capnp::compiler::Declaration::ParamList::Pipeline Declaration::Method:
 #endif  // !CAPNP_LITE
 inline void Declaration::Method::Builder::setParams( ::capnp::compiler::Declaration::ParamList::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Builder::initParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline typename Declaration::Method::Results::Reader Declaration::Method::Reader::getResults() const {
@@ -6492,17 +6492,17 @@ inline typename Declaration::Method::Results::Pipeline Declaration::Method::Pipe
 }
 #endif  // !CAPNP_LITE
 inline typename Declaration::Method::Results::Builder Declaration::Method::Builder::initResults() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<6>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<6>() * ::capnp::POINTERS).clear();
   return typename Declaration::Method::Results::Builder(_builder);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Declaration::Method::Results::Which Declaration::Method::Results::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Method::Results::Reader::isNone() const {
@@ -6515,20 +6515,20 @@ inline  ::capnp::Void Declaration::Method::Results::Reader::getNone() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Declaration::Method::Results::Builder::getNone() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Method::Results::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Method::Results::Reader::isExplicit() const {
@@ -6540,66 +6540,66 @@ inline bool Declaration::Method::Results::Builder::isExplicit() {
 inline bool Declaration::Method::Results::Reader::hasExplicit() const {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Method::Results::Builder::hasExplicit() {
   if (which() != Declaration::Method::Results::EXPLICIT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<6>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::ParamList::Reader Declaration::Method::Results::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_reader.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::get(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::setExplicit( ::capnp::compiler::Declaration::ParamList::Reader value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::set(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<6>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::ParamList::Builder Declaration::Method::Results::Builder::initExplicit() {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::init(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 inline void Declaration::Method::Results::Builder::adoptExplicit(
     ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList>&& value) {
   _builder.setDataField<Declaration::Method::Results::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Declaration::Method::Results::EXPLICIT);
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::adopt(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<6>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration::ParamList> Declaration::Method::Results::Builder::disownExplicit() {
   KJ_IREQUIRE((which() == Declaration::Method::Results::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration::ParamList>::disown(_builder.getPointerField(
-      ::kj::guarded<6>() * ::capnp::POINTERS));
+      ::capnp::guarded<6>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Declaration::Annotation::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Expression::Reader Declaration::Annotation::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipeline::getType() {
@@ -6608,205 +6608,205 @@ inline  ::capnp::compiler::Expression::Pipeline Declaration::Annotation::Pipelin
 #endif  // !CAPNP_LITE
 inline void Declaration::Annotation::Builder::setType( ::capnp::compiler::Expression::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Expression::Builder Declaration::Annotation::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Declaration::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::compiler::Expression>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Expression> Declaration::Annotation::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Expression>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<96>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<96>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<96>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<96>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<96>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<96>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<97>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<97>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<97>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<97>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<97>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<97>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<98>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<98>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<98>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<98>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<98>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<98>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<99>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<99>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<99>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<99>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<99>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<99>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<100>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<100>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<100>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<100>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<100>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<100>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<101>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<101>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<101>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<101>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<101>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<101>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<102>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<102>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<102>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<102>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<102>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<102>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<103>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<103>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<103>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<103>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<103>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<103>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<104>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<104>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<104>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<104>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<104>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<104>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<105>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<105>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<105>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<105>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<105>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<105>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<106>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<106>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<106>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<106>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<106>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<106>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Declaration::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<107>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<107>() * ::capnp::ELEMENTS);
 }
 
 inline bool Declaration::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<107>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<107>() * ::capnp::ELEMENTS);
 }
 inline void Declaration::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<107>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<107>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ParsedFile::Reader::hasRoot() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ParsedFile::Builder::hasRoot() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::compiler::Declaration::Reader ParsedFile::Reader::getRoot() const {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::getRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot() {
@@ -6815,20 +6815,20 @@ inline  ::capnp::compiler::Declaration::Pipeline ParsedFile::Pipeline::getRoot()
 #endif  // !CAPNP_LITE
 inline void ParsedFile::Builder::setRoot( ::capnp::compiler::Declaration::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::compiler::Declaration::Builder ParsedFile::Builder::initRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void ParsedFile::Builder::adoptRoot(
     ::capnp::Orphan< ::capnp::compiler::Declaration>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::compiler::Declaration> ParsedFile::Builder::disownRoot() {
   return ::capnp::_::PointerHelpers< ::capnp::compiler::Declaration>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/lexer.capnp.h
+++ b/c++/src/capnp/compiler/lexer.capnp.h
@@ -559,10 +559,12 @@ private:
 // =======================================================================================
 
 inline  ::capnp::compiler::Token::Which Token::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Token::Which Token::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Token::Reader::isIdentifier() const {
@@ -573,48 +575,50 @@ inline bool Token::Builder::isIdentifier() {
 }
 inline bool Token::Reader::hasIdentifier() const {
   if (which() != Token::IDENTIFIER) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasIdentifier() {
   if (which() != Token::IDENTIFIER) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getIdentifier() const {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setIdentifier( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::IDENTIFIER);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initIdentifier(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::IDENTIFIER);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptIdentifier(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::IDENTIFIER);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isStringLiteral() const {
@@ -625,48 +629,50 @@ inline bool Token::Builder::isStringLiteral() {
 }
 inline bool Token::Reader::hasStringLiteral() const {
   if (which() != Token::STRING_LITERAL) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasStringLiteral() {
   if (which() != Token::STRING_LITERAL) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getStringLiteral() const {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setStringLiteral( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::STRING_LITERAL);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initStringLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::STRING_LITERAL);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptStringLiteral(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::STRING_LITERAL);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isIntegerLiteral() const {
@@ -679,20 +685,20 @@ inline  ::uint64_t Token::Reader::getIntegerLiteral() const {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Token::Builder::getIntegerLiteral() {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setIntegerLiteral( ::uint64_t value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isFloatLiteral() const {
@@ -705,20 +711,20 @@ inline double Token::Reader::getFloatLiteral() const {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Token::Builder::getFloatLiteral() {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setFloatLiteral(double value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
   _builder.setDataField<double>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isOperator() const {
@@ -729,48 +735,50 @@ inline bool Token::Builder::isOperator() {
 }
 inline bool Token::Reader::hasOperator() const {
   if (which() != Token::OPERATOR) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasOperator() {
   if (which() != Token::OPERATOR) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getOperator() const {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setOperator( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::OPERATOR);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initOperator(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::OPERATOR);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptOperator(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::OPERATOR);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isParenthesizedList() const {
@@ -781,54 +789,56 @@ inline bool Token::Builder::isParenthesizedList() {
 }
 inline bool Token::Reader::hasParenthesizedList() const {
   if (which() != Token::PARENTHESIZED_LIST) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasParenthesizedList() {
   if (which() != Token::PARENTHESIZED_LIST) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getParenthesizedList() const {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setParenthesizedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setParenthesizedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initParenthesizedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptParenthesizedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isBracketedList() const {
@@ -839,82 +849,84 @@ inline bool Token::Builder::isBracketedList() {
 }
 inline bool Token::Reader::hasBracketedList() const {
   if (which() != Token::BRACKETED_LIST) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBracketedList() {
   if (which() != Token::BRACKETED_LIST) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getBracketedList() const {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBracketedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setBracketedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initBracketedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBracketedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Token::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Token::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      4 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isBinaryLiteral() const {
@@ -925,87 +937,93 @@ inline bool Token::Builder::isBinaryLiteral() {
 }
 inline bool Token::Reader::hasBinaryLiteral() const {
   if (which() != Token::BINARY_LITERAL) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBinaryLiteral() {
   if (which() != Token::BINARY_LITERAL) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Token::Reader::getBinaryLiteral() const {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Token::Builder::getBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBinaryLiteral( ::capnp::Data::Reader value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Token::Builder::initBinaryLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBinaryLiteral(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Token::Which>(
-      0 * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Token::Builder::disownBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Statement::Which Statement::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Statement::Which Statement::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Statement::Reader::hasTokens() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasTokens() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader Statement::Reader::getTokens() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::getTokens() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::initTokens(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> Statement::Builder::disownTokens() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::isLine() const {
@@ -1018,20 +1036,20 @@ inline  ::capnp::Void Statement::Reader::getLine() const {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Statement::Builder::getLine() {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setLine( ::capnp::Void value) {
   _builder.setDataField<Statement::Which>(
-      0 * ::capnp::ELEMENTS, Statement::LINE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::LINE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Statement::Reader::isBlock() const {
@@ -1042,172 +1060,180 @@ inline bool Statement::Builder::isBlock() {
 }
 inline bool Statement::Reader::hasBlock() const {
   if (which() != Statement::BLOCK) return false;
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasBlock() {
   if (which() != Statement::BLOCK) return false;
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader Statement::Reader::getBlock() const {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::getBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setBlock( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
   _builder.setDataField<Statement::Which>(
-      0 * ::capnp::ELEMENTS, Statement::BLOCK);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::initBlock(unsigned int size) {
   _builder.setDataField<Statement::Which>(
-      0 * ::capnp::ELEMENTS, Statement::BLOCK);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptBlock(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
   _builder.setDataField<Statement::Which>(
-      0 * ::capnp::ELEMENTS, Statement::BLOCK);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> Statement::Builder::disownBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::hasDocComment() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasDocComment() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Statement::Reader::getDocComment() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Statement::Builder::getDocComment() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setDocComment( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Statement::Builder::initDocComment(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Statement::Builder::disownDocComment() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Statement::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Statement::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool LexedTokens::Reader::hasTokens() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedTokens::Builder::hasTokens() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader LexedTokens::Reader::getTokens() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::getTokens() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LexedTokens::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::initTokens(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedTokens::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> LexedTokens::Builder::disownTokens() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool LexedStatements::Reader::hasStatements() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedStatements::Builder::hasStatements() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader LexedStatements::Reader::getStatements() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::getStatements() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LexedStatements::Builder::setStatements( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::initStatements(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedStatements::Builder::adoptStatements(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> LexedStatements::Builder::disownStatements() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/lexer.capnp.h
+++ b/c++/src/capnp/compiler/lexer.capnp.h
@@ -560,11 +560,11 @@ private:
 
 inline  ::capnp::compiler::Token::Which Token::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Token::Which Token::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Token::Reader::isIdentifier() const {
@@ -576,49 +576,49 @@ inline bool Token::Builder::isIdentifier() {
 inline bool Token::Reader::hasIdentifier() const {
   if (which() != Token::IDENTIFIER) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasIdentifier() {
   if (which() != Token::IDENTIFIER) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getIdentifier() const {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setIdentifier( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initIdentifier(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptIdentifier(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isStringLiteral() const {
@@ -630,49 +630,49 @@ inline bool Token::Builder::isStringLiteral() {
 inline bool Token::Reader::hasStringLiteral() const {
   if (which() != Token::STRING_LITERAL) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasStringLiteral() {
   if (which() != Token::STRING_LITERAL) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getStringLiteral() const {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setStringLiteral( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initStringLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptStringLiteral(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isIntegerLiteral() const {
@@ -685,20 +685,20 @@ inline  ::uint64_t Token::Reader::getIntegerLiteral() const {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Token::Builder::getIntegerLiteral() {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setIntegerLiteral( ::uint64_t value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isFloatLiteral() const {
@@ -711,20 +711,20 @@ inline double Token::Reader::getFloatLiteral() const {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Token::Builder::getFloatLiteral() {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setFloatLiteral(double value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
   _builder.setDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isOperator() const {
@@ -736,49 +736,49 @@ inline bool Token::Builder::isOperator() {
 inline bool Token::Reader::hasOperator() const {
   if (which() != Token::OPERATOR) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasOperator() {
   if (which() != Token::OPERATOR) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getOperator() const {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setOperator( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initOperator(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptOperator(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isParenthesizedList() const {
@@ -790,55 +790,55 @@ inline bool Token::Builder::isParenthesizedList() {
 inline bool Token::Reader::hasParenthesizedList() const {
   if (which() != Token::PARENTHESIZED_LIST) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasParenthesizedList() {
   if (which() != Token::PARENTHESIZED_LIST) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getParenthesizedList() const {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setParenthesizedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setParenthesizedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initParenthesizedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptParenthesizedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isBracketedList() const {
@@ -850,83 +850,83 @@ inline bool Token::Builder::isBracketedList() {
 inline bool Token::Reader::hasBracketedList() const {
   if (which() != Token::BRACKETED_LIST) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBracketedList() {
   if (which() != Token::BRACKETED_LIST) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getBracketedList() const {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBracketedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setBracketedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initBracketedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBracketedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Token::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Token::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isBinaryLiteral() const {
@@ -938,92 +938,92 @@ inline bool Token::Builder::isBinaryLiteral() {
 inline bool Token::Reader::hasBinaryLiteral() const {
   if (which() != Token::BINARY_LITERAL) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBinaryLiteral() {
   if (which() != Token::BINARY_LITERAL) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Token::Reader::getBinaryLiteral() const {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Token::Builder::getBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBinaryLiteral( ::capnp::Data::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Token::Builder::initBinaryLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBinaryLiteral(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Token::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Token::Builder::disownBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Statement::Which Statement::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Statement::Which Statement::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Statement::Reader::hasTokens() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasTokens() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader Statement::Reader::getTokens() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::getTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::initTokens(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> Statement::Builder::disownTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::isLine() const {
@@ -1036,20 +1036,20 @@ inline  ::capnp::Void Statement::Reader::getLine() const {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Statement::Builder::getLine() {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setLine( ::capnp::Void value) {
   _builder.setDataField<Statement::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::LINE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::LINE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Statement::Reader::isBlock() const {
@@ -1061,179 +1061,179 @@ inline bool Statement::Builder::isBlock() {
 inline bool Statement::Reader::hasBlock() const {
   if (which() != Statement::BLOCK) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasBlock() {
   if (which() != Statement::BLOCK) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader Statement::Reader::getBlock() const {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::getBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setBlock( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
   _builder.setDataField<Statement::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::initBlock(unsigned int size) {
   _builder.setDataField<Statement::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptBlock(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
   _builder.setDataField<Statement::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> Statement::Builder::disownBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::hasDocComment() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasDocComment() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Statement::Reader::getDocComment() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Statement::Builder::getDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setDocComment( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Statement::Builder::initDocComment(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Statement::Builder::disownDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Statement::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Statement::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool LexedTokens::Reader::hasTokens() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedTokens::Builder::hasTokens() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader LexedTokens::Reader::getTokens() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::getTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LexedTokens::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::initTokens(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedTokens::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> LexedTokens::Builder::disownTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool LexedStatements::Reader::hasStatements() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedStatements::Builder::hasStatements() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader LexedStatements::Reader::getStatements() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::getStatements() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void LexedStatements::Builder::setStatements( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::initStatements(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedStatements::Builder::adoptStatements(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> LexedStatements::Builder::disownStatements() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/compiler/lexer.capnp.h
+++ b/c++/src/capnp/compiler/lexer.capnp.h
@@ -560,11 +560,11 @@ private:
 
 inline  ::capnp::compiler::Token::Which Token::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Token::Which Token::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Token::Reader::isIdentifier() const {
@@ -576,49 +576,49 @@ inline bool Token::Builder::isIdentifier() {
 inline bool Token::Reader::hasIdentifier() const {
   if (which() != Token::IDENTIFIER) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasIdentifier() {
   if (which() != Token::IDENTIFIER) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getIdentifier() const {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setIdentifier( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initIdentifier(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptIdentifier(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::IDENTIFIER);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownIdentifier() {
   KJ_IREQUIRE((which() == Token::IDENTIFIER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isStringLiteral() const {
@@ -630,49 +630,49 @@ inline bool Token::Builder::isStringLiteral() {
 inline bool Token::Reader::hasStringLiteral() const {
   if (which() != Token::STRING_LITERAL) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasStringLiteral() {
   if (which() != Token::STRING_LITERAL) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getStringLiteral() const {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setStringLiteral( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initStringLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptStringLiteral(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::STRING_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownStringLiteral() {
   KJ_IREQUIRE((which() == Token::STRING_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isIntegerLiteral() const {
@@ -685,20 +685,20 @@ inline  ::uint64_t Token::Reader::getIntegerLiteral() const {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Token::Builder::getIntegerLiteral() {
   KJ_IREQUIRE((which() == Token::INTEGER_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setIntegerLiteral( ::uint64_t value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::INTEGER_LITERAL);
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isFloatLiteral() const {
@@ -711,20 +711,20 @@ inline double Token::Reader::getFloatLiteral() const {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Token::Builder::getFloatLiteral() {
   KJ_IREQUIRE((which() == Token::FLOAT_LITERAL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setFloatLiteral(double value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::FLOAT_LITERAL);
   _builder.setDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isOperator() const {
@@ -736,49 +736,49 @@ inline bool Token::Builder::isOperator() {
 inline bool Token::Reader::hasOperator() const {
   if (which() != Token::OPERATOR) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasOperator() {
   if (which() != Token::OPERATOR) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Token::Reader::getOperator() const {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Token::Builder::getOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setOperator( ::capnp::Text::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Token::Builder::initOperator(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptOperator(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::OPERATOR);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Token::Builder::disownOperator() {
   KJ_IREQUIRE((which() == Token::OPERATOR),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isParenthesizedList() const {
@@ -790,55 +790,55 @@ inline bool Token::Builder::isParenthesizedList() {
 inline bool Token::Reader::hasParenthesizedList() const {
   if (which() != Token::PARENTHESIZED_LIST) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasParenthesizedList() {
   if (which() != Token::PARENTHESIZED_LIST) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getParenthesizedList() const {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setParenthesizedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setParenthesizedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initParenthesizedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptParenthesizedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::PARENTHESIZED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownParenthesizedList() {
   KJ_IREQUIRE((which() == Token::PARENTHESIZED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Token::Reader::isBracketedList() const {
@@ -850,83 +850,83 @@ inline bool Token::Builder::isBracketedList() {
 inline bool Token::Reader::hasBracketedList() const {
   if (which() != Token::BRACKETED_LIST) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBracketedList() {
   if (which() != Token::BRACKETED_LIST) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader Token::Reader::getBracketedList() const {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::getBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBracketedList( ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline void Token::Builder::setBracketedList(::kj::ArrayPtr<const  ::capnp::List< ::capnp::compiler::Token>::Reader> value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>::Builder Token::Builder::initBracketedList(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBracketedList(
     ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BRACKETED_LIST);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>> Token::Builder::disownBracketedList() {
   KJ_IREQUIRE((which() == Token::BRACKETED_LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::List< ::capnp::compiler::Token>>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Token::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Token::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Token::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 inline void Token::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Token::Reader::isBinaryLiteral() const {
@@ -938,92 +938,92 @@ inline bool Token::Builder::isBinaryLiteral() {
 inline bool Token::Reader::hasBinaryLiteral() const {
   if (which() != Token::BINARY_LITERAL) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Token::Builder::hasBinaryLiteral() {
   if (which() != Token::BINARY_LITERAL) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Token::Reader::getBinaryLiteral() const {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Token::Builder::getBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Token::Builder::setBinaryLiteral( ::capnp::Data::Reader value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Token::Builder::initBinaryLiteral(unsigned int size) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Token::Builder::adoptBinaryLiteral(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Token::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Token::BINARY_LITERAL);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Token::Builder::disownBinaryLiteral() {
   KJ_IREQUIRE((which() == Token::BINARY_LITERAL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::compiler::Statement::Which Statement::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::compiler::Statement::Which Statement::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Statement::Reader::hasTokens() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasTokens() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader Statement::Reader::getTokens() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::getTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder Statement::Builder::initTokens(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> Statement::Builder::disownTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::isLine() const {
@@ -1036,20 +1036,20 @@ inline  ::capnp::Void Statement::Reader::getLine() const {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Statement::Builder::getLine() {
   KJ_IREQUIRE((which() == Statement::LINE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setLine( ::capnp::Void value) {
   _builder.setDataField<Statement::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::LINE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Statement::LINE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Statement::Reader::isBlock() const {
@@ -1061,179 +1061,179 @@ inline bool Statement::Builder::isBlock() {
 inline bool Statement::Reader::hasBlock() const {
   if (which() != Statement::BLOCK) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasBlock() {
   if (which() != Statement::BLOCK) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader Statement::Reader::getBlock() const {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::getBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setBlock( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
   _builder.setDataField<Statement::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder Statement::Builder::initBlock(unsigned int size) {
   _builder.setDataField<Statement::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptBlock(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
   _builder.setDataField<Statement::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Statement::BLOCK);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> Statement::Builder::disownBlock() {
   KJ_IREQUIRE((which() == Statement::BLOCK),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Statement::Reader::hasDocComment() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Statement::Builder::hasDocComment() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Statement::Reader::getDocComment() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Statement::Builder::getDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Statement::Builder::setDocComment( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Statement::Builder::initDocComment(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), size);
 }
 inline void Statement::Builder::adoptDocComment(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Statement::Builder::disownDocComment() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Statement::Reader::getStartByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getStartByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setStartByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Statement::Reader::getEndByte() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Statement::Builder::getEndByte() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Statement::Builder::setEndByte( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool LexedTokens::Reader::hasTokens() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedTokens::Builder::hasTokens() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Reader LexedTokens::Reader::getTokens() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::getTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void LexedTokens::Builder::setTokens( ::capnp::List< ::capnp::compiler::Token>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Token>::Builder LexedTokens::Builder::initTokens(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedTokens::Builder::adoptTokens(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Token>> LexedTokens::Builder::disownTokens() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Token>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool LexedStatements::Reader::hasStatements() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool LexedStatements::Builder::hasStatements() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Reader LexedStatements::Reader::getStatements() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::getStatements() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void LexedStatements::Builder::setStatements( ::capnp::List< ::capnp::compiler::Statement>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::compiler::Statement>::Builder LexedStatements::Builder::initStatements(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void LexedStatements::Builder::adoptStatements(
     ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::compiler::Statement>> LexedStatements::Builder::disownStatements() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::compiler::Statement>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -369,7 +369,7 @@ public:
 
   inline ListSchema getSchema() const { return schema; }
 
-  inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+  inline uint size() const { return unbound(reader.size() / ELEMENTS); }
   DynamicValue::Reader operator[](uint index) const;
 
   typedef _::IndexingIterator<const Reader, DynamicValue::Reader> Iterator;
@@ -411,7 +411,7 @@ public:
 
   inline ListSchema getSchema() const { return schema; }
 
-  inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+  inline uint size() const { return unbound(builder.size() / ELEMENTS); }
   DynamicValue::Builder operator[](uint index);
   void set(uint index, const DynamicValue::Reader& value);
   DynamicValue::Builder init(uint index, uint size);

--- a/c++/src/capnp/dynamic.h
+++ b/c++/src/capnp/dynamic.h
@@ -369,7 +369,7 @@ public:
 
   inline ListSchema getSchema() const { return schema; }
 
-  inline uint size() const { return reader.size() / ELEMENTS; }
+  inline uint size() const { return unguard(reader.size() / ELEMENTS); }
   DynamicValue::Reader operator[](uint index) const;
 
   typedef _::IndexingIterator<const Reader, DynamicValue::Reader> Iterator;
@@ -411,7 +411,7 @@ public:
 
   inline ListSchema getSchema() const { return schema; }
 
-  inline uint size() const { return builder.size() / ELEMENTS; }
+  inline uint size() const { return unguard(builder.size() / ELEMENTS); }
   DynamicValue::Builder operator[](uint index);
   void set(uint index, const DynamicValue::Reader& value);
   DynamicValue::Builder init(uint index, uint size);

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -311,7 +311,7 @@ inline constexpr uint sizeInWords() {
   // Return the size, in words, of a Struct type, if allocated free-standing (not in a list).
   // May be useful for pre-computing space needed in order to precisely allocate messages.
 
-  return unguard((upgradeGuard<uint>(_::structSize<T>().data) +
+  return unbound((upgradeBound<uint>(_::structSize<T>().data) +
       _::structSize<T>().pointers * WORDS_PER_POINTER) / WORDS);
 }
 

--- a/c++/src/capnp/generated-header-support.h
+++ b/c++/src/capnp/generated-header-support.h
@@ -311,8 +311,8 @@ inline constexpr uint sizeInWords() {
   // Return the size, in words, of a Struct type, if allocated free-standing (not in a list).
   // May be useful for pre-computing space needed in order to precisely allocate messages.
 
-  return (WordCount32(_::structSize<T>().data) +
-      _::structSize<T>().pointers * WORDS_PER_POINTER) / WORDS;
+  return unguard((upgradeGuard<uint>(_::structSize<T>().data) +
+      _::structSize<T>().pointers * WORDS_PER_POINTER) / WORDS);
 }
 
 }  // namespace capnp

--- a/c++/src/capnp/layout-test.c++
+++ b/c++/src/capnp/layout-test.c++
@@ -29,7 +29,18 @@
 namespace kj {
   template <typename T, typename U>
   String KJ_STRINGIFY(kj::Quantity<T, U> value) {
-    return kj::str(value / kj::unit<kj::Quantity<T, U>>());
+    return kj::str(unguardAs<uint64_t>(value / kj::unit<kj::Quantity<T, U>>()));
+  }
+
+  // Hack: Allow direct comparisons and multiplications so that we don't have to rewrite the code
+  //   below.
+  template <uint64_t maxN, typename T>
+  inline constexpr Guarded<65535, T> operator*(uint a, Guarded<maxN, T> b) {
+    return assumeBits<16>(a * unguard(b));
+  }
+  template <uint b>
+  inline constexpr Guarded<65535, uint> operator*(uint a, GuardedConst<b>) {
+    return assumeBits<16>(a * b);
   }
 }
 #endif

--- a/c++/src/capnp/layout-test.c++
+++ b/c++/src/capnp/layout-test.c++
@@ -29,17 +29,17 @@
 namespace kj {
   template <typename T, typename U>
   String KJ_STRINGIFY(kj::Quantity<T, U> value) {
-    return kj::str(unguardAs<uint64_t>(value / kj::unit<kj::Quantity<T, U>>()));
+    return kj::str(unboundAs<uint64_t>(value / kj::unit<kj::Quantity<T, U>>()));
   }
 
   // Hack: Allow direct comparisons and multiplications so that we don't have to rewrite the code
   //   below.
   template <uint64_t maxN, typename T>
-  inline constexpr Guarded<65535, T> operator*(uint a, Guarded<maxN, T> b) {
-    return assumeBits<16>(a * unguard(b));
+  inline constexpr Bounded<65535, T> operator*(uint a, Bounded<maxN, T> b) {
+    return assumeBits<16>(a * unbound(b));
   }
   template <uint b>
-  inline constexpr Guarded<65535, uint> operator*(uint a, GuardedConst<b>) {
+  inline constexpr Bounded<65535, uint> operator*(uint a, BoundedConst<b>) {
     return assumeBits<16>(a * b);
   }
 }

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -367,7 +367,7 @@ struct WireHelpers {
   }
 
   template <typename T>
-  static KJ_ALWAYS_INLINE(void zeroMemory(kj::ArrayPtr<T> array)) {
+  static inline void zeroMemory(kj::ArrayPtr<T> array) {
     memset(array.begin(), 0, array.size() * sizeof(array[0]));
   }
 
@@ -385,17 +385,17 @@ struct WireHelpers {
   }
 
   template <typename T>
-  static KJ_ALWAYS_INLINE(void copyMemory(T* to, const T* from)) {
+  static inline void copyMemory(T* to, const T* from) {
     memcpy(to, from, sizeof(*from));
   }
 
   // TODO(cleanup): Turn these into a .copyTo() method of ArrayPtr?
   template <typename T>
-  static KJ_ALWAYS_INLINE(void copyMemory(T* to, kj::ArrayPtr<T> from)) {
+  static inline void copyMemory(T* to, kj::ArrayPtr<T> from) {
     memcpy(to, from.begin(), from.size() * sizeof(from[0]));
   }
   template <typename T>
-  static KJ_ALWAYS_INLINE(void copyMemory(T* to, kj::ArrayPtr<const T> from)) {
+  static inline void copyMemory(T* to, kj::ArrayPtr<const T> from) {
     memcpy(to, from.begin(), from.size() * sizeof(from[0]));
   }
   static KJ_ALWAYS_INLINE(void copyMemory(char* to, kj::StringPtr from)) {

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -59,6 +59,8 @@ namespace _ {  // private
 
 #endif  // !CAPNP_LITE
 
+#define G(n) guarded<n>()
+
 // =======================================================================================
 
 struct WirePointer {
@@ -159,26 +161,28 @@ struct WirePointer {
     offsetAndKind.set(kind | 0xfffffffc);
   }
 
-  KJ_ALWAYS_INLINE(ElementCount inlineCompositeListElementCount() const) {
-    return (offsetAndKind.get() >> 2) * ELEMENTS;
+  KJ_ALWAYS_INLINE(ListElementCount inlineCompositeListElementCount() const) {
+    return ((guarded(offsetAndKind.get()) >> G(2))
+            & G(kj::maxValueForBits<LIST_ELEMENT_COUNT_BITS>())) * ELEMENTS;
   }
   KJ_ALWAYS_INLINE(void setKindAndInlineCompositeListElementCount(
-      Kind kind, ElementCount elementCount)) {
-    offsetAndKind.set(((elementCount / ELEMENTS) << 2) | kind);
+      Kind kind, ListElementCount elementCount)) {
+    offsetAndKind.set(unguardAs<uint32_t>((elementCount / ELEMENTS) << G(2)) | kind);
   }
 
-  KJ_ALWAYS_INLINE(WordCount farPositionInSegment() const) {
+  KJ_ALWAYS_INLINE(SegmentWordCount farPositionInSegment() const) {
     KJ_DREQUIRE(kind() == FAR,
         "positionInSegment() should only be called on FAR pointers.");
-    return (offsetAndKind.get() >> 3) * WORDS;
+    return (guarded(offsetAndKind.get()) >> G(3)) * WORDS;
   }
   KJ_ALWAYS_INLINE(bool isDoubleFar() const) {
     KJ_DREQUIRE(kind() == FAR,
         "isDoubleFar() should only be called on FAR pointers.");
-    return (offsetAndKind.get() >> 2) & 1;
+    return unguard((guarded(offsetAndKind.get()) >> G(2)) & G(1));
   }
-  KJ_ALWAYS_INLINE(void setFar(bool isDoubleFar, WordCount pos)) {
-    offsetAndKind.set(((pos / WORDS) << 3) | (static_cast<uint32_t>(isDoubleFar) << 2) |
+  KJ_ALWAYS_INLINE(void setFar(bool isDoubleFar, WordCountN<29> pos)) {
+    offsetAndKind.set(unguardAs<uint32_t>((pos / WORDS) << G(3)) |
+                      (static_cast<uint32_t>(isDoubleFar) << 2) |
                       static_cast<uint32_t>(Kind::FAR));
   }
   KJ_ALWAYS_INLINE(void setCap(uint index)) {
@@ -196,11 +200,11 @@ struct WirePointer {
     WireValue<WordCount16> dataSize;
     WireValue<WirePointerCount16> ptrCount;
 
-    inline WordCount wordSize() const {
-      return dataSize.get() + ptrCount.get() * WORDS_PER_POINTER;
+    inline WordCountN<17> wordSize() const {
+      return upgradeGuard<uint32_t>(dataSize.get()) + ptrCount.get() * WORDS_PER_POINTER;
     }
 
-    KJ_ALWAYS_INLINE(void set(WordCount ds, WirePointerCount rc)) {
+    KJ_ALWAYS_INLINE(void set(WordCount16 ds, WirePointerCount16 rc)) {
       dataSize.set(ds);
       ptrCount.set(rc);
     }
@@ -216,21 +220,20 @@ struct WirePointer {
     KJ_ALWAYS_INLINE(ElementSize elementSize() const) {
       return static_cast<ElementSize>(elementSizeAndCount.get() & 7);
     }
-    KJ_ALWAYS_INLINE(ElementCount elementCount() const) {
-      return (elementSizeAndCount.get() >> 3) * ELEMENTS;
+    KJ_ALWAYS_INLINE(ElementCountN<29> elementCount() const) {
+      return (guarded(elementSizeAndCount.get()) >> G(3)) * ELEMENTS;
     }
-    KJ_ALWAYS_INLINE(WordCount inlineCompositeWordCount() const) {
-      return elementCount() * (1 * WORDS / ELEMENTS);
-    }
-
-    KJ_ALWAYS_INLINE(void set(ElementSize es, ElementCount ec)) {
-      KJ_DREQUIRE(ec < (1 << 29) * ELEMENTS, "Lists are limited to 2**29 elements.");
-      elementSizeAndCount.set(((ec / ELEMENTS) << 3) | static_cast<int>(es));
+    KJ_ALWAYS_INLINE(WordCountN<29> inlineCompositeWordCount() const) {
+      return elementCount() * (ONE * WORDS / ELEMENTS);
     }
 
-    KJ_ALWAYS_INLINE(void setInlineComposite(WordCount wc)) {
-      KJ_DREQUIRE(wc < (1 << 29) * WORDS, "Inline composite lists are limited to 2**29 words.");
-      elementSizeAndCount.set(((wc / WORDS) << 3) |
+    KJ_ALWAYS_INLINE(void set(ElementSize es, ElementCountN<29> ec)) {
+      elementSizeAndCount.set(unguardAs<uint32_t>((ec / ELEMENTS) << G(3)) |
+                              static_cast<int>(es));
+    }
+
+    KJ_ALWAYS_INLINE(void setInlineComposite(WordCountN<29> wc)) {
+      elementSizeAndCount.set(unguardAs<uint32_t>((wc / WORDS) << G(3)) |
                               static_cast<int>(ElementSize::INLINE_COMPOSITE));
     }
   };
@@ -269,17 +272,19 @@ struct WirePointer {
 };
 static_assert(sizeof(WirePointer) == sizeof(word),
     "capnp::WirePointer is not exactly one word.  This will probably break everything.");
-static_assert(POINTERS * WORDS_PER_POINTER * BYTES_PER_WORD / BYTES == sizeof(WirePointer),
+static_assert(unguardAs<size_t>(POINTERS * WORDS_PER_POINTER * BYTES_PER_WORD / BYTES) ==
+              sizeof(WirePointer),
     "WORDS_PER_POINTER is wrong.");
-static_assert(POINTERS * BYTES_PER_POINTER / BYTES == sizeof(WirePointer),
+static_assert(unguardAs<size_t>(POINTERS * BYTES_PER_POINTER / BYTES) == sizeof(WirePointer),
     "BYTES_PER_POINTER is wrong.");
-static_assert(POINTERS * BITS_PER_POINTER / BITS_PER_BYTE / BYTES == sizeof(WirePointer),
+static_assert(unguardAs<size_t>(POINTERS * BITS_PER_POINTER / BITS_PER_BYTE / BYTES) ==
+              sizeof(WirePointer),
     "BITS_PER_POINTER is wrong.");
 
 namespace {
 
 static const union {
-  AlignedData<POINTER_SIZE_IN_WORDS / WORDS> word;
+  AlignedData<unguard(POINTER_SIZE_IN_WORDS / WORDS)> word;
   WirePointer pointer;
 } zero = {{{0}}};
 
@@ -298,22 +303,72 @@ struct SegmentAnd {
 }  // namespace
 
 struct WireHelpers {
+#if CAPNP_DEBUG_TYPES
+  template <uint64_t maxN, typename T>
+  static KJ_ALWAYS_INLINE(
+      kj::Quantity<kj::Guarded<(maxN + 7) / 8, T>, word> roundBytesUpToWords(
+          kj::Quantity<kj::Guarded<maxN, T>, byte> bytes)) {
+    static_assert(sizeof(word) == 8, "This code assumes 64-bit words.");
+    return (bytes + G(7) * BYTES) / BYTES_PER_WORD;
+  }
+
+  template <uint64_t maxN, typename T>
+  static KJ_ALWAYS_INLINE(
+      kj::Quantity<kj::Guarded<(maxN + 7) / 8, T>, byte> roundBitsUpToBytes(
+          kj::Quantity<kj::Guarded<maxN, T>, BitLabel> bits)) {
+    return (bits + G(7) * BITS) / BITS_PER_BYTE;
+  }
+
+  template <uint64_t maxN, typename T>
+  static KJ_ALWAYS_INLINE(
+      kj::Quantity<kj::Guarded<(maxN + 63) / 64, T>, word> roundBitsUpToWords(
+          kj::Quantity<kj::Guarded<maxN, T>, BitLabel> bits)) {
+    static_assert(sizeof(word) == 8, "This code assumes 64-bit words.");
+    return (bits + G(63) * BITS) / BITS_PER_WORD;
+  }
+#else
   static KJ_ALWAYS_INLINE(WordCount roundBytesUpToWords(ByteCount bytes)) {
     static_assert(sizeof(word) == 8, "This code assumes 64-bit words.");
-    return (bytes + 7 * BYTES) / BYTES_PER_WORD;
+    return (bytes + G(7) * BYTES) / BYTES_PER_WORD;
   }
 
   static KJ_ALWAYS_INLINE(ByteCount roundBitsUpToBytes(BitCount bits)) {
-    return (bits + 7 * BITS) / BITS_PER_BYTE;
+    return (bits + G(7) * BITS) / BITS_PER_BYTE;
   }
 
   static KJ_ALWAYS_INLINE(WordCount64 roundBitsUpToWords(BitCount64 bits)) {
     static_assert(sizeof(word) == 8, "This code assumes 64-bit words.");
-    return (bits + 63 * BITS) / BITS_PER_WORD;
+    return (bits + G(63) * BITS) / BITS_PER_WORD;
   }
 
   static KJ_ALWAYS_INLINE(ByteCount64 roundBitsUpToBytes(BitCount64 bits)) {
-    return (bits + 7 * BITS) / BITS_PER_BYTE;
+    return (bits + G(7) * BITS) / BITS_PER_BYTE;
+  }
+#endif
+
+  static KJ_ALWAYS_INLINE(void zeroMemory(byte* ptr, ByteCount32 count)) {
+    memset(ptr, 0, unguard(count / BYTES));
+  }
+
+  static KJ_ALWAYS_INLINE(void zeroMemory(word* ptr, WordCountN<29> count)) {
+    memset(ptr, 0, unguard(count * BYTES_PER_WORD / BYTES));
+  }
+
+  static KJ_ALWAYS_INLINE(void zeroMemory(WirePointer* ptr, WirePointerCountN<29> count)) {
+    memset(ptr, 0, unguard(count * BYTES_PER_POINTER / BYTES));
+  }
+
+  static KJ_ALWAYS_INLINE(void copyMemory(byte* to, const byte* from, ByteCount32 count)) {
+    memcpy(to, from, unguard(count / BYTES));
+  }
+
+  static KJ_ALWAYS_INLINE(void copyMemory(word* to, const word* from, WordCountN<29> count)) {
+    memcpy(to, from, unguard(count * BYTES_PER_WORD / BYTES));
+  }
+
+  static KJ_ALWAYS_INLINE(void copyMemory(WirePointer* to, const WirePointer* from,
+                                          WirePointerCountN<29> count)) {
+    memcpy(to, from, unguard(count * BYTES_PER_POINTER  / BYTES));
   }
 
   static KJ_ALWAYS_INLINE(bool boundsCheck(
@@ -328,8 +383,8 @@ struct WireHelpers {
   }
 
   static KJ_ALWAYS_INLINE(word* allocate(
-      WirePointer*& ref, SegmentBuilder*& segment, CapTableBuilder* capTable, WordCount amount,
-      WirePointer::Kind kind, BuilderArena* orphanArena)) {
+      WirePointer*& ref, SegmentBuilder*& segment, CapTableBuilder* capTable,
+      SegmentWordCount amount, WirePointer::Kind kind, BuilderArena* orphanArena)) {
     // Allocate space in the message for a new object, creating far pointers if necessary.
     //
     // * `ref` starts out being a reference to the pointer which shall be assigned to point at the
@@ -353,7 +408,7 @@ struct WireHelpers {
     if (orphanArena == nullptr) {
       if (!ref->isNull()) zeroObject(segment, capTable, ref);
 
-      if (amount == 0 * WORDS && kind == WirePointer::STRUCT) {
+      if (amount == ZERO * WORDS && kind == WirePointer::STRUCT) {
         // Note that the check for kind == WirePointer::STRUCT will hopefully cause this whole
         // branch to be optimized away from all the call sites that are allocating non-structs.
         ref->setKindAndTargetForEmptyStruct();
@@ -368,7 +423,10 @@ struct WireHelpers {
         // space to act as the landing pad for a far pointer.
 
         WordCount amountPlusRef = amount + POINTER_SIZE_IN_WORDS;
-        auto allocation = segment->getArena()->allocate(amountPlusRef);
+        auto allocation = segment->getArena()->allocate(
+            assertMaxBits<SEGMENT_WORD_COUNT_BITS>(amountPlusRef, []() {
+              KJ_FAIL_REQUIRE("requested object size exceeds maximum segment size");
+            }));
         segment = allocation.segment;
         ptr = allocation.words;
 
@@ -448,7 +506,7 @@ struct WireHelpers {
 
       // Find the landing pad and check that it is within bounds.
       const word* ptr = segment->getStartPtr() + ref->farPositionInSegment();
-      WordCount padWords = (1 + ref->isDoubleFar()) * POINTER_SIZE_IN_WORDS;
+      WordCount padWords = guarded(1 + ref->isDoubleFar()) * POINTER_SIZE_IN_WORDS;
       KJ_REQUIRE(boundsCheck(segment, ptr, ptr + padWords),
                  "Message contains out-of-bounds far pointer.") {
         return nullptr;
@@ -503,10 +561,10 @@ struct WireHelpers {
               zeroObject(segment, capTable,
                          pad + 1, segment->getPtrUnchecked(pad->farPositionInSegment()));
             }
-            memset(pad, 0, sizeof(WirePointer) * 2);
+            zeroMemory(pad, G(2) * POINTERS);
           } else {
             zeroObject(segment, capTable, pad);
-            memset(pad, 0, sizeof(WirePointer));
+            zeroMemory(pad, ONE * POINTERS);
           }
         }
         break;
@@ -534,11 +592,10 @@ struct WireHelpers {
       case WirePointer::STRUCT: {
         WirePointer* pointerSection =
             reinterpret_cast<WirePointer*>(ptr + tag->structRef.dataSize.get());
-        uint count = tag->structRef.ptrCount.get() / POINTERS;
-        for (uint i = 0; i < count; i++) {
+        for (auto i: kj::zeroTo(tag->structRef.ptrCount.get())) {
           zeroObject(segment, capTable, pointerSection + i);
         }
-        memset(ptr, 0, tag->structRef.wordSize() * BYTES_PER_WORD / BYTES);
+        zeroMemory(ptr, tag->structRef.wordSize());
         break;
       }
       case WirePointer::LIST: {
@@ -550,18 +607,19 @@ struct WireHelpers {
           case ElementSize::BYTE:
           case ElementSize::TWO_BYTES:
           case ElementSize::FOUR_BYTES:
-          case ElementSize::EIGHT_BYTES:
-            memset(ptr, 0,
-                roundBitsUpToWords(ElementCount64(tag->listRef.elementCount()) *
-                                   dataBitsPerElement(tag->listRef.elementSize()))
-                    * BYTES_PER_WORD / BYTES);
+          case ElementSize::EIGHT_BYTES: {
+            zeroMemory(ptr, roundBitsUpToWords(
+                upgradeGuard<uint64_t>(tag->listRef.elementCount()) *
+                dataBitsPerElement(tag->listRef.elementSize())));
             break;
+          }
           case ElementSize::POINTER: {
-            uint count = tag->listRef.elementCount() / ELEMENTS;
-            for (uint i = 0; i < count; i++) {
-              zeroObject(segment, capTable, reinterpret_cast<WirePointer*>(ptr) + i);
+            WirePointer* typedPtr = reinterpret_cast<WirePointer*>(ptr);
+            auto count = tag->listRef.elementCount() * (ONE * POINTERS / ELEMENTS);
+            for (auto i: kj::zeroTo(count)) {
+              zeroObject(segment, capTable, typedPtr + i);
             }
-            memset(ptr, 0, POINTER_SIZE_IN_WORDS * count * BYTES_PER_WORD / BYTES);
+            zeroMemory(typedPtr, count);
             break;
           }
           case ElementSize::INLINE_COMPOSITE: {
@@ -572,21 +630,25 @@ struct WireHelpers {
             WordCount dataSize = elementTag->structRef.dataSize.get();
             WirePointerCount pointerCount = elementTag->structRef.ptrCount.get();
 
-            uint count = elementTag->inlineCompositeListElementCount() / ELEMENTS;
+            auto count = elementTag->inlineCompositeListElementCount();
             if (pointerCount > 0 * POINTERS) {
               word* pos = ptr + POINTER_SIZE_IN_WORDS;
-              for (uint i = 0; i < count; i++) {
+              for (auto i KJ_UNUSED: kj::zeroTo(count)) {
                 pos += dataSize;
 
-                for (uint j = 0; j < pointerCount / POINTERS; j++) {
+                for (auto j KJ_UNUSED: kj::zeroTo(pointerCount)) {
                   zeroObject(segment, capTable, reinterpret_cast<WirePointer*>(pos));
                   pos += POINTER_SIZE_IN_WORDS;
                 }
               }
             }
 
-            memset(ptr, 0, (elementTag->structRef.wordSize() * count + POINTER_SIZE_IN_WORDS)
-                           * BYTES_PER_WORD / BYTES);
+            auto wordsPerElement = elementTag->structRef.wordSize() / ELEMENTS;
+            zeroMemory(ptr, assertMaxBits<SEGMENT_WORD_COUNT_BITS>(POINTER_SIZE_IN_WORDS +
+                upgradeGuard<uint64_t>(count) * wordsPerElement, []() {
+                  KJ_FAIL_ASSERT("encountered list pointer in builder which is too large to "
+                      "possibly fit in a segment. Bug in builder code?");
+                }));
             break;
           }
         }
@@ -627,7 +689,7 @@ struct WireHelpers {
       SegmentReader* segment, const WirePointer* ref, int nestingLimit) {
     // Compute the total size of the object pointed to, not counting far pointer overhead.
 
-    MessageSizeCounts result = { 0 * WORDS, 0 };
+    MessageSizeCounts result = { ZERO * WORDS, 0 };
 
     if (ref->isNull()) {
       return result;
@@ -646,12 +708,11 @@ struct WireHelpers {
                    "Message contained out-of-bounds struct pointer.") {
           return result;
         }
-        result.wordCount += ref->structRef.wordSize();
+        result.addWords(ref->structRef.wordSize());
 
         const WirePointer* pointerSection =
             reinterpret_cast<const WirePointer*>(ptr + ref->structRef.dataSize.get());
-        uint count = ref->structRef.ptrCount.get() / POINTERS;
-        for (uint i = 0; i < count; i++) {
+        for (auto i: kj::zeroTo(ref->structRef.ptrCount.get())) {
           result += totalSize(segment, pointerSection + i, nestingLimit);
         }
         break;
@@ -666,14 +727,14 @@ struct WireHelpers {
           case ElementSize::TWO_BYTES:
           case ElementSize::FOUR_BYTES:
           case ElementSize::EIGHT_BYTES: {
-            WordCount64 totalWords = roundBitsUpToWords(
-                ElementCount64(ref->listRef.elementCount()) *
+            auto totalWords = roundBitsUpToWords(
+                upgradeGuard<uint64_t>(ref->listRef.elementCount()) *
                 dataBitsPerElement(ref->listRef.elementSize()));
             KJ_REQUIRE(boundsCheck(segment, ptr, ptr + totalWords),
                        "Message contained out-of-bounds list pointer.") {
               return result;
             }
-            result.wordCount += totalWords;
+            result.addWords(totalWords);
             break;
           }
           case ElementSize::POINTER: {
@@ -684,30 +745,31 @@ struct WireHelpers {
               return result;
             }
 
-            result.wordCount += count * WORDS_PER_POINTER;
+            result.addWords(count * WORDS_PER_POINTER);
 
-            for (uint i = 0; i < count / POINTERS; i++) {
+            for (auto i: kj::zeroTo(count)) {
               result += totalSize(segment, reinterpret_cast<const WirePointer*>(ptr) + i,
                                   nestingLimit);
             }
             break;
           }
           case ElementSize::INLINE_COMPOSITE: {
-            WordCount wordCount = ref->listRef.inlineCompositeWordCount();
+            auto wordCount = ref->listRef.inlineCompositeWordCount();
             KJ_REQUIRE(boundsCheck(segment, ptr, ptr + wordCount + POINTER_SIZE_IN_WORDS),
                        "Message contained out-of-bounds list pointer.") {
               return result;
             }
 
             const WirePointer* elementTag = reinterpret_cast<const WirePointer*>(ptr);
-            ElementCount count = elementTag->inlineCompositeListElementCount();
+            auto count = elementTag->inlineCompositeListElementCount();
 
             KJ_REQUIRE(elementTag->kind() == WirePointer::STRUCT,
                        "Don't know how to handle non-STRUCT inline composite.") {
               return result;
             }
 
-            auto actualSize = elementTag->structRef.wordSize() / ELEMENTS * ElementCount64(count);
+            auto actualSize = elementTag->structRef.wordSize() / ELEMENTS *
+                              upgradeGuard<uint64_t>(count);
             KJ_REQUIRE(actualSize <= wordCount,
                        "Struct list pointer's elements overran size.") {
               return result;
@@ -715,17 +777,17 @@ struct WireHelpers {
 
             // We count the actual size rather than the claimed word count because that's what
             // we'll end up with if we make a copy.
-            result.wordCount += actualSize + POINTER_SIZE_IN_WORDS;
+            result.addWords(wordCount + POINTER_SIZE_IN_WORDS);
 
             WordCount dataSize = elementTag->structRef.dataSize.get();
             WirePointerCount pointerCount = elementTag->structRef.ptrCount.get();
 
             if (pointerCount > 0 * POINTERS) {
               const word* pos = ptr + POINTER_SIZE_IN_WORDS;
-              for (uint i = 0; i < count / ELEMENTS; i++) {
+              for (auto i KJ_UNUSED: kj::zeroTo(count)) {
                 pos += dataSize;
 
-                for (uint j = 0; j < pointerCount / POINTERS; j++) {
+                for (auto j KJ_UNUSED: kj::zeroTo(pointerCount)) {
                   result += totalSize(segment, reinterpret_cast<const WirePointer*>(pos),
                                       nestingLimit);
                   pos += POINTER_SIZE_IN_WORDS;
@@ -760,13 +822,13 @@ struct WireHelpers {
   static KJ_ALWAYS_INLINE(
       void copyStruct(SegmentBuilder* segment, CapTableBuilder* capTable,
                       word* dst, const word* src,
-                      WordCount dataSize, WirePointerCount pointerCount)) {
-    memcpy(dst, src, dataSize * BYTES_PER_WORD / BYTES);
+                      StructDataWordCount dataSize, StructPointerCount pointerCount)) {
+    copyMemory(dst, src, dataSize);
 
     const WirePointer* srcRefs = reinterpret_cast<const WirePointer*>(src + dataSize);
     WirePointer* dstRefs = reinterpret_cast<WirePointer*>(dst + dataSize);
 
-    for (uint i = 0; i < pointerCount / POINTERS; i++) {
+    for (auto i: kj::zeroTo(pointerCount)) {
       SegmentBuilder* subSegment = segment;
       WirePointer* dstRef = dstRefs + i;
       copyMessage(subSegment, capTable, dstRef, srcRefs + i);
@@ -803,12 +865,12 @@ struct WireHelpers {
           case ElementSize::TWO_BYTES:
           case ElementSize::FOUR_BYTES:
           case ElementSize::EIGHT_BYTES: {
-            WordCount wordCount = roundBitsUpToWords(
-                ElementCount64(src->listRef.elementCount()) *
+            auto wordCount = roundBitsUpToWords(
+                upgradeGuard<uint64_t>(src->listRef.elementCount()) *
                 dataBitsPerElement(src->listRef.elementSize()));
             const word* srcPtr = src->target();
             word* dstPtr = allocate(dst, segment, capTable, wordCount, WirePointer::LIST, nullptr);
-            memcpy(dstPtr, srcPtr, wordCount * BYTES_PER_WORD / BYTES);
+            copyMemory(dstPtr, srcPtr, wordCount);
 
             dst->listRef.set(src->listRef.elementSize(), src->listRef.elementCount());
             return dstPtr;
@@ -818,11 +880,10 @@ struct WireHelpers {
             const WirePointer* srcRefs = reinterpret_cast<const WirePointer*>(src->target());
             WirePointer* dstRefs = reinterpret_cast<WirePointer*>(
                 allocate(dst, segment, capTable, src->listRef.elementCount() *
-                    (1 * POINTERS / ELEMENTS) * WORDS_PER_POINTER,
+                    (ONE * POINTERS / ELEMENTS) * WORDS_PER_POINTER,
                     WirePointer::LIST, nullptr));
 
-            uint n = src->listRef.elementCount() / ELEMENTS;
-            for (uint i = 0; i < n; i++) {
+            for (auto i: kj::zeroTo(src->listRef.elementCount() * (ONE * POINTERS / ELEMENTS))) {
               SegmentBuilder* subSegment = segment;
               WirePointer* dstRef = dstRefs + i;
               copyMessage(subSegment, capTable, dstRef, srcRefs + i);
@@ -835,7 +896,9 @@ struct WireHelpers {
           case ElementSize::INLINE_COMPOSITE: {
             const word* srcPtr = src->target();
             word* dstPtr = allocate(dst, segment, capTable,
-                src->listRef.inlineCompositeWordCount() + POINTER_SIZE_IN_WORDS,
+                assertMaxBits<SEGMENT_WORD_COUNT_BITS>(
+                    src->listRef.inlineCompositeWordCount() + POINTER_SIZE_IN_WORDS,
+                    []() { KJ_FAIL_ASSERT("list too big to fit in a segment"); }),
                 WirePointer::LIST, nullptr);
 
             dst->listRef.setInlineComposite(src->listRef.inlineCompositeWordCount());
@@ -849,8 +912,7 @@ struct WireHelpers {
             KJ_ASSERT(srcTag->kind() == WirePointer::STRUCT,
                 "INLINE_COMPOSITE of lists is not yet supported.");
 
-            uint n = srcTag->inlineCompositeListElementCount() / ELEMENTS;
-            for (uint i = 0; i < n; i++) {
+            for (auto i KJ_UNUSED: kj::zeroTo(srcTag->inlineCompositeListElementCount())) {
               copyStruct(segment, capTable, dstElement, srcElement,
                   srcTag->structRef.dataSize.get(), srcTag->structRef.ptrCount.get());
               srcElement += srcTag->structRef.wordSize();
@@ -917,10 +979,10 @@ struct WireHelpers {
       // that it doesn't need to be a double-far.
 
       WirePointer* landingPad =
-          reinterpret_cast<WirePointer*>(srcSegment->allocate(1 * WORDS));
+          reinterpret_cast<WirePointer*>(srcSegment->allocate(G(1) * WORDS));
       if (landingPad == nullptr) {
         // Darn, need a double-far.
-        auto allocation = srcSegment->getArena()->allocate(2 * WORDS);
+        auto allocation = srcSegment->getArena()->allocate(G(2) * WORDS);
         SegmentBuilder* farSegment = allocation.segment;
         landingPad = reinterpret_cast<WirePointer*>(allocation.words);
 
@@ -988,8 +1050,8 @@ struct WireHelpers {
       goto useDefault;
     }
 
-    WordCount oldDataSize = oldRef->structRef.dataSize.get();
-    WirePointerCount oldPointerCount = oldRef->structRef.ptrCount.get();
+    auto oldDataSize = oldRef->structRef.dataSize.get();
+    auto oldPointerCount = oldRef->structRef.ptrCount.get();
     WirePointer* oldPointerSection =
         reinterpret_cast<WirePointer*>(oldPtr + oldDataSize);
 
@@ -998,9 +1060,9 @@ struct WireHelpers {
       // run with it and do bounds checks at access time, because how would we handle writes?
       // Instead, we have to copy the struct to a new space now.
 
-      WordCount newDataSize = kj::max(oldDataSize, size.data);
-      WirePointerCount newPointerCount = kj::max(oldPointerCount, size.pointers);
-      WordCount totalSize = newDataSize + newPointerCount * WORDS_PER_POINTER;
+      auto newDataSize = kj::max(oldDataSize, size.data);
+      auto newPointerCount = kj::max(oldPointerCount, size.pointers);
+      auto totalSize = newDataSize + newPointerCount * WORDS_PER_POINTER;
 
       // Don't let allocate() zero out the object just yet.
       zeroPointerAndFars(segment, ref);
@@ -1009,11 +1071,11 @@ struct WireHelpers {
       ref->structRef.set(newDataSize, newPointerCount);
 
       // Copy data section.
-      memcpy(ptr, oldPtr, oldDataSize * BYTES_PER_WORD / BYTES);
+      copyMemory(ptr, oldPtr, oldDataSize);
 
       // Copy pointer section.
       WirePointer* newPointerSection = reinterpret_cast<WirePointer*>(ptr + newDataSize);
-      for (uint i = 0; i < oldPointerCount / POINTERS; i++) {
+      for (auto i: kj::zeroTo(oldPointerCount)) {
         transferPointer(segment, newPointerSection + i, oldSegment, oldPointerSection + i);
       }
 
@@ -1022,8 +1084,7 @@ struct WireHelpers {
       //    out as it may contain secrets that the caller intends to remove from the new copy.
       // 2) Zeros will be deflated by packing, making this dead memory almost-free if it ever
       //    hits the wire.
-      memset(oldPtr, 0,
-             (oldDataSize + oldPointerCount * WORDS_PER_POINTER) * BYTES_PER_WORD / BYTES);
+      zeroMemory(oldPtr, oldDataSize + oldPointerCount * WORDS_PER_POINTER);
 
       return StructBuilder(segment, capTable, ptr, newPointerSection, newDataSize * BITS_PER_WORD,
                            newPointerCount);
@@ -1039,31 +1100,40 @@ struct WireHelpers {
     KJ_DREQUIRE(elementSize != ElementSize::INLINE_COMPOSITE,
         "Should have called initStructListPointer() instead.");
 
-    BitCount dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
-    WirePointerCount pointerCount = pointersPerElement(elementSize) * ELEMENTS;
-    auto step = (dataSize + pointerCount * BITS_PER_POINTER) / ELEMENTS;
+    auto checkedElementCount = assertMaxBits<LIST_ELEMENT_COUNT_BITS>(elementCount,
+        []() { KJ_FAIL_REQUIRE("tried to allocate list with too many elements"); });
+
+    auto dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
+    auto pointerCount = pointersPerElement(elementSize) * ELEMENTS;
+    auto step = bitsPerElementIncludingPointers(elementSize);
+    KJ_DASSERT(step * ELEMENTS == (dataSize + pointerCount * BITS_PER_POINTER));
 
     // Calculate size of the list.
-    WordCount wordCount = roundBitsUpToWords(ElementCount64(elementCount) * step);
+    auto wordCount = roundBitsUpToWords(upgradeGuard<uint64_t>(checkedElementCount) * step);
 
     // Allocate the list.
     word* ptr = allocate(ref, segment, capTable, wordCount, WirePointer::LIST, orphanArena);
 
     // Initialize the pointer.
-    ref->listRef.set(elementSize, elementCount);
+    ref->listRef.set(elementSize, checkedElementCount);
 
     // Build the ListBuilder.
-    return ListBuilder(segment, capTable, ptr, step, elementCount, dataSize,
-                       pointerCount, elementSize);
+    return ListBuilder(segment, capTable, ptr, step, checkedElementCount,
+                       dataSize, pointerCount, elementSize);
   }
 
   static KJ_ALWAYS_INLINE(ListBuilder initStructListPointer(
       WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable,
       ElementCount elementCount, StructSize elementSize, BuilderArena* orphanArena = nullptr)) {
-    auto wordsPerElement = elementSize.total() / ELEMENTS;
+    auto checkedElementCount = assertMaxBits<LIST_ELEMENT_COUNT_BITS>(elementCount,
+        []() { KJ_FAIL_REQUIRE("tried to allocate list with too many elements"); });
+
+    WordsPerElementN<17> wordsPerElement = elementSize.total() / ELEMENTS;
 
     // Allocate the list, prefixed by a single WirePointer.
-    WordCount wordCount = elementCount * wordsPerElement;
+    auto wordCount = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+        upgradeGuard<uint64_t>(checkedElementCount) * wordsPerElement,
+        []() { KJ_FAIL_REQUIRE("total size of struct list is larger than max segment size"); });
     word* ptr = allocate(ref, segment, capTable, POINTER_SIZE_IN_WORDS + wordCount,
                          WirePointer::LIST, orphanArena);
 
@@ -1073,12 +1143,12 @@ struct WireHelpers {
 
     // Initialize the list tag.
     reinterpret_cast<WirePointer*>(ptr)->setKindAndInlineCompositeListElementCount(
-        WirePointer::STRUCT, elementCount);
+        WirePointer::STRUCT, checkedElementCount);
     reinterpret_cast<WirePointer*>(ptr)->structRef.set(elementSize);
     ptr += POINTER_SIZE_IN_WORDS;
 
     // Build the ListBuilder.
-    return ListBuilder(segment, capTable, ptr, wordsPerElement * BITS_PER_WORD, elementCount,
+    return ListBuilder(segment, capTable, ptr, wordsPerElement * BITS_PER_WORD, checkedElementCount,
                        elementSize.data * BITS_PER_WORD, elementSize.pointers,
                        ElementSize::INLINE_COMPOSITE);
   }
@@ -1136,8 +1206,8 @@ struct WireHelpers {
           "INLINE_COMPOSITE list with non-STRUCT elements not supported.");
       ptr += POINTER_SIZE_IN_WORDS;
 
-      WordCount dataSize = tag->structRef.dataSize.get();
-      WirePointerCount pointerCount = tag->structRef.ptrCount.get();
+      auto dataSize = tag->structRef.dataSize.get();
+      auto pointerCount = tag->structRef.ptrCount.get();
 
       switch (elementSize) {
         case ElementSize::VOID:
@@ -1156,14 +1226,14 @@ struct WireHelpers {
         case ElementSize::TWO_BYTES:
         case ElementSize::FOUR_BYTES:
         case ElementSize::EIGHT_BYTES:
-          KJ_REQUIRE(dataSize >= 1 * WORDS,
+          KJ_REQUIRE(dataSize >= ONE * WORDS,
                      "Existing list value is incompatible with expected type.") {
             goto useDefault;
           }
           break;
 
         case ElementSize::POINTER:
-          KJ_REQUIRE(pointerCount >= 1 * POINTERS,
+          KJ_REQUIRE(pointerCount >= ONE * POINTERS,
                      "Existing list value is incompatible with expected type.") {
             goto useDefault;
           }
@@ -1182,8 +1252,8 @@ struct WireHelpers {
                          tag->inlineCompositeListElementCount(),
                          dataSize * BITS_PER_WORD, pointerCount, ElementSize::INLINE_COMPOSITE);
     } else {
-      BitCount dataSize = dataBitsPerElement(oldSize) * ELEMENTS;
-      WirePointerCount pointerCount = pointersPerElement(oldSize) * ELEMENTS;
+      auto dataSize = dataBitsPerElement(oldSize) * ELEMENTS;
+      auto pointerCount = pointersPerElement(oldSize) * ELEMENTS;
 
       if (elementSize == ElementSize::BIT) {
         KJ_REQUIRE(oldSize == ElementSize::BIT,
@@ -1257,8 +1327,8 @@ struct WireHelpers {
                          tag->structRef.dataSize.get() * BITS_PER_WORD,
                          tag->structRef.ptrCount.get(), ElementSize::INLINE_COMPOSITE);
     } else {
-      BitCount dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
-      WirePointerCount pointerCount = pointersPerElement(elementSize) * ELEMENTS;
+      auto dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
+      auto pointerCount = pointersPerElement(elementSize) * ELEMENTS;
 
       auto step = (dataSize + pointerCount * BITS_PER_POINTER) / ELEMENTS;
       return ListBuilder(segment, capTable, ptr, step, ref->listRef.elementCount(),
@@ -1310,10 +1380,11 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      WordCount oldDataSize = oldTag->structRef.dataSize.get();
-      WirePointerCount oldPointerCount = oldTag->structRef.ptrCount.get();
+      auto oldDataSize = oldTag->structRef.dataSize.get();
+      auto oldPointerCount = oldTag->structRef.ptrCount.get();
       auto oldStep = (oldDataSize + oldPointerCount * WORDS_PER_POINTER) / ELEMENTS;
-      ElementCount elementCount = oldTag->inlineCompositeListElementCount();
+
+      auto elementCount = oldTag->inlineCompositeListElementCount();
 
       if (oldDataSize >= elementSize.data && oldPointerCount >= elementSize.pointers) {
         // Old size is at least as large as we need.  Ship it.
@@ -1325,10 +1396,13 @@ struct WireHelpers {
       // The structs in this list are smaller than expected, probably written using an older
       // version of the protocol.  We need to make a copy and expand them.
 
-      WordCount newDataSize = kj::max(oldDataSize, elementSize.data);
-      WirePointerCount newPointerCount = kj::max(oldPointerCount, elementSize.pointers);
+      auto newDataSize = kj::max(oldDataSize, elementSize.data);
+      auto newPointerCount = kj::max(oldPointerCount, elementSize.pointers);
       auto newStep = (newDataSize + newPointerCount * WORDS_PER_POINTER) / ELEMENTS;
-      WordCount totalSize = newStep * elementCount;
+
+      auto totalSize = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+            newStep * upgradeGuard<uint64_t>(elementCount),
+            []() { KJ_FAIL_REQUIRE("total size of struct list is larger than max segment size"); });
 
       // Don't let allocate() zero out the object just yet.
       zeroPointerAndFars(origSegment, origRef);
@@ -1344,35 +1418,39 @@ struct WireHelpers {
 
       word* src = oldPtr;
       word* dst = newPtr;
-      for (uint i = 0; i < elementCount / ELEMENTS; i++) {
+      for (auto i KJ_UNUSED: kj::zeroTo(elementCount)) {
         // Copy data section.
-        memcpy(dst, src, oldDataSize * BYTES_PER_WORD / BYTES);
+        copyMemory(dst, src, oldDataSize);
 
         // Copy pointer section.
         WirePointer* newPointerSection = reinterpret_cast<WirePointer*>(dst + newDataSize);
         WirePointer* oldPointerSection = reinterpret_cast<WirePointer*>(src + oldDataSize);
-        for (uint j = 0; j < oldPointerCount / POINTERS; j++) {
+        for (auto j: kj::zeroTo(oldPointerCount)) {
           transferPointer(origSegment, newPointerSection + j, oldSegment, oldPointerSection + j);
         }
 
-        dst += newStep * (1 * ELEMENTS);
-        src += oldStep * (1 * ELEMENTS);
+        dst += newStep * (ONE * ELEMENTS);
+        src += oldStep * (ONE * ELEMENTS);
       }
+
+      auto oldSize = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+            oldStep * upgradeGuard<uint64_t>(elementCount),
+            []() { KJ_FAIL_ASSERT("old size overflows but new size doesn't?"); });
 
       // Zero out old location.  See explanation in getWritableStructPointer().
       // Make sure to include the tag word.
-      memset(oldPtr - POINTER_SIZE_IN_WORDS, 0,
-             (POINTER_SIZE_IN_WORDS + oldStep * elementCount) * BYTES_PER_WORD / BYTES);
+      zeroMemory(oldPtr - POINTER_SIZE_IN_WORDS, oldSize + POINTER_SIZE_IN_WORDS);
 
       return ListBuilder(origSegment, capTable, newPtr, newStep * BITS_PER_WORD, elementCount,
-                         newDataSize * BITS_PER_WORD, newPointerCount, ElementSize::INLINE_COMPOSITE);
+                         newDataSize * BITS_PER_WORD, newPointerCount,
+                         ElementSize::INLINE_COMPOSITE);
     } else {
       // We're upgrading from a non-struct list.
 
-      BitCount oldDataSize = dataBitsPerElement(oldSize) * ELEMENTS;
-      WirePointerCount oldPointerCount = pointersPerElement(oldSize) * ELEMENTS;
+      auto oldDataSize = dataBitsPerElement(oldSize) * ELEMENTS;
+      auto oldPointerCount = pointersPerElement(oldSize) * ELEMENTS;
       auto oldStep = (oldDataSize + oldPointerCount * BITS_PER_POINTER) / ELEMENTS;
-      ElementCount elementCount = oldRef->listRef.elementCount();
+      auto elementCount = oldRef->listRef.elementCount();
 
       if (oldSize == ElementSize::VOID) {
         // Nothing to copy, just allocate a new list.
@@ -1386,18 +1464,20 @@ struct WireHelpers {
           goto useDefault;
         }
 
-        WordCount newDataSize = elementSize.data;
-        WirePointerCount newPointerCount = elementSize.pointers;
+        auto newDataSize = elementSize.data;
+        auto newPointerCount = elementSize.pointers;
 
         if (oldSize == ElementSize::POINTER) {
-          newPointerCount = kj::max(newPointerCount, 1 * POINTERS);
+          newPointerCount = kj::max(newPointerCount, ONE * POINTERS);
         } else {
           // Old list contains data elements, so we need at least 1 word of data.
-          newDataSize = kj::max(newDataSize, 1 * WORDS);
+          newDataSize = kj::max(newDataSize, ONE * WORDS);
         }
 
         auto newStep = (newDataSize + newPointerCount * WORDS_PER_POINTER) / ELEMENTS;
-        WordCount totalWords = elementCount * newStep;
+        auto totalWords = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+              newStep * upgradeGuard<uint64_t>(elementCount),
+              []() {KJ_FAIL_REQUIRE("total size of struct list is larger than max segment size");});
 
         // Don't let allocate() zero out the object just yet.
         zeroPointerAndFars(origSegment, origRef);
@@ -1414,24 +1494,29 @@ struct WireHelpers {
         if (oldSize == ElementSize::POINTER) {
           WirePointer* dst = reinterpret_cast<WirePointer*>(newPtr + newDataSize);
           WirePointer* src = reinterpret_cast<WirePointer*>(oldPtr);
-          for (uint i = 0; i < elementCount / ELEMENTS; i++) {
+          for (auto i KJ_UNUSED: kj::zeroTo(elementCount)) {
             transferPointer(origSegment, dst, oldSegment, src);
-            dst += newStep / WORDS_PER_POINTER * (1 * ELEMENTS);
+            dst += newStep / WORDS_PER_POINTER * (ONE * ELEMENTS);
             ++src;
           }
         } else {
-          word* dst = newPtr;
-          char* src = reinterpret_cast<char*>(oldPtr);
-          ByteCount oldByteStep = oldDataSize / BITS_PER_BYTE;
-          for (uint i = 0; i < elementCount / ELEMENTS; i++) {
-            memcpy(dst, src, oldByteStep / BYTES);
-            src += oldByteStep / BYTES;
-            dst += newStep * (1 * ELEMENTS);
+          byte* dst = reinterpret_cast<byte*>(newPtr);
+          byte* src = reinterpret_cast<byte*>(oldPtr);
+          auto newByteStep = newStep * (ONE * ELEMENTS) * BYTES_PER_WORD;
+          auto oldByteStep = oldDataSize / BITS_PER_BYTE;
+          for (auto i KJ_UNUSED: kj::zeroTo(elementCount)) {
+            copyMemory(dst, src, oldByteStep);
+            src += oldByteStep;
+            dst += newByteStep;
           }
         }
 
+        auto oldSize = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+              roundBitsUpToWords(oldStep * upgradeGuard<uint64_t>(elementCount)),
+              []() { KJ_FAIL_ASSERT("old size overflows but new size doesn't?"); });
+
         // Zero out old location.  See explanation in getWritableStructPointer().
-        memset(oldPtr, 0, roundBitsUpToBytes(oldStep * elementCount) / BYTES);
+        zeroMemory(oldPtr, oldSize);
 
         return ListBuilder(origSegment, capTable, newPtr, newStep * BITS_PER_WORD, elementCount,
                            newDataSize * BITS_PER_WORD, newPointerCount,
@@ -1441,46 +1526,50 @@ struct WireHelpers {
   }
 
   static KJ_ALWAYS_INLINE(SegmentAnd<Text::Builder> initTextPointer(
-      WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, ByteCount size,
+      WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, TextSize size,
       BuilderArena* orphanArena = nullptr)) {
     // The byte list must include a NUL terminator.
-    ByteCount byteSize = size + 1 * BYTES;
+    auto byteSize = size + ONE * BYTES;
 
     // Allocate the space.
     word* ptr = allocate(
         ref, segment, capTable, roundBytesUpToWords(byteSize), WirePointer::LIST, orphanArena);
 
     // Initialize the pointer.
-    ref->listRef.set(ElementSize::BYTE, byteSize * (1 * ELEMENTS / BYTES));
+    ref->listRef.set(ElementSize::BYTE, byteSize * (ONE * ELEMENTS / BYTES));
 
     // Build the Text::Builder.  This will initialize the NUL terminator.
-    return { segment, Text::Builder(reinterpret_cast<char*>(ptr), size / BYTES) };
+    return { segment, Text::Builder(reinterpret_cast<char*>(ptr), unguard(size / BYTES)) };
   }
 
   static KJ_ALWAYS_INLINE(SegmentAnd<Text::Builder> setTextPointer(
       WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, Text::Reader value,
       BuilderArena* orphanArena = nullptr)) {
-    auto allocation = initTextPointer(ref, segment, capTable, value.size() * BYTES, orphanArena);
+    TextSize size = assertMax<MAX_TEXT_SIZE>(guarded(value.size()),
+        []() { KJ_FAIL_REQUIRE("text blob too big"); }) * BYTES;
+
+    auto allocation = initTextPointer(ref, segment, capTable, size, orphanArena);
     memcpy(allocation.value.begin(), value.begin(), value.size());
     return allocation;
   }
 
   static KJ_ALWAYS_INLINE(Text::Builder getWritableTextPointer(
       WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable,
-      const void* defaultValue, ByteCount defaultSize)) {
-    return getWritableTextPointer(ref, ref->target(), segment, capTable, defaultValue, defaultSize);
+      const void* defaultValue, TextSize defaultSize)) {
+    return getWritableTextPointer(ref, ref->target(), segment,capTable,  defaultValue, defaultSize);
   }
 
   static KJ_ALWAYS_INLINE(Text::Builder getWritableTextPointer(
       WirePointer* ref, word* refTarget, SegmentBuilder* segment, CapTableBuilder* capTable,
-      const void* defaultValue, ByteCount defaultSize)) {
+      const void* defaultValue, TextSize defaultSize)) {
     if (ref->isNull()) {
     useDefault:
-      if (defaultSize == 0 * BYTES) {
+      if (defaultSize == ZERO * BYTES) {
         return nullptr;
       } else {
         Text::Builder builder = initTextPointer(ref, segment, capTable, defaultSize).value;
-        memcpy(builder.begin(), defaultValue, defaultSize / BYTES);
+        copyMemory(builder.asBytes().begin(), reinterpret_cast<const byte*>(defaultValue),
+                   defaultSize);
         return builder;
       }
     } else {
@@ -1492,52 +1581,56 @@ struct WireHelpers {
       KJ_REQUIRE(ref->listRef.elementSize() == ElementSize::BYTE,
           "Called getText{Field,Element}() but existing list pointer is not byte-sized.");
 
-      size_t size = ref->listRef.elementCount() / ELEMENTS;
-      KJ_REQUIRE(size > 0 && cptr[size-1] == '\0', "Text blob missing NUL terminator.") {
+      size_t size = unguard(subtractChecked(ref->listRef.elementCount() / ELEMENTS, ONE,
+          []() { KJ_FAIL_REQUIRE("zero-size blob can't be text (need NUL terminator)"); }));
+      KJ_REQUIRE(cptr[size] == '\0', "Text blob missing NUL terminator.") {
         goto useDefault;
       }
 
-      return Text::Builder(cptr, size - 1);
+      return Text::Builder(cptr, size);
     }
   }
 
   static KJ_ALWAYS_INLINE(SegmentAnd<Data::Builder> initDataPointer(
-      WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, ByteCount size,
+      WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, BlobSize size,
       BuilderArena* orphanArena = nullptr)) {
     // Allocate the space.
     word* ptr = allocate(ref, segment, capTable, roundBytesUpToWords(size),
                          WirePointer::LIST, orphanArena);
 
     // Initialize the pointer.
-    ref->listRef.set(ElementSize::BYTE, size * (1 * ELEMENTS / BYTES));
+    ref->listRef.set(ElementSize::BYTE, size * (ONE * ELEMENTS / BYTES));
 
     // Build the Data::Builder.
-    return { segment, Data::Builder(reinterpret_cast<byte*>(ptr), size / BYTES) };
+    return { segment, Data::Builder(reinterpret_cast<byte*>(ptr), unguard(size / BYTES)) };
   }
 
   static KJ_ALWAYS_INLINE(SegmentAnd<Data::Builder> setDataPointer(
       WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable, Data::Reader value,
       BuilderArena* orphanArena = nullptr)) {
-    auto allocation = initDataPointer(ref, segment, capTable, value.size() * BYTES, orphanArena);
+    BlobSize size = assertMaxBits<BLOB_SIZE_BITS>(guarded(value.size()),
+        []() { KJ_FAIL_REQUIRE("text blob too big"); }) * BYTES;
+
+    auto allocation = initDataPointer(ref, segment, capTable, size, orphanArena);
     memcpy(allocation.value.begin(), value.begin(), value.size());
     return allocation;
   }
 
   static KJ_ALWAYS_INLINE(Data::Builder getWritableDataPointer(
       WirePointer* ref, SegmentBuilder* segment, CapTableBuilder* capTable,
-      const void* defaultValue, ByteCount defaultSize)) {
+      const void* defaultValue, BlobSize defaultSize)) {
     return getWritableDataPointer(ref, ref->target(), segment, capTable, defaultValue, defaultSize);
   }
 
   static KJ_ALWAYS_INLINE(Data::Builder getWritableDataPointer(
       WirePointer* ref, word* refTarget, SegmentBuilder* segment, CapTableBuilder* capTable,
-      const void* defaultValue, ByteCount defaultSize)) {
+      const void* defaultValue, BlobSize defaultSize)) {
     if (ref->isNull()) {
-      if (defaultSize == 0 * BYTES) {
+      if (defaultSize == ZERO * BYTES) {
         return nullptr;
       } else {
         Data::Builder builder = initDataPointer(ref, segment, capTable, defaultSize).value;
-        memcpy(builder.begin(), defaultValue, defaultSize / BYTES);
+        copyMemory(builder.begin(), reinterpret_cast<const byte*>(defaultValue), defaultSize);
         return builder;
       }
     } else {
@@ -1548,15 +1641,17 @@ struct WireHelpers {
       KJ_REQUIRE(ref->listRef.elementSize() == ElementSize::BYTE,
           "Called getData{Field,Element}() but existing list pointer is not byte-sized.");
 
-      return Data::Builder(reinterpret_cast<byte*>(ptr), ref->listRef.elementCount() / ELEMENTS);
+      return Data::Builder(reinterpret_cast<byte*>(ptr),
+          unguard(ref->listRef.elementCount() / ELEMENTS));
     }
   }
 
   static SegmentAnd<word*> setStructPointer(
       SegmentBuilder* segment, CapTableBuilder* capTable, WirePointer* ref, StructReader value,
       BuilderArena* orphanArena = nullptr, bool canonical = false) {
-    ByteCount dataSize = roundBitsUpToBytes(value.dataSize);
-    WirePointerCount ptrCount = value.pointerCount;
+    // TODO(now): Function may have been damaged in merge conflict resolution.
+    auto dataSize = roundBitsUpToBytes(value.dataSize);
+    auto ptrCount = value.pointerCount;
 
     if (canonical) {
       // StructReaders should not have bitwidths other than 1, but let's be safe
@@ -1604,17 +1699,19 @@ struct WireHelpers {
     word* ptr = allocate(ref, segment, capTable, totalSize, WirePointer::STRUCT, orphanArena);
     ref->structRef.set(dataWords, ptrCount);
 
-    if (value.dataSize == 1 * BITS) {
+    if (value.dataSize == ONE * BITS) {
       // Data size could be made 0 by truncation
-      if (dataSize != 0 * BYTES) {
-        *reinterpret_cast<char*>(ptr) = value.getDataField<bool>(0 * ELEMENTS);
+      if (dataSize != ZERO * BYTES) {
+        *reinterpret_cast<char*>(ptr) = value.getDataField<bool>(ZERO * ELEMENTS);
       }
     } else {
-      memcpy(ptr, value.data, dataSize / BYTES);
+      copyMemory(reinterpret_cast<byte*>(ptr),
+                 reinterpret_cast<const byte*>(value.data),
+                 dataSize);
     }
 
     WirePointer* pointerSection = reinterpret_cast<WirePointer*>(ptr + dataWords);
-    for (uint i = 0; i < ptrCount / POINTERS; i++) {
+    for (auto i: kj::zeroTo(ptrCount)) {
       copyPointer(segment, capTable, pointerSection + i,
                   value.segment, value.capTable, value.pointers + i,
                   value.nestingLimit, nullptr, canonical);
@@ -1641,7 +1738,10 @@ struct WireHelpers {
   static SegmentAnd<word*> setListPointer(
       SegmentBuilder* segment, CapTableBuilder* capTable, WirePointer* ref, ListReader value,
       BuilderArena* orphanArena = nullptr, bool canonical = false) {
-    WordCount totalSize = roundBitsUpToWords(value.elementCount * value.step);
+    // TODO(now): Function may have been damaged in merge conflict resolution.
+    auto totalSize = assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS>() - 1>(
+        roundBitsUpToWords(upgradeGuard<uint64_t>(value.elementCount) * value.step),
+        []() { KJ_FAIL_ASSERT("encountered impossibly long struct list ListReader"); });
 
     if (value.elementSize != ElementSize::INLINE_COMPOSITE) {
       // List of non-structs.
@@ -1650,7 +1750,7 @@ struct WireHelpers {
       if (value.elementSize == ElementSize::POINTER) {
         // List of pointers.
         ref->listRef.set(ElementSize::POINTER, value.elementCount);
-        for (uint i = 0; i < value.elementCount / ELEMENTS; i++) {
+        for (auto i: zeroTo(value.elementCount * (ONE * POINTERS / ELEMENTS))) {
           copyPointer(segment, capTable, reinterpret_cast<WirePointer*>(ptr) + i,
                       value.segment, value.capTable,
                       reinterpret_cast<const WirePointer*>(value.ptr) + i,
@@ -1659,14 +1759,12 @@ struct WireHelpers {
       } else {
         // List of data.
         ref->listRef.set(value.elementSize, value.elementCount);
-        memcpy(ptr, value.ptr, totalSize * BYTES_PER_WORD / BYTES);
+        copyMemory(ptr, reinterpret_cast<const word*>(value.ptr), totalSize);
       }
 
       return { segment, ptr };
     } else {
       // List of structs.
-      KJ_DASSERT(value.structDataSize % BITS_PER_WORD == 0 * BITS);
-
       WordCount declDataSize = value.structDataSize / BITS_PER_WORD;
       WirePointerCount declPointerCount = value.structPointerCount;
 
@@ -1711,6 +1809,7 @@ struct WireHelpers {
         ptrCount = declPointerCount;
       }
 
+      KJ_DASSERT(value.structDataSize % BITS_PER_WORD == 0 * BITS);
       word* ptr = allocate(ref, segment, capTable, totalSize + POINTER_SIZE_IN_WORDS,
                            WirePointer::LIST, orphanArena);
       ref->listRef.setInlineComposite(totalSize);
@@ -1721,12 +1820,12 @@ struct WireHelpers {
       word* dst = ptr + POINTER_SIZE_IN_WORDS;
 
       const word* src = reinterpret_cast<const word*>(value.ptr);
-      for (uint i = 0; i < value.elementCount / ELEMENTS; i++) {
-        memcpy(dst, src, dataSize * BYTES_PER_WORD / BYTES);
+      for (auto i KJ_UNUSED: kj::zeroTo(value.elementCount)) {
+        copyMemory(dst, src, dataSize);
         dst += dataSize;
         src += declDataSize;
 
-        for (uint j = 0; j < ptrCount / POINTERS; j++) {
+        for (auto j KJ_UNUSED: kj::zeroTo(ptrCount)) {
           copyPointer(segment, capTable, reinterpret_cast<WirePointer*>(dst),
               value.segment, value.capTable, reinterpret_cast<const WirePointer*>(src),
               value.nestingLimit, nullptr, canonical);
@@ -1802,7 +1901,7 @@ struct WireHelpers {
         }
 
         if (elementSize == ElementSize::INLINE_COMPOSITE) {
-          WordCount wordCount = src->listRef.inlineCompositeWordCount();
+          auto wordCount = src->listRef.inlineCompositeWordCount();
           const WirePointer* tag = reinterpret_cast<const WirePointer*>(ptr);
           ptr += POINTER_SIZE_IN_WORDS;
 
@@ -1816,10 +1915,10 @@ struct WireHelpers {
             goto useDefault;
           }
 
-          ElementCount elementCount = tag->inlineCompositeListElementCount();
+          auto elementCount = tag->inlineCompositeListElementCount();
           auto wordsPerElement = tag->structRef.wordSize() / ELEMENTS;
 
-          KJ_REQUIRE(wordsPerElement * ElementCount64(elementCount) <= wordCount,
+          KJ_REQUIRE(wordsPerElement * upgradeGuard<uint64_t>(elementCount) <= wordCount,
                      "INLINE_COMPOSITE list's elements overrun its word count.") {
             goto useDefault;
           }
@@ -1841,11 +1940,11 @@ struct WireHelpers {
                          nestingLimit - 1),
               orphanArena, canonical);
         } else {
-          BitCount dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
-          WirePointerCount pointerCount = pointersPerElement(elementSize) * ELEMENTS;
+          auto dataSize = dataBitsPerElement(elementSize) * ELEMENTS;
+          auto pointerCount = pointersPerElement(elementSize) * ELEMENTS;
           auto step = (dataSize + pointerCount * BITS_PER_POINTER) / ELEMENTS;
-          ElementCount elementCount = src->listRef.elementCount();
-          WordCount64 wordCount = roundBitsUpToWords(ElementCount64(elementCount) * step);
+          auto elementCount = src->listRef.elementCount();
+          auto wordCount = roundBitsUpToWords(upgradeGuard<uint64_t>(elementCount) * step);
 
           KJ_REQUIRE(boundsCheck(srcSegment, ptr, ptr + wordCount),
                      "Message contains out-of-bounds list pointer.") {
@@ -2081,15 +2180,7 @@ struct WireHelpers {
 
     ElementSize elementSize = ref->listRef.elementSize();
     if (elementSize == ElementSize::INLINE_COMPOSITE) {
-#if _MSC_VER
-      // TODO(msvc): MSVC thinks decltype(WORDS/ELEMENTS) is a const type. /eyeroll
-      uint wordsPerElement;
-#else
-      decltype(WORDS/ELEMENTS) wordsPerElement;
-#endif
-      ElementCount size;
-
-      WordCount wordCount = ref->listRef.inlineCompositeWordCount();
+      auto wordCount = ref->listRef.inlineCompositeWordCount();
 
       // An INLINE_COMPOSITE list points to a tag, which is formatted like a pointer.
       const WirePointer* tag = reinterpret_cast<const WirePointer*>(ptr);
@@ -2105,18 +2196,18 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      size = tag->inlineCompositeListElementCount();
-      wordsPerElement = tag->structRef.wordSize() / ELEMENTS;
+      auto size = tag->inlineCompositeListElementCount();
+      auto wordsPerElement = tag->structRef.wordSize() / ELEMENTS;
 
-      KJ_REQUIRE(ElementCount64(size) * wordsPerElement <= wordCount,
+      KJ_REQUIRE(upgradeGuard<uint64_t>(size) * wordsPerElement <= wordCount,
                  "INLINE_COMPOSITE list's elements overrun its word count.") {
         goto useDefault;
       }
 
-      if (wordsPerElement * (1 * ELEMENTS) == 0 * WORDS) {
+      if (wordsPerElement * (ONE * ELEMENTS) == ZERO * WORDS) {
         // Watch out for lists of zero-sized structs, which can claim to be arbitrarily large
         // without having sent actual data.
-        KJ_REQUIRE(amplifiedRead(segment, size * (1 * WORDS / ELEMENTS)),
+        KJ_REQUIRE(amplifiedRead(segment, size * (ONE * WORDS / ELEMENTS)),
                    "Message contains amplified list pointer.") {
           goto useDefault;
         }
@@ -2145,7 +2236,7 @@ struct WireHelpers {
           case ElementSize::TWO_BYTES:
           case ElementSize::FOUR_BYTES:
           case ElementSize::EIGHT_BYTES:
-            KJ_REQUIRE(tag->structRef.dataSize.get() > 0 * WORDS,
+            KJ_REQUIRE(tag->structRef.dataSize.get() > ZERO * WORDS,
                        "Expected a primitive list, but got a list of pointer-only structs.") {
               goto useDefault;
             }
@@ -2156,7 +2247,7 @@ struct WireHelpers {
             // in the struct is the pointer we were looking for, we want to munge the pointer to
             // point at the first element's pointer section.
             ptr += tag->structRef.dataSize.get();
-            KJ_REQUIRE(tag->structRef.ptrCount.get() > 0 * POINTERS,
+            KJ_REQUIRE(tag->structRef.ptrCount.get() > ZERO * POINTERS,
                        "Expected a pointer list, but got a list of data-only structs.") {
               goto useDefault;
             }
@@ -2176,22 +2267,21 @@ struct WireHelpers {
     } else {
       // This is a primitive or pointer list, but all such lists can also be interpreted as struct
       // lists.  We need to compute the data size and pointer count for such structs.
-      BitCount dataSize = dataBitsPerElement(ref->listRef.elementSize()) * ELEMENTS;
-      WirePointerCount pointerCount =
-          pointersPerElement(ref->listRef.elementSize()) * ELEMENTS;
-      ElementCount elementCount = ref->listRef.elementCount();
+      auto dataSize = dataBitsPerElement(ref->listRef.elementSize()) * ELEMENTS;
+      auto pointerCount = pointersPerElement(ref->listRef.elementSize()) * ELEMENTS;
+      auto elementCount = ref->listRef.elementCount();
       auto step = (dataSize + pointerCount * BITS_PER_POINTER) / ELEMENTS;
 
-      WordCount wordCount = roundBitsUpToWords(ElementCount64(elementCount) * step);
+      auto wordCount = roundBitsUpToWords(upgradeGuard<uint64_t>(elementCount) * step);
       KJ_REQUIRE(boundsCheck(segment, ptr, ptr + wordCount),
-                 "Message contains out-of-bounds list pointer.") {
+            "Message contains out-of-bounds list pointer.") {
         goto useDefault;
       }
 
       if (elementSize == ElementSize::VOID) {
         // Watch out for lists of void, which can claim to be arbitrarily large without having sent
         // actual data.
-        KJ_REQUIRE(amplifiedRead(segment, elementCount * (1 * WORDS / ELEMENTS)),
+        KJ_REQUIRE(amplifiedRead(segment, elementCount * (ONE * WORDS / ELEMENTS)),
                    "Message contains amplified list pointer.") {
           goto useDefault;
         }
@@ -2243,7 +2333,8 @@ struct WireHelpers {
     if (ref->isNull()) {
     useDefault:
       if (defaultValue == nullptr) defaultValue = "";
-      return Text::Reader(reinterpret_cast<const char*>(defaultValue), defaultSize / BYTES);
+      return Text::Reader(reinterpret_cast<const char*>(defaultValue),
+          unguard(defaultSize / BYTES));
     } else {
       const word* ptr = followFars(ref, refTarget, segment);
 
@@ -2252,7 +2343,7 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      uint size = ref->listRef.elementCount() / ELEMENTS;
+      auto size = ref->listRef.elementCount() * (ONE * BYTES / ELEMENTS);
 
       KJ_REQUIRE(ref->kind() == WirePointer::LIST,
                  "Message contains non-list pointer where text was expected.") {
@@ -2264,39 +2355,39 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      KJ_REQUIRE(boundsCheck(segment, ptr, ptr +
-                     roundBytesUpToWords(ref->listRef.elementCount() * (1 * BYTES / ELEMENTS))),
+      KJ_REQUIRE(boundsCheck(segment, ptr, ptr + roundBytesUpToWords(size)),
                  "Message contained out-of-bounds text pointer.") {
         goto useDefault;
       }
 
-      KJ_REQUIRE(size > 0, "Message contains text that is not NUL-terminated.") {
+      KJ_REQUIRE(size > ZERO * BYTES, "Message contains text that is not NUL-terminated.") {
         goto useDefault;
       }
 
       const char* cptr = reinterpret_cast<const char*>(ptr);
-      --size;  // NUL terminator
+      uint unguardedSize = unguard(size / BYTES) - 1;
 
-      KJ_REQUIRE(cptr[size] == '\0', "Message contains text that is not NUL-terminated.") {
+      KJ_REQUIRE(cptr[unguardedSize] == '\0', "Message contains text that is not NUL-terminated.") {
         goto useDefault;
       }
 
-      return Text::Reader(cptr, size);
+      return Text::Reader(cptr, unguardedSize);
     }
   }
 
   static KJ_ALWAYS_INLINE(Data::Reader readDataPointer(
       SegmentReader* segment, const WirePointer* ref,
-      const void* defaultValue, ByteCount defaultSize)) {
+      const void* defaultValue, BlobSize defaultSize)) {
     return readDataPointer(segment, ref, ref->target(), defaultValue, defaultSize);
   }
 
   static KJ_ALWAYS_INLINE(Data::Reader readDataPointer(
       SegmentReader* segment, const WirePointer* ref, const word* refTarget,
-      const void* defaultValue, ByteCount defaultSize)) {
+      const void* defaultValue, BlobSize defaultSize)) {
     if (ref->isNull()) {
     useDefault:
-      return Data::Reader(reinterpret_cast<const byte*>(defaultValue), defaultSize / BYTES);
+      return Data::Reader(reinterpret_cast<const byte*>(defaultValue),
+          unguard(defaultSize / BYTES));
     } else {
       const word* ptr = followFars(ref, refTarget, segment);
 
@@ -2305,7 +2396,7 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      uint size = ref->listRef.elementCount() / ELEMENTS;
+      auto size = ref->listRef.elementCount() * (ONE * BYTES / ELEMENTS);
 
       KJ_REQUIRE(ref->kind() == WirePointer::LIST,
                  "Message contains non-list pointer where data was expected.") {
@@ -2317,13 +2408,12 @@ struct WireHelpers {
         goto useDefault;
       }
 
-      KJ_REQUIRE(boundsCheck(segment, ptr, ptr +
-                     roundBytesUpToWords(ref->listRef.elementCount() * (1 * BYTES / ELEMENTS))),
+      KJ_REQUIRE(boundsCheck(segment, ptr, ptr + roundBytesUpToWords(size)),
                  "Message contained out-of-bounds data pointer.") {
         goto useDefault;
       }
 
-      return Data::Reader(reinterpret_cast<const byte*>(ptr), size);
+      return Data::Reader(reinterpret_cast<const byte*>(ptr), unguard(size / BYTES));
     }
   }
 };
@@ -2362,7 +2452,8 @@ ListBuilder PointerBuilder::getListAnySize(const word* defaultValue) {
 
 template <>
 Text::Builder PointerBuilder::initBlob<Text>(ByteCount size) {
-  return WireHelpers::initTextPointer(pointer, segment, capTable, size).value;
+  return WireHelpers::initTextPointer(pointer, segment, capTable,
+      assertMax<MAX_TEXT_SIZE>(size, ThrowOverflow())).value;
 }
 template <>
 void PointerBuilder::setBlob<Text>(Text::Reader value) {
@@ -2370,12 +2461,14 @@ void PointerBuilder::setBlob<Text>(Text::Reader value) {
 }
 template <>
 Text::Builder PointerBuilder::getBlob<Text>(const void* defaultValue, ByteCount defaultSize) {
-  return WireHelpers::getWritableTextPointer(pointer, segment, capTable, defaultValue, defaultSize);
+  return WireHelpers::getWritableTextPointer(pointer, segment, capTable, defaultValue,
+      assertMax<MAX_TEXT_SIZE>(defaultSize, ThrowOverflow()));
 }
 
 template <>
 Data::Builder PointerBuilder::initBlob<Data>(ByteCount size) {
-  return WireHelpers::initDataPointer(pointer, segment, capTable, size).value;
+  return WireHelpers::initDataPointer(pointer, segment, capTable,
+      assertMaxBits<BLOB_SIZE_BITS>(size, ThrowOverflow())).value;
 }
 template <>
 void PointerBuilder::setBlob<Data>(Data::Reader value) {
@@ -2383,7 +2476,8 @@ void PointerBuilder::setBlob<Data>(Data::Reader value) {
 }
 template <>
 Data::Builder PointerBuilder::getBlob<Data>(const void* defaultValue, ByteCount defaultSize) {
-  return WireHelpers::getWritableDataPointer(pointer, segment, capTable, defaultValue, defaultSize);
+  return WireHelpers::getWritableDataPointer(pointer, segment, capTable, defaultValue,
+      assertMaxBits<BLOB_SIZE_BITS>(defaultSize, ThrowOverflow()));
 }
 
 void PointerBuilder::setStruct(const StructReader& value, bool canonical) {
@@ -2521,7 +2615,8 @@ Text::Reader PointerReader::getBlob<Text>(const void* defaultValue, ByteCount de
 template <>
 Data::Reader PointerReader::getBlob<Data>(const void* defaultValue, ByteCount defaultSize) const {
   const WirePointer* ref = pointer == nullptr ? &zero.pointer : pointer;
-  return WireHelpers::readDataPointer(segment, ref, defaultValue, defaultSize);
+  return WireHelpers::readDataPointer(segment, ref, defaultValue,
+      assertMaxBits<BLOB_SIZE_BITS>(defaultSize, ThrowOverflow()));
 }
 
 #if !CAPNP_LITE
@@ -2537,7 +2632,7 @@ const word* PointerReader::getUnchecked() const {
 }
 
 MessageSizeCounts PointerReader::targetSize() const {
-  return pointer == nullptr ? MessageSizeCounts { 0 * WORDS, 0 }
+  return pointer == nullptr ? MessageSizeCounts { ZERO * WORDS, 0 }
                             : WireHelpers::totalSize(segment, pointer, nestingLimit);
 }
 
@@ -2615,89 +2710,96 @@ bool PointerReader::isCanonical(const word **readHead) {
 // StructBuilder
 
 void StructBuilder::clearAll() {
-  if (dataSize == 1 * BITS) {
-    setDataField<bool>(1 * ELEMENTS, false);
+  if (dataSize == ONE * BITS) {
+    setDataField<bool>(ONE * ELEMENTS, false);
   } else {
-    memset(data, 0, dataSize / BITS_PER_BYTE / BYTES);
+    WireHelpers::zeroMemory(reinterpret_cast<byte*>(data), dataSize / BITS_PER_BYTE);
   }
 
-  for (uint i = 0; i < pointerCount / POINTERS; i++) {
+  for (auto i: kj::zeroTo(pointerCount)) {
     WireHelpers::zeroObject(segment, capTable, pointers + i);
   }
-  memset(pointers, 0, pointerCount * BYTES_PER_POINTER / BYTES);
+  WireHelpers::zeroMemory(pointers, pointerCount);
 }
 
 void StructBuilder::transferContentFrom(StructBuilder other) {
   // Determine the amount of data the builders have in common.
-  BitCount sharedDataSize = kj::min(dataSize, other.dataSize);
+  auto sharedDataSize = kj::min(dataSize, other.dataSize);
 
   if (dataSize > sharedDataSize) {
     // Since the target is larger than the source, make sure to zero out the extra bits that the
     // source doesn't have.
-    if (dataSize == 1 * BITS) {
-      setDataField<bool>(0 * ELEMENTS, false);
+    if (dataSize == ONE * BITS) {
+      setDataField<bool>(ZERO * ELEMENTS, false);
     } else {
-      byte* unshared = reinterpret_cast<byte*>(data) + sharedDataSize / BITS_PER_BYTE / BYTES;
-      memset(unshared, 0, (dataSize - sharedDataSize) / BITS_PER_BYTE / BYTES);
+      byte* unshared = reinterpret_cast<byte*>(data) + sharedDataSize / BITS_PER_BYTE;
+      // Note: this subtraction can't fail due to the if() above
+      WireHelpers::zeroMemory(unshared,
+          subtractChecked(dataSize, sharedDataSize, []() {}) / BITS_PER_BYTE);
     }
   }
 
   // Copy over the shared part.
-  if (sharedDataSize == 1 * BITS) {
-    setDataField<bool>(0 * ELEMENTS, other.getDataField<bool>(0 * ELEMENTS));
+  if (sharedDataSize == ONE * BITS) {
+    setDataField<bool>(ZERO * ELEMENTS, other.getDataField<bool>(ZERO * ELEMENTS));
   } else {
-    memcpy(data, other.data, sharedDataSize / BITS_PER_BYTE / BYTES);
+    WireHelpers::copyMemory(reinterpret_cast<byte*>(data),
+                            reinterpret_cast<byte*>(other.data),
+                            sharedDataSize / BITS_PER_BYTE);
   }
 
   // Zero out all pointers in the target.
-  for (uint i = 0; i < pointerCount / POINTERS; i++) {
+  for (auto i: kj::zeroTo(pointerCount)) {
     WireHelpers::zeroObject(segment, capTable, pointers + i);
   }
-  memset(pointers, 0, pointerCount * BYTES_PER_POINTER / BYTES);
+  WireHelpers::zeroMemory(pointers, pointerCount);
 
   // Transfer the pointers.
-  WirePointerCount sharedPointerCount = kj::min(pointerCount, other.pointerCount);
-  for (uint i = 0; i < sharedPointerCount / POINTERS; i++) {
+  auto sharedPointerCount = kj::min(pointerCount, other.pointerCount);
+  for (auto i: kj::zeroTo(sharedPointerCount)) {
     WireHelpers::transferPointer(segment, pointers + i, other.segment, other.pointers + i);
   }
 
   // Zero out the pointers that were transferred in the source because it no longer has ownership.
   // If the source had any extra pointers that the destination didn't have space for, we
   // intentionally leave them be, so that they'll be cleaned up later.
-  memset(other.pointers, 0, sharedPointerCount * BYTES_PER_POINTER / BYTES);
+  WireHelpers::zeroMemory(other.pointers, sharedPointerCount);
 }
 
 void StructBuilder::copyContentFrom(StructReader other) {
   // Determine the amount of data the builders have in common.
-  BitCount sharedDataSize = kj::min(dataSize, other.dataSize);
+  auto sharedDataSize = kj::min(dataSize, other.dataSize);
 
   if (dataSize > sharedDataSize) {
     // Since the target is larger than the source, make sure to zero out the extra bits that the
     // source doesn't have.
-    if (dataSize == 1 * BITS) {
-      setDataField<bool>(0 * ELEMENTS, false);
+    if (dataSize == ONE * BITS) {
+      setDataField<bool>(ZERO * ELEMENTS, false);
     } else {
-      byte* unshared = reinterpret_cast<byte*>(data) + sharedDataSize / BITS_PER_BYTE / BYTES;
-      memset(unshared, 0, (dataSize - sharedDataSize) / BITS_PER_BYTE / BYTES);
+      byte* unshared = reinterpret_cast<byte*>(data) + sharedDataSize / BITS_PER_BYTE;
+      WireHelpers::zeroMemory(unshared,
+          subtractChecked(dataSize, sharedDataSize, []() {}) / BITS_PER_BYTE);
     }
   }
 
   // Copy over the shared part.
-  if (sharedDataSize == 1 * BITS) {
-    setDataField<bool>(0 * ELEMENTS, other.getDataField<bool>(0 * ELEMENTS));
+  if (sharedDataSize == ONE * BITS) {
+    setDataField<bool>(ZERO * ELEMENTS, other.getDataField<bool>(ZERO * ELEMENTS));
   } else {
-    memcpy(data, other.data, sharedDataSize / BITS_PER_BYTE / BYTES);
+    WireHelpers::copyMemory(reinterpret_cast<byte*>(data),
+                            reinterpret_cast<const byte*>(other.data),
+                            sharedDataSize / BITS_PER_BYTE);
   }
 
   // Zero out all pointers in the target.
-  for (uint i = 0; i < pointerCount / POINTERS; i++) {
+  for (auto i: kj::zeroTo(pointerCount)) {
     WireHelpers::zeroObject(segment, capTable, pointers + i);
   }
-  memset(pointers, 0, pointerCount * BYTES_PER_POINTER / BYTES);
+  WireHelpers::zeroMemory(pointers, pointerCount);
 
   // Copy the pointers.
-  WirePointerCount sharedPointerCount = kj::min(pointerCount, other.pointerCount);
-  for (uint i = 0; i < sharedPointerCount / POINTERS; i++) {
+  auto sharedPointerCount = kj::min(pointerCount, other.pointerCount);
+  for (auto i: kj::zeroTo(sharedPointerCount)) {
     WireHelpers::copyPointer(segment, capTable, pointers + i,
         other.segment, other.capTable, other.pointers + i, other.nestingLimit);
   }
@@ -2729,7 +2831,7 @@ MessageSizeCounts StructReader::totalSize() const {
   MessageSizeCounts result = {
     WireHelpers::roundBitsUpToWords(dataSize) + pointerCount * WORDS_PER_POINTER, 0 };
 
-  for (uint i = 0; i < pointerCount / POINTERS; i++) {
+  for (auto i: kj::zeroTo(pointerCount)) {
     result += WireHelpers::totalSize(segment, pointers + i, nestingLimit);
   }
 
@@ -2812,12 +2914,12 @@ bool StructReader::isCanonical(const word **readHead,
 // ListBuilder
 
 Text::Builder ListBuilder::asText() {
-  KJ_REQUIRE(structDataSize == 8 * BITS && structPointerCount == 0 * POINTERS,
+  KJ_REQUIRE(structDataSize == G(8) * BITS && structPointerCount == ZERO * POINTERS,
              "Expected Text, got list of non-bytes.") {
     return Text::Builder();
   }
 
-  size_t size = elementCount / ELEMENTS;
+  size_t size = unguard(elementCount / ELEMENTS);
 
   KJ_REQUIRE(size > 0, "Message contains text that is not NUL-terminated.") {
     return Text::Builder();
@@ -2834,18 +2936,18 @@ Text::Builder ListBuilder::asText() {
 }
 
 Data::Builder ListBuilder::asData() {
-  KJ_REQUIRE(structDataSize == 8 * BITS && structPointerCount == 0 * POINTERS,
+  KJ_REQUIRE(structDataSize == G(8) * BITS && structPointerCount == ZERO * POINTERS,
              "Expected Text, got list of non-bytes.") {
     return Data::Builder();
   }
 
-  return Data::Builder(reinterpret_cast<byte*>(ptr), elementCount / ELEMENTS);
+  return Data::Builder(reinterpret_cast<byte*>(ptr), unguard(elementCount / ELEMENTS));
 }
 
 StructBuilder ListBuilder::getStructElement(ElementCount index) {
-  BitCount64 indexBit = ElementCount64(index) * step;
+  auto indexBit = upgradeGuard<uint64_t>(index) * step;
   byte* structData = ptr + indexBit / BITS_PER_BYTE;
-  KJ_DASSERT(indexBit % BITS_PER_BYTE == 0 * BITS);
+  KJ_DASSERT(indexBit % BITS_PER_BYTE == ZERO * BITS);
   return StructBuilder(segment, capTable, structData,
       reinterpret_cast<WirePointer*>(structData + structDataSize / BITS_PER_BYTE),
       structDataSize, structPointerCount);
@@ -2874,12 +2976,12 @@ ListBuilder ListBuilder::imbue(CapTableBuilder* capTable) {
 // ListReader
 
 Text::Reader ListReader::asText() {
-  KJ_REQUIRE(structDataSize == 8 * BITS && structPointerCount == 0 * POINTERS,
+  KJ_REQUIRE(structDataSize == G(8) * BITS && structPointerCount == ZERO * POINTERS,
              "Expected Text, got list of non-bytes.") {
     return Text::Reader();
   }
 
-  size_t size = elementCount / ELEMENTS;
+  size_t size = unguard(elementCount / ELEMENTS);
 
   KJ_REQUIRE(size > 0, "Message contains text that is not NUL-terminated.") {
     return Text::Reader();
@@ -2896,12 +2998,12 @@ Text::Reader ListReader::asText() {
 }
 
 Data::Reader ListReader::asData() {
-  KJ_REQUIRE(structDataSize == 8 * BITS && structPointerCount == 0 * POINTERS,
+  KJ_REQUIRE(structDataSize == G(8) * BITS && structPointerCount == ZERO * POINTERS,
              "Expected Text, got list of non-bytes.") {
     return Data::Reader();
   }
 
-  return Data::Reader(reinterpret_cast<const byte*>(ptr), elementCount / ELEMENTS);
+  return Data::Reader(reinterpret_cast<const byte*>(ptr), unguard(elementCount / ELEMENTS));
 }
 
 kj::ArrayPtr<const byte> ListReader::asRawBytes() {
@@ -2920,17 +3022,17 @@ StructReader ListReader::getStructElement(ElementCount index) const {
     return StructReader();
   }
 
-  BitCount64 indexBit = ElementCount64(index) * step;
+  auto indexBit = upgradeGuard<uint64_t>(index) * step;
   const byte* structData = ptr + indexBit / BITS_PER_BYTE;
   const WirePointer* structPointers =
       reinterpret_cast<const WirePointer*>(structData + structDataSize / BITS_PER_BYTE);
 
   // This check should pass if there are no bugs in the list pointer validation code.
-  KJ_DASSERT(structPointerCount == 0 * POINTERS ||
+  KJ_DASSERT(structPointerCount == ZERO * POINTERS ||
          (uintptr_t)structPointers % sizeof(void*) == 0,
          "Pointer section of struct list element not aligned.");
 
-  KJ_DASSERT(indexBit % BITS_PER_BYTE == 0 * BITS);
+  KJ_DASSERT(indexBit % BITS_PER_BYTE == ZERO * BITS);
   return StructReader(
       segment, capTable, structData, structPointers,
       structDataSize, structPointerCount,
@@ -3062,7 +3164,8 @@ OrphanBuilder OrphanBuilder::initStructList(
 OrphanBuilder OrphanBuilder::initText(
     BuilderArena* arena, CapTableBuilder* capTable, ByteCount size) {
   OrphanBuilder result;
-  auto allocation = WireHelpers::initTextPointer(result.tagAsPtr(), nullptr, capTable, size, arena);
+  auto allocation = WireHelpers::initTextPointer(result.tagAsPtr(), nullptr, capTable,
+      assertMax<MAX_TEXT_SIZE>(size, ThrowOverflow()), arena);
   result.segment = allocation.segment;
   result.capTable = capTable;
   result.location = reinterpret_cast<word*>(allocation.value.begin());
@@ -3072,7 +3175,8 @@ OrphanBuilder OrphanBuilder::initText(
 OrphanBuilder OrphanBuilder::initData(
     BuilderArena* arena, CapTableBuilder* capTable, ByteCount size) {
   OrphanBuilder result;
-  auto allocation = WireHelpers::initDataPointer(result.tagAsPtr(), nullptr, capTable, size, arena);
+  auto allocation = WireHelpers::initDataPointer(result.tagAsPtr(), nullptr, capTable,
+      assertMaxBits<BLOB_SIZE_BITS>(size), arena);
   result.segment = allocation.segment;
   result.capTable = capTable;
   result.location = reinterpret_cast<word*>(allocation.value.begin());
@@ -3236,12 +3340,14 @@ OrphanBuilder OrphanBuilder::referenceExternalData(BuilderArena* arena, Data::Re
   KJ_REQUIRE(reinterpret_cast<uintptr_t>(data.begin()) % sizeof(void*) == 0,
              "Cannot referenceExternalData() that is not aligned.");
 
-  auto wordCount = WireHelpers::roundBytesUpToWords(data.size() * BYTES);
-  kj::ArrayPtr<const word> words(reinterpret_cast<const word*>(data.begin()), wordCount / WORDS);
+  auto checkedSize = assertMaxBits<BLOB_SIZE_BITS>(guarded(data.size()));
+  auto wordCount = WireHelpers::roundBytesUpToWords(checkedSize * BYTES);
+  kj::ArrayPtr<const word> words(reinterpret_cast<const word*>(data.begin()),
+                                 unguard(wordCount / WORDS));
 
   OrphanBuilder result;
   result.tagAsPtr()->setKindForOrphan(WirePointer::LIST);
-  result.tagAsPtr()->listRef.set(ElementSize::BYTE, data.size() * ELEMENTS);
+  result.tagAsPtr()->listRef.set(ElementSize::BYTE, checkedSize * ELEMENTS);
   result.segment = arena->addExternalSegment(words);
 
   // External data cannot possibly contain capabilities.
@@ -3297,7 +3403,7 @@ Text::Builder OrphanBuilder::asText() {
 
   // Never relocates.
   return WireHelpers::getWritableTextPointer(
-      tagAsPtr(), location, segment, capTable, nullptr, 0 * BYTES);
+      tagAsPtr(), location, segment, capTable, nullptr, ZERO * BYTES);
 }
 
 Data::Builder OrphanBuilder::asData() {
@@ -3305,7 +3411,7 @@ Data::Builder OrphanBuilder::asData() {
 
   // Never relocates.
   return WireHelpers::getWritableDataPointer(
-      tagAsPtr(), location, segment, capTable, nullptr, 0 * BYTES);
+      tagAsPtr(), location, segment, capTable, nullptr, ZERO * BYTES);
 }
 
 StructReader OrphanBuilder::asStructReader(StructSize size) const {
@@ -3328,12 +3434,12 @@ kj::Own<ClientHook> OrphanBuilder::asCapability() const {
 
 Text::Reader OrphanBuilder::asTextReader() const {
   KJ_DASSERT(tagAsPtr()->isNull() == (location == nullptr));
-  return WireHelpers::readTextPointer(segment, tagAsPtr(), location, nullptr, 0 * BYTES);
+  return WireHelpers::readTextPointer(segment, tagAsPtr(), location, nullptr, ZERO * BYTES);
 }
 
 Data::Reader OrphanBuilder::asDataReader() const {
   KJ_DASSERT(tagAsPtr()->isNull() == (location == nullptr));
-  return WireHelpers::readDataPointer(segment, tagAsPtr(), location, nullptr, 0 * BYTES);
+  return WireHelpers::readDataPointer(segment, tagAsPtr(), location, nullptr, ZERO * BYTES);
 }
 
 bool OrphanBuilder::truncate(ElementCount size, bool isText) {

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -104,11 +104,7 @@ inline KJ_CONSTEXPR() BitsPerElementTableType dataBitsPerElement(ElementSize siz
 }
 
 inline constexpr PointersPerElementN<1> pointersPerElement(ElementSize size) {
-  if (size == ElementSize::POINTER) {
-    return ONE * POINTERS / ELEMENTS;
-  } else {
-    return ZERO * POINTERS / ELEMENTS;
-  }
+  return size == ElementSize::POINTER ? ONE * POINTERS / ELEMENTS : ZERO * POINTERS / ELEMENTS;
 }
 
 static constexpr BitsPerElementTableType BITS_PER_ELEMENT_INCLUDING_PONITERS_TABLE[8] = {

--- a/c++/src/capnp/layout.h
+++ b/c++/src/capnp/layout.h
@@ -82,26 +82,48 @@ class BuilderArena;
 
 // =============================================================================
 
-typedef decltype(BITS / ELEMENTS) BitsPerElement;
-typedef decltype(POINTERS / ELEMENTS) PointersPerElement;
+#if CAPNP_DEBUG_TYPES
+typedef kj::UnitRatio<kj::Guarded<64, uint>, BitLabel, ElementLabel> BitsPerElementTableType;
+#else
+typedef uint BitsPerElementTableType;
+#endif
 
-static constexpr BitsPerElement BITS_PER_ELEMENT_TABLE[8] = {
-    0 * BITS / ELEMENTS,
-    1 * BITS / ELEMENTS,
-    8 * BITS / ELEMENTS,
-    16 * BITS / ELEMENTS,
-    32 * BITS / ELEMENTS,
-    64 * BITS / ELEMENTS,
-    0 * BITS / ELEMENTS,
-    0 * BITS / ELEMENTS
+static constexpr BitsPerElementTableType BITS_PER_ELEMENT_TABLE[8] = {
+  guarded< 0>() * BITS / ELEMENTS,
+  guarded< 1>() * BITS / ELEMENTS,
+  guarded< 8>() * BITS / ELEMENTS,
+  guarded<16>() * BITS / ELEMENTS,
+  guarded<32>() * BITS / ELEMENTS,
+  guarded<64>() * BITS / ELEMENTS,
+  guarded< 0>() * BITS / ELEMENTS,
+  guarded< 0>() * BITS / ELEMENTS
 };
 
-inline KJ_CONSTEXPR() BitsPerElement dataBitsPerElement(ElementSize size) {
+inline KJ_CONSTEXPR() BitsPerElementTableType dataBitsPerElement(ElementSize size) {
   return _::BITS_PER_ELEMENT_TABLE[static_cast<int>(size)];
 }
 
-inline constexpr PointersPerElement pointersPerElement(ElementSize size) {
-  return size == ElementSize::POINTER ? 1 * POINTERS / ELEMENTS : 0 * POINTERS / ELEMENTS;
+inline constexpr PointersPerElementN<1> pointersPerElement(ElementSize size) {
+  if (size == ElementSize::POINTER) {
+    return ONE * POINTERS / ELEMENTS;
+  } else {
+    return ZERO * POINTERS / ELEMENTS;
+  }
+}
+
+static constexpr BitsPerElementTableType BITS_PER_ELEMENT_INCLUDING_PONITERS_TABLE[8] = {
+  guarded< 0>() * BITS / ELEMENTS,
+  guarded< 1>() * BITS / ELEMENTS,
+  guarded< 8>() * BITS / ELEMENTS,
+  guarded<16>() * BITS / ELEMENTS,
+  guarded<32>() * BITS / ELEMENTS,
+  guarded<64>() * BITS / ELEMENTS,
+  guarded<64>() * BITS / ELEMENTS,
+  guarded< 0>() * BITS / ELEMENTS
+};
+
+inline KJ_CONSTEXPR() BitsPerElementTableType bitsPerElementIncludingPointers(ElementSize size) {
+  return _::BITS_PER_ELEMENT_INCLUDING_PONITERS_TABLE[static_cast<int>(size)];
 }
 
 template <size_t size> struct ElementSizeForByteSize;
@@ -142,17 +164,23 @@ inline constexpr ElementSize elementSizeForType() {
 }
 
 struct MessageSizeCounts {
-  WordCount64 wordCount;
+  WordCountN<61, uint64_t> wordCount;  // 2^64 bytes
   uint capCount;
 
   MessageSizeCounts& operator+=(const MessageSizeCounts& other) {
-    wordCount += other.wordCount;
+    // OK to truncate unchecked because this class is used to count actual stuff in memory, and
+    // we couldn't possibly have anywhere near 2^61 words.
+    wordCount = assumeBits<61>(wordCount + other.wordCount);
     capCount += other.capCount;
     return *this;
   }
 
+  void addWords(WordCountN<61, uint64_t> other) {
+    wordCount = assumeBits<61>(wordCount + other);
+  }
+
   MessageSize asPublic() {
-    return MessageSize { wordCount / WORDS, capCount };
+    return MessageSize { unguard(wordCount / WORDS), capCount };
   }
 };
 
@@ -168,13 +196,13 @@ union AlignedData {
 };
 
 struct StructSize {
-  WordCount16 data;
-  WirePointerCount16 pointers;
+  StructDataWordCount data;
+  StructPointerCount pointers;
 
-  inline constexpr WordCount total() const { return data + pointers * WORDS_PER_POINTER; }
+  inline constexpr WordCountN<17> total() const { return data + pointers * WORDS_PER_POINTER; }
 
   StructSize() = default;
-  inline constexpr StructSize(WordCount data, WirePointerCount pointers)
+  inline constexpr StructSize(StructDataWordCount data, StructPointerCount pointers)
       : data(data), pointers(pointers) {}
 };
 
@@ -324,7 +352,8 @@ public:
   ListBuilder getList(ElementSize elementSize, const word* defaultValue);
   ListBuilder getStructList(StructSize elementSize, const word* defaultValue);
   ListBuilder getListAnySize(const word* defaultValue);
-  template <typename T> typename T::Builder getBlob(const void* defaultValue,ByteCount defaultSize);
+  template <typename T> typename T::Builder getBlob(
+      const void* defaultValue, ByteCount defaultSize);
 #if !CAPNP_LITE
   kj::Own<ClientHook> getCapability();
 #endif  // !CAPNP_LITE
@@ -474,37 +503,36 @@ public:
   // Get the object's location.  Only valid for independently-allocated objects (i.e. not list
   // elements).
 
-  inline BitCount getDataSectionSize() const { return dataSize; }
-  inline WirePointerCount getPointerSectionSize() const { return pointerCount; }
+  inline StructDataBitCount getDataSectionSize() const { return dataSize; }
+  inline StructPointerCount getPointerSectionSize() const { return pointerCount; }
   inline kj::ArrayPtr<byte> getDataSectionAsBlob();
   inline _::ListBuilder getPointerSectionAsList();
 
   template <typename T>
-  KJ_ALWAYS_INLINE(bool hasDataField(ElementCount offset));
+  KJ_ALWAYS_INLINE(bool hasDataField(StructDataElementOffset offset));
   // Return true if the field is set to something other than its default value.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(T getDataField(ElementCount offset));
+  KJ_ALWAYS_INLINE(T getDataField(StructDataElementOffset offset));
   // Gets the data field value of the given type at the given offset.  The offset is measured in
   // multiples of the field size, determined by the type.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(T getDataField(ElementCount offset, Mask<T> mask));
+  KJ_ALWAYS_INLINE(T getDataField(StructDataElementOffset offset, Mask<T> mask));
   // Like getDataField() but applies the given XOR mask to the data on load.  Used for reading
   // fields with non-zero default values.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(void setDataField(
-      ElementCount offset, kj::NoInfer<T> value));
+  KJ_ALWAYS_INLINE(void setDataField(StructDataElementOffset offset, kj::NoInfer<T> value));
   // Sets the data field value at the given offset.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(void setDataField(
-      ElementCount offset, kj::NoInfer<T> value, Mask<T> mask));
+  KJ_ALWAYS_INLINE(void setDataField(StructDataElementOffset offset,
+                                     kj::NoInfer<T> value, Mask<T> mask));
   // Like setDataField() but applies the given XOR mask before storing.  Used for writing fields
   // with non-zero default values.
 
-  KJ_ALWAYS_INLINE(PointerBuilder getPointerField(WirePointerCount ptrIndex));
+  KJ_ALWAYS_INLINE(PointerBuilder getPointerField(StructPointerCount ptrIndex));
   // Get a builder for a pointer field given the index within the pointer section.
 
   void clearAll();
@@ -538,15 +566,15 @@ private:
   void* data;                  // Pointer to the encoded data.
   WirePointer* pointers;   // Pointer to the encoded pointers.
 
-  BitCount32 dataSize;
+  StructDataBitCount dataSize;
   // Size of data section.  We use a bit count rather than a word count to more easily handle the
   // case of struct lists encoded with less than a word per element.
 
-  WirePointerCount16 pointerCount;  // Size of the pointer section.
+  StructPointerCount pointerCount;  // Size of the pointer section.
 
   inline StructBuilder(SegmentBuilder* segment, CapTableBuilder* capTable,
                        void* data, WirePointer* pointers,
-                       BitCount dataSize, WirePointerCount pointerCount)
+                       StructDataBitCount dataSize, StructPointerCount pointerCount)
       : segment(segment), capTable(capTable), data(data), pointers(pointers),
         dataSize(dataSize), pointerCount(pointerCount) {}
 
@@ -558,38 +586,38 @@ private:
 class StructReader {
 public:
   inline StructReader()
-      : segment(nullptr), capTable(nullptr), data(nullptr), pointers(nullptr), dataSize(0),
-        pointerCount(0), nestingLimit(0x7fffffff) {}
+      : segment(nullptr), capTable(nullptr), data(nullptr), pointers(nullptr),
+        dataSize(ZERO * BITS), pointerCount(ZERO * POINTERS), nestingLimit(0x7fffffff) {}
   inline StructReader(kj::ArrayPtr<const word> data)
       : segment(nullptr), capTable(nullptr), data(data.begin()), pointers(nullptr),
-        dataSize(data.size() * WORDS * BITS_PER_WORD), pointerCount(0), nestingLimit(0x7fffffff) {}
+        dataSize(data.size() * WORDS * BITS_PER_WORD), pointerCount(ZERO * POINTERS),
+        nestingLimit(0x7fffffff) {}
 
   const void* getLocation() const { return data; }
 
-  inline BitCount getDataSectionSize() const { return dataSize; }
-  inline WirePointerCount getPointerSectionSize() const { return pointerCount; }
+  inline StructDataBitCount getDataSectionSize() const { return dataSize; }
+  inline StructPointerCount getPointerSectionSize() const { return pointerCount; }
   inline kj::ArrayPtr<const byte> getDataSectionAsBlob();
   inline _::ListReader getPointerSectionAsList();
 
   kj::Array<word> canonicalize();
 
   template <typename T>
-  KJ_ALWAYS_INLINE(bool hasDataField(ElementCount offset) const);
+  KJ_ALWAYS_INLINE(bool hasDataField(StructDataElementOffset offset) const);
   // Return true if the field is set to something other than its default value.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(T getDataField(ElementCount offset) const);
+  KJ_ALWAYS_INLINE(T getDataField(StructDataElementOffset offset) const);
   // Get the data field value of the given type at the given offset.  The offset is measured in
   // multiples of the field size, determined by the type.  Returns zero if the offset is past the
   // end of the struct's data section.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(
-      T getDataField(ElementCount offset, Mask<T> mask) const);
+  KJ_ALWAYS_INLINE(T getDataField(StructDataElementOffset offset, Mask<T> mask) const);
   // Like getDataField(offset), but applies the given XOR mask to the result.  Used for reading
   // fields with non-zero default values.
 
-  KJ_ALWAYS_INLINE(PointerReader getPointerField(WirePointerCount ptrIndex) const);
+  KJ_ALWAYS_INLINE(PointerReader getPointerField(StructPointerCount ptrIndex) const);
   // Get a reader for a pointer field given the index within the pointer section.  If the index
   // is out-of-bounds, returns a null pointer.
 
@@ -628,11 +656,11 @@ private:
   const void* data;
   const WirePointer* pointers;
 
-  BitCount32 dataSize;
+  StructDataBitCount dataSize;
   // Size of data section.  We use a bit count rather than a word count to more easily handle the
   // case of struct lists encoded with less than a word per element.
 
-  WirePointerCount16 pointerCount;  // Size of the pointer section.
+  StructPointerCount pointerCount;  // Size of the pointer section.
 
   int nestingLimit;
   // Limits the depth of message structures to guard against stack-overflow-based DoS attacks.
@@ -641,7 +669,8 @@ private:
 
   inline StructReader(SegmentReader* segment, CapTableReader* capTable,
                       const void* data, const WirePointer* pointers,
-                      BitCount dataSize, WirePointerCount pointerCount, int nestingLimit)
+                      StructDataBitCount dataSize, StructPointerCount pointerCount,
+                      int nestingLimit)
       : segment(segment), capTable(capTable), data(data), pointers(pointers),
         dataSize(dataSize), pointerCount(pointerCount),
         nestingLimit(nestingLimit) {}
@@ -657,8 +686,8 @@ class ListBuilder: public kj::DisallowConstCopy {
 public:
   inline explicit ListBuilder(ElementSize elementSize)
       : segment(nullptr), capTable(nullptr), ptr(nullptr), elementCount(0 * ELEMENTS),
-        step(0 * BITS / ELEMENTS), structDataSize(0 * BITS), structPointerCount(0 * POINTERS),
-        elementSize(elementSize) {}
+        step(ZERO * BITS / ELEMENTS), structDataSize(0 * BITS),
+        structPointerCount(ZERO * POINTERS), elementSize(elementSize) {}
 
   inline word* getLocation() {
     // Get the object's location.
@@ -672,7 +701,7 @@ public:
 
   inline ElementSize getElementSize() const { return elementSize; }
 
-  inline ElementCount size() const;
+  inline ListElementCount size() const;
   // The number of elements in the list.
 
   Text::Builder asText();
@@ -684,8 +713,7 @@ public:
   // Get the element of the given type at the given index.
 
   template <typename T>
-  KJ_ALWAYS_INLINE(void setDataElement(
-      ElementCount index, kj::NoInfer<T> value));
+  KJ_ALWAYS_INLINE(void setDataElement(ElementCount index, kj::NoInfer<T> value));
   // Set the element at the given index.
 
   KJ_ALWAYS_INLINE(PointerBuilder getPointerElement(ElementCount index));
@@ -710,13 +738,14 @@ private:
 
   byte* ptr;  // Pointer to list content.
 
-  ElementCount elementCount;  // Number of elements in the list.
+  ListElementCount elementCount;  // Number of elements in the list.
 
-  decltype(BITS / ELEMENTS) step;
-  // The distance between elements.
+  BitsPerElementN<23> step;
+  // The distance between elements. The maximum value occurs when a struct contains 2^16-1 data
+  // words and 2^16-1 pointers, i.e. 2^17 - 2 words, or 2^23 - 128 bits.
 
-  BitCount32 structDataSize;
-  WirePointerCount16 structPointerCount;
+  StructDataBitCount structDataSize;
+  StructPointerCount structPointerCount;
   // The struct properties to use when interpreting the elements as structs.  All lists can be
   // interpreted as struct lists, so these are always filled in.
 
@@ -726,7 +755,7 @@ private:
 
   inline ListBuilder(SegmentBuilder* segment, CapTableBuilder* capTable, void* ptr,
                      decltype(BITS / ELEMENTS) step, ElementCount size,
-                     BitCount structDataSize, WirePointerCount structPointerCount,
+                     StructDataBitCount structDataSize, StructPointerCount structPointerCount,
                      ElementSize elementSize)
       : segment(segment), capTable(capTable), ptr(reinterpret_cast<byte*>(ptr)),
         elementCount(size), step(step), structDataSize(structDataSize),
@@ -740,11 +769,11 @@ private:
 class ListReader {
 public:
   inline explicit ListReader(ElementSize elementSize)
-      : segment(nullptr), capTable(nullptr), ptr(nullptr), elementCount(0),
-        step(0 * BITS / ELEMENTS), structDataSize(0), structPointerCount(0),
-        elementSize(elementSize), nestingLimit(0x7fffffff) {}
+      : segment(nullptr), capTable(nullptr), ptr(nullptr), elementCount(ZERO * ELEMENTS),
+        step(ZERO * BITS / ELEMENTS), structDataSize(ZERO * BITS),
+        structPointerCount(ZERO * POINTERS), elementSize(elementSize), nestingLimit(0x7fffffff) {}
 
-  inline ElementCount size() const;
+  inline ListElementCount size() const;
   // The number of elements in the list.
 
   inline ElementSize getElementSize() const { return elementSize; }
@@ -782,13 +811,14 @@ private:
 
   const byte* ptr;  // Pointer to list content.
 
-  ElementCount elementCount;  // Number of elements in the list.
+  ListElementCount elementCount;  // Number of elements in the list.
 
-  decltype(BITS / ELEMENTS) step;
-  // The distance between elements.
+  BitsPerElementN<23> step;
+  // The distance between elements. The maximum value occurs when a struct contains 2^16-1 data
+  // words and 2^16-1 pointers, i.e. 2^17 - 2 words, or 2^23 - 2 bits.
 
-  BitCount32 structDataSize;
-  WirePointerCount16 structPointerCount;
+  StructDataBitCount structDataSize;
+  StructPointerCount structPointerCount;
   // The struct properties to use when interpreting the elements as structs.  All lists can be
   // interpreted as struct lists, so these are always filled in.
 
@@ -801,8 +831,8 @@ private:
   // Once this reaches zero, further pointers will be pruned.
 
   inline ListReader(SegmentReader* segment, CapTableReader* capTable, const void* ptr,
-                    ElementCount elementCount, decltype(BITS / ELEMENTS) step,
-                    BitCount structDataSize, WirePointerCount structPointerCount,
+                    ElementCount elementCount, BitsPerElementN<23> step,
+                    StructDataBitCount structDataSize, StructPointerCount structPointerCount,
                     ElementSize elementSize, int nestingLimit)
       : segment(segment), capTable(capTable), ptr(reinterpret_cast<const byte*>(ptr)),
         elementCount(elementCount), step(step), structDataSize(structDataSize),
@@ -888,7 +918,7 @@ public:
   // Versions of truncate() that know how to allocate a new list if needed.
 
 private:
-  static_assert(1 * POINTERS * WORDS_PER_POINTER == 1 * WORDS,
+  static_assert(ONE * POINTERS * WORDS_PER_POINTER == ONE * WORDS,
                 "This struct assumes a pointer is one word.");
   word tag;
   // Contains an encoded WirePointer representing this object.  WirePointer is defined in
@@ -934,13 +964,17 @@ private:
 // These are defined in the source file.
 template <> typename Text::Builder PointerBuilder::initBlob<Text>(ByteCount size);
 template <> void PointerBuilder::setBlob<Text>(typename Text::Reader value);
-template <> typename Text::Builder PointerBuilder::getBlob<Text>(const void* defaultValue, ByteCount defaultSize);
-template <> typename Text::Reader PointerReader::getBlob<Text>(const void* defaultValue, ByteCount defaultSize) const;
+template <> typename Text::Builder PointerBuilder::getBlob<Text>(
+    const void* defaultValue, ByteCount defaultSize);
+template <> typename Text::Reader PointerReader::getBlob<Text>(
+    const void* defaultValue, ByteCount defaultSize) const;
 
 template <> typename Data::Builder PointerBuilder::initBlob<Data>(ByteCount size);
 template <> void PointerBuilder::setBlob<Data>(typename Data::Reader value);
-template <> typename Data::Builder PointerBuilder::getBlob<Data>(const void* defaultValue, ByteCount defaultSize);
-template <> typename Data::Reader PointerReader::getBlob<Data>(const void* defaultValue, ByteCount defaultSize) const;
+template <> typename Data::Builder PointerBuilder::getBlob<Data>(
+    const void* defaultValue, ByteCount defaultSize);
+template <> typename Data::Reader PointerReader::getBlob<Data>(
+    const void* defaultValue, ByteCount defaultSize) const;
 
 inline PointerBuilder PointerBuilder::getRoot(
     SegmentBuilder* segment, CapTableBuilder* capTable, word* location) {
@@ -955,82 +989,85 @@ inline PointerReader PointerReader::getRootUnchecked(const word* location) {
 // -------------------------------------------------------------------
 
 inline kj::ArrayPtr<byte> StructBuilder::getDataSectionAsBlob() {
-  return kj::ArrayPtr<byte>(reinterpret_cast<byte*>(data), dataSize / BITS_PER_BYTE / BYTES);
+  return kj::ArrayPtr<byte>(reinterpret_cast<byte*>(data),
+      unguard(dataSize / BITS_PER_BYTE / BYTES));
 }
 
 inline _::ListBuilder StructBuilder::getPointerSectionAsList() {
-  return _::ListBuilder(segment, capTable, pointers, 1 * POINTERS * BITS_PER_POINTER / ELEMENTS,
-                        pointerCount * (1 * ELEMENTS / POINTERS),
-                        0 * BITS, 1 * POINTERS, ElementSize::POINTER);
+  return _::ListBuilder(segment, capTable, pointers, ONE * POINTERS * BITS_PER_POINTER / ELEMENTS,
+                        pointerCount * (ONE * ELEMENTS / POINTERS),
+                        ZERO * BITS, ONE * POINTERS, ElementSize::POINTER);
 }
 
 template <typename T>
-inline bool StructBuilder::hasDataField(ElementCount offset) {
+inline bool StructBuilder::hasDataField(StructDataElementOffset offset) {
   return getDataField<Mask<T>>(offset) != 0;
 }
 
 template <>
-inline bool StructBuilder::hasDataField<Void>(ElementCount offset) {
+inline bool StructBuilder::hasDataField<Void>(StructDataElementOffset offset) {
   return false;
 }
 
 template <typename T>
-inline T StructBuilder::getDataField(ElementCount offset) {
+inline T StructBuilder::getDataField(StructDataElementOffset offset) {
   return reinterpret_cast<WireValue<T>*>(data)[offset / ELEMENTS].get();
 }
 
 template <>
-inline bool StructBuilder::getDataField<bool>(ElementCount offset) {
-  BitCount boffset = offset * (1 * BITS / ELEMENTS);
+inline bool StructBuilder::getDataField<bool>(StructDataElementOffset offset) {
+  BitCountN<22> boffset = offset * (ONE * BITS / ELEMENTS);
   byte* b = reinterpret_cast<byte*>(data) + boffset / BITS_PER_BYTE;
-  return (*reinterpret_cast<uint8_t*>(b) & (1 << (boffset % BITS_PER_BYTE / BITS))) != 0;
+  return (*reinterpret_cast<uint8_t*>(b) &
+      unguard(ONE << (boffset % BITS_PER_BYTE / BITS))) != 0;
 }
 
 template <>
-inline Void StructBuilder::getDataField<Void>(ElementCount offset) {
+inline Void StructBuilder::getDataField<Void>(StructDataElementOffset offset) {
   return VOID;
 }
 
 template <typename T>
-inline T StructBuilder::getDataField(ElementCount offset, Mask<T> mask) {
+inline T StructBuilder::getDataField(StructDataElementOffset offset, Mask<T> mask) {
   return unmask<T>(getDataField<Mask<T> >(offset), mask);
 }
 
 template <typename T>
-inline void StructBuilder::setDataField(ElementCount offset, kj::NoInfer<T> value) {
+inline void StructBuilder::setDataField(StructDataElementOffset offset, kj::NoInfer<T> value) {
   reinterpret_cast<WireValue<T>*>(data)[offset / ELEMENTS].set(value);
 }
 
 #if CAPNP_CANONICALIZE_NAN
 // Use mask() on floats and doubles to make sure we canonicalize NaNs.
 template <>
-inline void StructBuilder::setDataField<float>(ElementCount offset, float value) {
+inline void StructBuilder::setDataField<float>(StructDataElementOffset offset, float value) {
   setDataField<uint32_t>(offset, mask<float>(value, 0));
 }
 template <>
-inline void StructBuilder::setDataField<double>(ElementCount offset, double value) {
+inline void StructBuilder::setDataField<double>(StructDataElementOffset offset, double value) {
   setDataField<uint64_t>(offset, mask<double>(value, 0));
 }
 #endif
 
 template <>
-inline void StructBuilder::setDataField<bool>(ElementCount offset, bool value) {
-  BitCount boffset = offset * (1 * BITS / ELEMENTS);
+inline void StructBuilder::setDataField<bool>(StructDataElementOffset offset, bool value) {
+  auto boffset = offset * (ONE * BITS / ELEMENTS);
   byte* b = reinterpret_cast<byte*>(data) + boffset / BITS_PER_BYTE;
-  uint bitnum = boffset % BITS_PER_BYTE / BITS;
+  uint bitnum = unguardMaxBits<3>(boffset % BITS_PER_BYTE / BITS);
   *reinterpret_cast<uint8_t*>(b) = (*reinterpret_cast<uint8_t*>(b) & ~(1 << bitnum))
                                  | (static_cast<uint8_t>(value) << bitnum);
 }
 
 template <>
-inline void StructBuilder::setDataField<Void>(ElementCount offset, Void value) {}
+inline void StructBuilder::setDataField<Void>(StructDataElementOffset offset, Void value) {}
 
 template <typename T>
-inline void StructBuilder::setDataField(ElementCount offset, kj::NoInfer<T> value, Mask<T> m) {
+inline void StructBuilder::setDataField(StructDataElementOffset offset,
+                                        kj::NoInfer<T> value, Mask<T> m) {
   setDataField<Mask<T> >(offset, mask<T>(value, m));
 }
 
-inline PointerBuilder StructBuilder::getPointerField(WirePointerCount ptrIndex) {
+inline PointerBuilder StructBuilder::getPointerField(StructPointerCount ptrIndex) {
   // Hacky because WirePointer is defined in the .c++ file (so is incomplete here).
   return PointerBuilder(segment, capTable, reinterpret_cast<WirePointer*>(
       reinterpret_cast<word*>(pointers) + ptrIndex * WORDS_PER_POINTER));
@@ -1039,28 +1076,29 @@ inline PointerBuilder StructBuilder::getPointerField(WirePointerCount ptrIndex) 
 // -------------------------------------------------------------------
 
 inline kj::ArrayPtr<const byte> StructReader::getDataSectionAsBlob() {
-  return kj::ArrayPtr<const byte>(reinterpret_cast<const byte*>(data), dataSize / BITS_PER_BYTE / BYTES);
+  return kj::ArrayPtr<const byte>(reinterpret_cast<const byte*>(data),
+      unguard(dataSize / BITS_PER_BYTE / BYTES));
 }
 
 inline _::ListReader StructReader::getPointerSectionAsList() {
-  return _::ListReader(segment, capTable, pointers, pointerCount * (1 * ELEMENTS / POINTERS),
-                       1 * POINTERS * BITS_PER_POINTER / ELEMENTS, 0 * BITS, 1 * POINTERS,
+  return _::ListReader(segment, capTable, pointers, pointerCount * (ONE * ELEMENTS / POINTERS),
+                       ONE * POINTERS * BITS_PER_POINTER / ELEMENTS, ZERO * BITS, ONE * POINTERS,
                        ElementSize::POINTER, nestingLimit);
 }
 
 template <typename T>
-inline bool StructReader::hasDataField(ElementCount offset) const {
+inline bool StructReader::hasDataField(StructDataElementOffset offset) const {
   return getDataField<Mask<T>>(offset) != 0;
 }
 
 template <>
-inline bool StructReader::hasDataField<Void>(ElementCount offset) const {
+inline bool StructReader::hasDataField<Void>(StructDataElementOffset offset) const {
   return false;
 }
 
 template <typename T>
-inline T StructReader::getDataField(ElementCount offset) const {
-  if ((offset + 1 * ELEMENTS) * capnp::bitsPerElement<T>() <= dataSize) {
+inline T StructReader::getDataField(StructDataElementOffset offset) const {
+  if ((offset + ONE * ELEMENTS) * capnp::bitsPerElement<T>() <= dataSize) {
     return reinterpret_cast<const WireValue<T>*>(data)[offset / ELEMENTS].get();
   } else {
     return static_cast<T>(0);
@@ -1068,27 +1106,28 @@ inline T StructReader::getDataField(ElementCount offset) const {
 }
 
 template <>
-inline bool StructReader::getDataField<bool>(ElementCount offset) const {
-  BitCount boffset = offset * (1 * BITS / ELEMENTS);
+inline bool StructReader::getDataField<bool>(StructDataElementOffset offset) const {
+  auto boffset = offset * (ONE * BITS / ELEMENTS);
   if (boffset < dataSize) {
     const byte* b = reinterpret_cast<const byte*>(data) + boffset / BITS_PER_BYTE;
-    return (*reinterpret_cast<const uint8_t*>(b) & (1 << (boffset % BITS_PER_BYTE / BITS))) != 0;
+    return (*reinterpret_cast<const uint8_t*>(b) &
+        unguard(ONE << (boffset % BITS_PER_BYTE / BITS))) != 0;
   } else {
     return false;
   }
 }
 
 template <>
-inline Void StructReader::getDataField<Void>(ElementCount offset) const {
+inline Void StructReader::getDataField<Void>(StructDataElementOffset offset) const {
   return VOID;
 }
 
 template <typename T>
-T StructReader::getDataField(ElementCount offset, Mask<T> mask) const {
+T StructReader::getDataField(StructDataElementOffset offset, Mask<T> mask) const {
   return unmask<T>(getDataField<Mask<T> >(offset), mask);
 }
 
-inline PointerReader StructReader::getPointerField(WirePointerCount ptrIndex) const {
+inline PointerReader StructReader::getPointerField(StructPointerCount ptrIndex) const {
   if (ptrIndex < pointerCount) {
     // Hacky because WirePointer is defined in the .c++ file (so is incomplete here).
     return PointerReader(segment, capTable, reinterpret_cast<const WirePointer*>(
@@ -1100,11 +1139,12 @@ inline PointerReader StructReader::getPointerField(WirePointerCount ptrIndex) co
 
 // -------------------------------------------------------------------
 
-inline ElementCount ListBuilder::size() const { return elementCount; }
+inline ListElementCount ListBuilder::size() const { return elementCount; }
 
 template <typename T>
 inline T ListBuilder::getDataElement(ElementCount index) {
-  return reinterpret_cast<WireValue<T>*>(ptr + index * step / BITS_PER_BYTE)->get();
+  return reinterpret_cast<WireValue<T>*>(
+      ptr + upgradeGuard<uint64_t>(index) * step / BITS_PER_BYTE)->get();
 
   // TODO(perf):  Benchmark this alternate implementation, which I suspect may make better use of
   //   the x86 SIB byte.  Also use it for all the other getData/setData implementations below, and
@@ -1117,9 +1157,10 @@ inline T ListBuilder::getDataElement(ElementCount index) {
 template <>
 inline bool ListBuilder::getDataElement<bool>(ElementCount index) {
   // Ignore step for bit lists because bit lists cannot be upgraded to struct lists.
-  BitCount bindex = index * (1 * BITS / ELEMENTS);
+  auto bindex = index * (ONE * BITS / ELEMENTS);
   byte* b = ptr + bindex / BITS_PER_BYTE;
-  return (*reinterpret_cast<uint8_t*>(b) & (1 << (bindex % BITS_PER_BYTE / BITS))) != 0;
+  return (*reinterpret_cast<uint8_t*>(b) &
+      unguard(ONE << (bindex % BITS_PER_BYTE / BITS))) != 0;
 }
 
 template <>
@@ -1129,7 +1170,8 @@ inline Void ListBuilder::getDataElement<Void>(ElementCount index) {
 
 template <typename T>
 inline void ListBuilder::setDataElement(ElementCount index, kj::NoInfer<T> value) {
-  reinterpret_cast<WireValue<T>*>(ptr + index * step / BITS_PER_BYTE)->set(value);
+  reinterpret_cast<WireValue<T>*>(
+      ptr + upgradeGuard<uint64_t>(index) * step / BITS_PER_BYTE)->set(value);
 }
 
 #if CAPNP_CANONICALIZE_NAN
@@ -1147,36 +1189,38 @@ inline void ListBuilder::setDataElement<double>(ElementCount index, double value
 template <>
 inline void ListBuilder::setDataElement<bool>(ElementCount index, bool value) {
   // Ignore stepBytes for bit lists because bit lists cannot be upgraded to struct lists.
-  BitCount bindex = index * (1 * BITS / ELEMENTS);
+  auto bindex = index * (ONE * BITS / ELEMENTS);
   byte* b = ptr + bindex / BITS_PER_BYTE;
-  uint bitnum = bindex % BITS_PER_BYTE / BITS;
-  *reinterpret_cast<uint8_t*>(b) = (*reinterpret_cast<uint8_t*>(b) & ~(1 << bitnum))
-                                 | (static_cast<uint8_t>(value) << bitnum);
+  auto bitnum = bindex % BITS_PER_BYTE / BITS;
+  *reinterpret_cast<uint8_t*>(b) = (*reinterpret_cast<uint8_t*>(b) & ~(1 << unguard(bitnum)))
+                                 | (static_cast<uint8_t>(value) << unguard(bitnum));
 }
 
 template <>
 inline void ListBuilder::setDataElement<Void>(ElementCount index, Void value) {}
 
 inline PointerBuilder ListBuilder::getPointerElement(ElementCount index) {
-  return PointerBuilder(segment, capTable,
-      reinterpret_cast<WirePointer*>(ptr + index * step / BITS_PER_BYTE));
+  return PointerBuilder(segment, capTable, reinterpret_cast<WirePointer*>(ptr +
+      upgradeGuard<uint64_t>(index) * step / BITS_PER_BYTE));
 }
 
 // -------------------------------------------------------------------
 
-inline ElementCount ListReader::size() const { return elementCount; }
+inline ListElementCount ListReader::size() const { return elementCount; }
 
 template <typename T>
 inline T ListReader::getDataElement(ElementCount index) const {
-  return reinterpret_cast<const WireValue<T>*>(ptr + index * step / BITS_PER_BYTE)->get();
+  return reinterpret_cast<const WireValue<T>*>(
+      ptr + upgradeGuard<uint64_t>(index) * step / BITS_PER_BYTE)->get();
 }
 
 template <>
 inline bool ListReader::getDataElement<bool>(ElementCount index) const {
   // Ignore step for bit lists because bit lists cannot be upgraded to struct lists.
-  BitCount bindex = index * (1 * BITS / ELEMENTS);
+  auto bindex = index * (ONE * BITS / ELEMENTS);
   const byte* b = ptr + bindex / BITS_PER_BYTE;
-  return (*reinterpret_cast<const uint8_t*>(b) & (1 << (bindex % BITS_PER_BYTE / BITS))) != 0;
+  return (*reinterpret_cast<const uint8_t*>(b) &
+      unguard(ONE << (bindex % BITS_PER_BYTE / BITS))) != 0;
 }
 
 template <>
@@ -1185,8 +1229,8 @@ inline Void ListReader::getDataElement<Void>(ElementCount index) const {
 }
 
 inline PointerReader ListReader::getPointerElement(ElementCount index) const {
-  return PointerReader(segment, capTable,
-      reinterpret_cast<const WirePointer*>(ptr + index * step / BITS_PER_BYTE), nestingLimit);
+  return PointerReader(segment, capTable, reinterpret_cast<const WirePointer*>(
+      ptr + upgradeGuard<uint64_t>(index) * step / BITS_PER_BYTE), nestingLimit);
 }
 
 // -------------------------------------------------------------------

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -114,10 +114,10 @@ struct List<T, Kind::PRIMITIVE> {
     inline Reader(): reader(_::elementSizeForType<T>()) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline T operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return reader.template getDataElement<T>(guarded(index) * ELEMENTS);
+      return reader.template getDataElement<T>(bounded(index) * ELEMENTS);
     }
 
     typedef _::IndexingIterator<const Reader, T> Iterator;
@@ -146,10 +146,10 @@ struct List<T, Kind::PRIMITIVE> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline T operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return builder.template getDataElement<T>(guarded(index) * ELEMENTS);
+      return builder.template getDataElement<T>(bounded(index) * ELEMENTS);
     }
     inline void set(uint index, T value) {
       // Alas, it is not possible to make operator[] return a reference to which you can assign,
@@ -158,7 +158,7 @@ struct List<T, Kind::PRIMITIVE> {
       // operator=() because it will lead to surprising behavior when using type inference (e.g.
       // calling a template function with inferred argument types, or using "auto" or "decltype").
 
-      builder.template setDataElement<T>(guarded(index) * ELEMENTS, value);
+      builder.template setDataElement<T>(bounded(index) * ELEMENTS, value);
     }
 
     typedef _::IndexingIterator<Builder, T> Iterator;
@@ -178,7 +178,7 @@ struct List<T, Kind::PRIMITIVE> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initList(_::elementSizeForType<T>(), guarded(size) * ELEMENTS);
+    return builder.initList(_::elementSizeForType<T>(), bounded(size) * ELEMENTS);
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getList(_::elementSizeForType<T>(), defaultValue);
@@ -210,10 +210,10 @@ struct List<T, Kind::STRUCT> {
     inline Reader(): reader(ElementSize::INLINE_COMPOSITE) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline typename T::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return typename T::Reader(reader.getStructElement(guarded(index) * ELEMENTS));
+      return typename T::Reader(reader.getStructElement(bounded(index) * ELEMENTS));
     }
 
     typedef _::IndexingIterator<const Reader, typename T::Reader> Iterator;
@@ -242,10 +242,10 @@ struct List<T, Kind::STRUCT> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline typename T::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return typename T::Builder(builder.getStructElement(guarded(index) * ELEMENTS));
+      return typename T::Builder(builder.getStructElement(bounded(index) * ELEMENTS));
     }
 
     inline void adoptWithCaveats(uint index, Orphan<T>&& orphan) {
@@ -263,7 +263,7 @@ struct List<T, Kind::STRUCT> {
       // We pass a zero-valued StructSize to asStruct() because we do not want the struct to be
       // expanded under any circumstances.  We're just going to throw it away anyway, and
       // transferContentFrom() already carefully compares the struct sizes before transferring.
-      builder.getStructElement(guarded(index) * ELEMENTS).transferContentFrom(
+      builder.getStructElement(bounded(index) * ELEMENTS).transferContentFrom(
           orphan.builder.asStruct(_::StructSize(ZERO * WORDS, ZERO * POINTERS)));
     }
     inline void setWithCaveats(uint index, const typename T::Reader& reader) {
@@ -278,7 +278,7 @@ struct List<T, Kind::STRUCT> {
       //   protocol. (Plus, it's easier to use anyhow.)
 
       KJ_IREQUIRE(index < size());
-      builder.getStructElement(guarded(index) * ELEMENTS).copyContentFrom(reader._reader);
+      builder.getStructElement(bounded(index) * ELEMENTS).copyContentFrom(reader._reader);
     }
 
     // There are no init(), set(), adopt(), or disown() methods for lists of structs because the
@@ -303,7 +303,7 @@ struct List<T, Kind::STRUCT> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initStructList(guarded(size) * ELEMENTS, _::structSize<T>());
+    return builder.initStructList(bounded(size) * ELEMENTS, _::structSize<T>());
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getStructList(_::structSize<T>(), defaultValue);
@@ -332,11 +332,11 @@ struct List<List<T>, Kind::LIST> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline typename List<T>::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return typename List<T>::Reader(_::PointerHelpers<List<T>>::get(
-          reader.getPointerElement(guarded(index) * ELEMENTS)));
+          reader.getPointerElement(bounded(index) * ELEMENTS)));
     }
 
     typedef _::IndexingIterator<const Reader, typename List<T>::Reader> Iterator;
@@ -365,20 +365,20 @@ struct List<List<T>, Kind::LIST> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline typename List<T>::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return typename List<T>::Builder(_::PointerHelpers<List<T>>::get(
-          builder.getPointerElement(guarded(index) * ELEMENTS)));
+          builder.getPointerElement(bounded(index) * ELEMENTS)));
     }
     inline typename List<T>::Builder init(uint index, uint size) {
       KJ_IREQUIRE(index < this->size());
       return typename List<T>::Builder(_::PointerHelpers<List<T>>::init(
-          builder.getPointerElement(guarded(index) * ELEMENTS), size));
+          builder.getPointerElement(bounded(index) * ELEMENTS), size));
     }
     inline void set(uint index, typename List<T>::Reader value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).setList(value.reader);
+      builder.getPointerElement(bounded(index) * ELEMENTS).setList(value.reader);
     }
     void set(uint index, std::initializer_list<ReaderFor<T>> value) {
       KJ_IREQUIRE(index < size());
@@ -390,11 +390,11 @@ struct List<List<T>, Kind::LIST> {
     }
     inline void adopt(uint index, Orphan<T>&& value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).adopt(kj::mv(value.builder));
+      builder.getPointerElement(bounded(index) * ELEMENTS).adopt(kj::mv(value.builder));
     }
     inline Orphan<T> disown(uint index) {
       KJ_IREQUIRE(index < size());
-      return Orphan<T>(builder.getPointerElement(guarded(index) * ELEMENTS).disown());
+      return Orphan<T>(builder.getPointerElement(bounded(index) * ELEMENTS).disown());
     }
 
     typedef _::IndexingIterator<Builder, typename List<T>::Builder> Iterator;
@@ -414,7 +414,7 @@ struct List<List<T>, Kind::LIST> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initList(ElementSize::POINTER, guarded(size) * ELEMENTS);
+    return builder.initList(ElementSize::POINTER, bounded(size) * ELEMENTS);
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getList(ElementSize::POINTER, defaultValue);
@@ -441,10 +441,10 @@ struct List<T, Kind::BLOB> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
+    inline uint size() const { return unbound(reader.size() / ELEMENTS); }
     inline typename T::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
-      return reader.getPointerElement(guarded(index) * ELEMENTS)
+      return reader.getPointerElement(bounded(index) * ELEMENTS)
           .template getBlob<T>(nullptr, ZERO * BYTES);
     }
 
@@ -474,28 +474,28 @@ struct List<T, Kind::BLOB> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
+    inline uint size() const { return unbound(builder.size() / ELEMENTS); }
     inline typename T::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
-      return builder.getPointerElement(guarded(index) * ELEMENTS)
+      return builder.getPointerElement(bounded(index) * ELEMENTS)
           .template getBlob<T>(nullptr, ZERO * BYTES);
     }
     inline void set(uint index, typename T::Reader value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).template setBlob<T>(value);
+      builder.getPointerElement(bounded(index) * ELEMENTS).template setBlob<T>(value);
     }
     inline typename T::Builder init(uint index, uint size) {
       KJ_IREQUIRE(index < this->size());
-      return builder.getPointerElement(guarded(index) * ELEMENTS)
-          .template initBlob<T>(guarded(size) * BYTES);
+      return builder.getPointerElement(bounded(index) * ELEMENTS)
+          .template initBlob<T>(bounded(size) * BYTES);
     }
     inline void adopt(uint index, Orphan<T>&& value) {
       KJ_IREQUIRE(index < size());
-      builder.getPointerElement(guarded(index) * ELEMENTS).adopt(kj::mv(value.builder));
+      builder.getPointerElement(bounded(index) * ELEMENTS).adopt(kj::mv(value.builder));
     }
     inline Orphan<T> disown(uint index) {
       KJ_IREQUIRE(index < size());
-      return Orphan<T>(builder.getPointerElement(guarded(index) * ELEMENTS).disown());
+      return Orphan<T>(builder.getPointerElement(bounded(index) * ELEMENTS).disown());
     }
 
     typedef _::IndexingIterator<Builder, typename T::Builder> Iterator;
@@ -515,7 +515,7 @@ struct List<T, Kind::BLOB> {
 
 private:
   inline static _::ListBuilder initPointer(_::PointerBuilder builder, uint size) {
-    return builder.initList(ElementSize::POINTER, guarded(size) * ELEMENTS);
+    return builder.initList(ElementSize::POINTER, bounded(size) * ELEMENTS);
   }
   inline static _::ListBuilder getFromPointer(_::PointerBuilder builder, const word* defaultValue) {
     return builder.getList(ElementSize::POINTER, defaultValue);

--- a/c++/src/capnp/list.h
+++ b/c++/src/capnp/list.h
@@ -114,7 +114,7 @@ struct List<T, Kind::PRIMITIVE> {
     inline Reader(): reader(_::elementSizeForType<T>()) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline T operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return reader.template getDataElement<T>(guarded(index) * ELEMENTS);
@@ -146,7 +146,7 @@ struct List<T, Kind::PRIMITIVE> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline T operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return builder.template getDataElement<T>(guarded(index) * ELEMENTS);
@@ -210,7 +210,7 @@ struct List<T, Kind::STRUCT> {
     inline Reader(): reader(ElementSize::INLINE_COMPOSITE) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline typename T::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return typename T::Reader(reader.getStructElement(guarded(index) * ELEMENTS));
@@ -242,7 +242,7 @@ struct List<T, Kind::STRUCT> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline typename T::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return typename T::Builder(builder.getStructElement(guarded(index) * ELEMENTS));
@@ -332,7 +332,7 @@ struct List<List<T>, Kind::LIST> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline typename List<T>::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return typename List<T>::Reader(_::PointerHelpers<List<T>>::get(
@@ -365,7 +365,7 @@ struct List<List<T>, Kind::LIST> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline typename List<T>::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return typename List<T>::Builder(_::PointerHelpers<List<T>>::get(
@@ -441,7 +441,7 @@ struct List<T, Kind::BLOB> {
     inline Reader(): reader(ElementSize::POINTER) {}
     inline explicit Reader(_::ListReader reader): reader(reader) {}
 
-    inline uint size() const { return reader.size() / ELEMENTS; }
+    inline uint size() const { return unguard(reader.size() / ELEMENTS); }
     inline typename T::Reader operator[](uint index) const {
       KJ_IREQUIRE(index < size());
       return reader.getPointerElement(guarded(index) * ELEMENTS)
@@ -474,7 +474,7 @@ struct List<T, Kind::BLOB> {
     inline operator Reader() const { return Reader(builder.asReader()); }
     inline Reader asReader() const { return Reader(builder.asReader()); }
 
-    inline uint size() const { return builder.size() / ELEMENTS; }
+    inline uint size() const { return unguard(builder.size() / ELEMENTS); }
     inline typename T::Builder operator[](uint index) {
       KJ_IREQUIRE(index < size());
       return builder.getPointerElement(guarded(index) * ELEMENTS)

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -135,7 +135,7 @@ _::SegmentBuilder* MessageBuilder::getRootSegment() {
 
     KJ_ASSERT(allocation.segment->getSegmentId() == _::SegmentId(0),
         "First allocated word of new arena was not in segment ID 0.");
-    KJ_ASSERT(allocation.words == allocation.segment->getPtrUnchecked(0 * WORDS),
+    KJ_ASSERT(allocation.words == allocation.segment->getPtrUnchecked(ZERO * WORDS),
         "First allocated word of new arena was not the first word in its segment.");
     return allocation.segment;
   }
@@ -144,7 +144,7 @@ _::SegmentBuilder* MessageBuilder::getRootSegment() {
 AnyPointer::Builder MessageBuilder::getRootInternal() {
   _::SegmentBuilder* rootSegment = getRootSegment();
   return AnyPointer::Builder(_::PointerBuilder::getRoot(
-      rootSegment, arena()->getLocalCapTable(), rootSegment->getPtrUnchecked(0 * WORDS)));
+      rootSegment, arena()->getLocalCapTable(), rootSegment->getPtrUnchecked(ZERO * WORDS)));
 }
 
 kj::ArrayPtr<const kj::ArrayPtr<const word>> MessageBuilder::getSegmentsForOutput() {

--- a/c++/src/capnp/orphan.h
+++ b/c++/src/capnp/orphan.h
@@ -307,17 +307,17 @@ inline ReaderFor<T> Orphan<T>::getReader() const {
 
 template <typename T>
 inline void Orphan<T>::truncate(uint size) {
-  _::OrphanGetImpl<ListElementType<T>>::truncateListOf(builder, guarded(size) * ELEMENTS);
+  _::OrphanGetImpl<ListElementType<T>>::truncateListOf(builder, bounded(size) * ELEMENTS);
 }
 
 template <>
 inline void Orphan<Text>::truncate(uint size) {
-  builder.truncateText(guarded(size) * ELEMENTS);
+  builder.truncateText(bounded(size) * ELEMENTS);
 }
 
 template <>
 inline void Orphan<Data>::truncate(uint size) {
-  builder.truncate(guarded(size) * ELEMENTS, ElementSize::BYTE);
+  builder.truncate(bounded(size) * ELEMENTS, ElementSize::BYTE);
 }
 
 template <typename T>
@@ -350,7 +350,7 @@ struct Orphanage::NewOrphanListImpl<List<T, k>> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
     return _::OrphanBuilder::initList(
-        arena, capTable, guarded(size) * ELEMENTS, _::ElementSizeForType<T>::value);
+        arena, capTable, bounded(size) * ELEMENTS, _::ElementSizeForType<T>::value);
   }
 };
 
@@ -359,7 +359,7 @@ struct Orphanage::NewOrphanListImpl<List<T, Kind::STRUCT>> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
     return _::OrphanBuilder::initStructList(
-        arena, capTable, guarded(size) * ELEMENTS, _::structSize<T>());
+        arena, capTable, bounded(size) * ELEMENTS, _::structSize<T>());
   }
 };
 
@@ -367,7 +367,7 @@ template <>
 struct Orphanage::NewOrphanListImpl<Text> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
-    return _::OrphanBuilder::initText(arena, capTable, guarded(size) * BYTES);
+    return _::OrphanBuilder::initText(arena, capTable, bounded(size) * BYTES);
   }
 };
 
@@ -375,7 +375,7 @@ template <>
 struct Orphanage::NewOrphanListImpl<Data> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
-    return _::OrphanBuilder::initData(arena, capTable, guarded(size) * BYTES);
+    return _::OrphanBuilder::initData(arena, capTable, bounded(size) * BYTES);
   }
 };
 

--- a/c++/src/capnp/orphan.h
+++ b/c++/src/capnp/orphan.h
@@ -307,17 +307,17 @@ inline ReaderFor<T> Orphan<T>::getReader() const {
 
 template <typename T>
 inline void Orphan<T>::truncate(uint size) {
-  _::OrphanGetImpl<ListElementType<T>>::truncateListOf(builder, size * ELEMENTS);
+  _::OrphanGetImpl<ListElementType<T>>::truncateListOf(builder, guarded(size) * ELEMENTS);
 }
 
 template <>
 inline void Orphan<Text>::truncate(uint size) {
-  builder.truncateText(size * ELEMENTS);
+  builder.truncateText(guarded(size) * ELEMENTS);
 }
 
 template <>
 inline void Orphan<Data>::truncate(uint size) {
-  builder.truncate(size * ELEMENTS, ElementSize::BYTE);
+  builder.truncate(guarded(size) * ELEMENTS, ElementSize::BYTE);
 }
 
 template <typename T>
@@ -350,7 +350,7 @@ struct Orphanage::NewOrphanListImpl<List<T, k>> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
     return _::OrphanBuilder::initList(
-        arena, capTable, size * ELEMENTS, _::ElementSizeForType<T>::value);
+        arena, capTable, guarded(size) * ELEMENTS, _::ElementSizeForType<T>::value);
   }
 };
 
@@ -359,7 +359,7 @@ struct Orphanage::NewOrphanListImpl<List<T, Kind::STRUCT>> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
     return _::OrphanBuilder::initStructList(
-        arena, capTable, size * ELEMENTS, _::structSize<T>());
+        arena, capTable, guarded(size) * ELEMENTS, _::structSize<T>());
   }
 };
 
@@ -367,7 +367,7 @@ template <>
 struct Orphanage::NewOrphanListImpl<Text> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
-    return _::OrphanBuilder::initText(arena, capTable, size * BYTES);
+    return _::OrphanBuilder::initText(arena, capTable, guarded(size) * BYTES);
   }
 };
 
@@ -375,7 +375,7 @@ template <>
 struct Orphanage::NewOrphanListImpl<Data> {
   static inline _::OrphanBuilder apply(
       _::BuilderArena* arena, _::CapTableBuilder* capTable, uint size) {
-    return _::OrphanBuilder::initData(arena, capTable, size * BYTES);
+    return _::OrphanBuilder::initData(arena, capTable, guarded(size) * BYTES);
   }
 };
 

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -723,21 +723,23 @@ inline typename  ::capnp::Persistent<SturdyRef, Owner>::Client& Persistent<Sturd
 #endif  // !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Reader::hasSealFor() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Builder::hasSealFor() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Reader::getSealFor() const {
-  return ::capnp::_::PointerHelpers<Owner>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<Owner>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::getSealFor() {
-  return ::capnp::_::PointerHelpers<Owner>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<Owner>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -747,29 +749,29 @@ inline  ::capnp::PipelineFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Pi
 #endif  // !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::setSealFor( ::capnp::ReaderFor<Owner> value) {
-  ::capnp::_::PointerHelpers<Owner>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers<Owner>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor() {
-  return ::capnp::_::PointerHelpers<Owner>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor(unsigned int size) {
-  return ::capnp::_::PointerHelpers<Owner>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::adoptSealFor(
     ::capnp::Orphan<Owner>&& value) {
-  ::capnp::_::PointerHelpers<Owner>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers<Owner>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::disownSealFor() {
-  return ::capnp::_::PointerHelpers<Owner>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<Owner>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveParams
@@ -800,21 +802,23 @@ const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::SaveParams::_ca
 
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Reader::hasSturdyRef() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Builder::hasSturdyRef() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Reader::getSturdyRef() const {
-  return ::capnp::_::PointerHelpers<SturdyRef>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<SturdyRef>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::getSturdyRef() {
-  return ::capnp::_::PointerHelpers<SturdyRef>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<SturdyRef>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -824,29 +828,29 @@ inline  ::capnp::PipelineFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResult
 #endif  // !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::setSturdyRef( ::capnp::ReaderFor<SturdyRef> value) {
-  ::capnp::_::PointerHelpers<SturdyRef>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers<SturdyRef>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef() {
-  return ::capnp::_::PointerHelpers<SturdyRef>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef(unsigned int size) {
-  return ::capnp::_::PointerHelpers<SturdyRef>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::adoptSturdyRef(
     ::capnp::Orphan<SturdyRef>&& value) {
-  ::capnp::_::PointerHelpers<SturdyRef>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers<SturdyRef>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::disownSturdyRef() {
-  return ::capnp::_::PointerHelpers<SturdyRef>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<SturdyRef>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveResults
@@ -976,22 +980,24 @@ inline typename  ::capnp::RealmGateway<InternalRef, ExternalRef, InternalOwner, 
 #endif  // !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasCap() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasCap() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getCap() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getCap() {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Pipeline::getCap() {
@@ -999,44 +1005,46 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGa
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client&& cap) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(cap));
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client& cap) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), cap);
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownCap() {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasParams() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasParams() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1046,24 +1054,24 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Pi
 #endif  // !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setParams(typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader value) {
-  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::initParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>&& value) {
-  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams
@@ -1101,22 +1109,24 @@ const ::capnp::_::RawBrandedSchema RealmGateway<InternalRef, ExternalRef, Intern
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasCap() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasCap() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getCap() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getCap() {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Pipeline::getCap() {
@@ -1124,44 +1134,46 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGa
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client&& cap) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(cap));
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client& cap) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), cap);
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownCap() {
-  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasParams() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasParams() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1171,24 +1183,24 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Pi
 #endif  // !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setParams(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader value) {
-  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::initParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>&& value) {
-  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -724,22 +724,22 @@ inline typename  ::capnp::Persistent<SturdyRef, Owner>::Client& Persistent<Sturd
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Reader::hasSealFor() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Builder::hasSealFor() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Reader::getSealFor() const {
   return ::capnp::_::PointerHelpers<Owner>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::getSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -750,28 +750,28 @@ inline  ::capnp::PipelineFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Pi
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::setSealFor( ::capnp::ReaderFor<Owner> value) {
   ::capnp::_::PointerHelpers<Owner>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor(unsigned int size) {
   return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::adoptSealFor(
     ::capnp::Orphan<Owner>&& value) {
   ::capnp::_::PointerHelpers<Owner>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::disownSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveParams
@@ -803,22 +803,22 @@ const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::SaveParams::_ca
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Reader::hasSturdyRef() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Builder::hasSturdyRef() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Reader::getSturdyRef() const {
   return ::capnp::_::PointerHelpers<SturdyRef>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::getSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -829,28 +829,28 @@ inline  ::capnp::PipelineFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResult
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::setSturdyRef( ::capnp::ReaderFor<SturdyRef> value) {
   ::capnp::_::PointerHelpers<SturdyRef>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef(unsigned int size) {
   return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::adoptSturdyRef(
     ::capnp::Orphan<SturdyRef>&& value) {
   ::capnp::_::PointerHelpers<SturdyRef>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::disownSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveResults
@@ -981,23 +981,23 @@ inline typename  ::capnp::RealmGateway<InternalRef, ExternalRef, InternalOwner, 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getCap() const {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Pipeline::getCap() {
@@ -1006,45 +1006,45 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGa
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client&& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), cap);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getParams() const {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1055,23 +1055,23 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Pi
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setParams(typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::initParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>&& value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams
@@ -1110,23 +1110,23 @@ const ::capnp::_::RawBrandedSchema RealmGateway<InternalRef, ExternalRef, Intern
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getCap() const {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Pipeline::getCap() {
@@ -1135,45 +1135,45 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGa
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client&& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), cap);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getParams() const {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1184,23 +1184,23 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Pi
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setParams(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::initParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>&& value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams

--- a/c++/src/capnp/persistent.capnp.h
+++ b/c++/src/capnp/persistent.capnp.h
@@ -724,22 +724,22 @@ inline typename  ::capnp::Persistent<SturdyRef, Owner>::Client& Persistent<Sturd
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Reader::hasSealFor() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveParams::Builder::hasSealFor() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Reader::getSealFor() const {
   return ::capnp::_::PointerHelpers<Owner>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::getSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -750,28 +750,28 @@ inline  ::capnp::PipelineFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Pi
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::setSealFor( ::capnp::ReaderFor<Owner> value) {
   ::capnp::_::PointerHelpers<Owner>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::initSealFor(unsigned int size) {
   return ::capnp::_::PointerHelpers<Owner>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveParams::Builder::adoptSealFor(
     ::capnp::Orphan<Owner>&& value) {
   ::capnp::_::PointerHelpers<Owner>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<Owner> Persistent<SturdyRef, Owner>::SaveParams::Builder::disownSealFor() {
   return ::capnp::_::PointerHelpers<Owner>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveParams
@@ -803,22 +803,22 @@ const ::capnp::_::RawBrandedSchema Persistent<SturdyRef, Owner>::SaveParams::_ca
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Reader::hasSturdyRef() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline bool Persistent<SturdyRef, Owner>::SaveResults::Builder::hasSturdyRef() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::ReaderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Reader::getSturdyRef() const {
   return ::capnp::_::PointerHelpers<SturdyRef>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::getSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename SturdyRef, typename Owner>
@@ -829,28 +829,28 @@ inline  ::capnp::PipelineFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResult
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::setSturdyRef( ::capnp::ReaderFor<SturdyRef> value) {
   ::capnp::_::PointerHelpers<SturdyRef>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename SturdyRef, typename Owner>
 inline  ::capnp::BuilderFor<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::initSturdyRef(unsigned int size) {
   return ::capnp::_::PointerHelpers<SturdyRef>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 template <typename SturdyRef, typename Owner>
 inline void Persistent<SturdyRef, Owner>::SaveResults::Builder::adoptSturdyRef(
     ::capnp::Orphan<SturdyRef>&& value) {
   ::capnp::_::PointerHelpers<SturdyRef>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename SturdyRef, typename Owner>
 inline ::capnp::Orphan<SturdyRef> Persistent<SturdyRef, Owner>::SaveResults::Builder::disownSturdyRef() {
   return ::capnp::_::PointerHelpers<SturdyRef>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 // Persistent<SturdyRef, Owner>::SaveResults
@@ -981,23 +981,23 @@ inline typename  ::capnp::RealmGateway<InternalRef, ExternalRef, InternalOwner, 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getCap() const {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Pipeline::getCap() {
@@ -1006,45 +1006,45 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client RealmGa
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client&& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setCap(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::Client& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), cap);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<ExternalRef, ExternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<ExternalRef, ExternalOwner>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Reader::getParams() const {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::getParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1055,23 +1055,23 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Pi
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::setParams(typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Reader value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::initParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>&& value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams::Builder::disownParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<InternalRef, InternalOwner>::SaveParams>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ImportParams
@@ -1110,23 +1110,23 @@ const ::capnp::_::RawBrandedSchema RealmGateway<InternalRef, ExternalRef, Intern
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getCap() const {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Pipeline::getCap() {
@@ -1135,45 +1135,45 @@ inline typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client RealmGa
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client&& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(cap));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(cap));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setCap(typename  ::capnp::Persistent<InternalRef, InternalOwner>::Client& cap) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), cap);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), cap);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan< ::capnp::Persistent<InternalRef, InternalOwner>> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownCap() {
   return ::capnp::_::PointerHelpers< ::capnp::Persistent<InternalRef, InternalOwner>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #endif  // !CAPNP_LITE
 
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline bool RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Reader::getParams() const {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::getParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
@@ -1184,23 +1184,23 @@ inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Pi
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::setParams(typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Reader value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams::Builder RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::initParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline void RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::adoptParams(
     ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>&& value) {
   ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 template <typename InternalRef, typename ExternalRef, typename InternalOwner, typename ExternalOwner>
 inline ::capnp::Orphan<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams> RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams::Builder::disownParams() {
   return ::capnp::_::PointerHelpers<typename  ::capnp::Persistent<ExternalRef, ExternalOwner>::SaveParams>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 // RealmGateway<InternalRef, ExternalRef, InternalOwner, ExternalOwner>::ExportParams

--- a/c++/src/capnp/pointer-helpers.h
+++ b/c++/src/capnp/pointer-helpers.h
@@ -113,12 +113,12 @@ struct PointerHelpers<T, Kind::BLOB> {
   static inline typename T::Reader get(PointerReader reader,
                                        const void* defaultValue = nullptr,
                                        uint defaultBytes = 0) {
-    return reader.getBlob<T>(defaultValue, defaultBytes * BYTES);
+    return reader.getBlob<T>(defaultValue, guarded(defaultBytes) * BYTES);
   }
   static inline typename T::Builder get(PointerBuilder builder,
                                         const void* defaultValue = nullptr,
                                         uint defaultBytes = 0) {
-    return builder.getBlob<T>(defaultValue, defaultBytes * BYTES);
+    return builder.getBlob<T>(defaultValue, guarded(defaultBytes) * BYTES);
   }
   static inline void set(PointerBuilder builder, typename T::Reader value) {
     builder.setBlob<T>(value);
@@ -127,7 +127,7 @@ struct PointerHelpers<T, Kind::BLOB> {
     builder.setBlob<T>(value);
   }
   static inline typename T::Builder init(PointerBuilder builder, uint size) {
-    return builder.initBlob<T>(size * BYTES);
+    return builder.initBlob<T>(guarded(size) * BYTES);
   }
   static inline void adopt(PointerBuilder builder, Orphan<T>&& value) {
     builder.adopt(kj::mv(value.builder));

--- a/c++/src/capnp/pointer-helpers.h
+++ b/c++/src/capnp/pointer-helpers.h
@@ -113,12 +113,12 @@ struct PointerHelpers<T, Kind::BLOB> {
   static inline typename T::Reader get(PointerReader reader,
                                        const void* defaultValue = nullptr,
                                        uint defaultBytes = 0) {
-    return reader.getBlob<T>(defaultValue, guarded(defaultBytes) * BYTES);
+    return reader.getBlob<T>(defaultValue, bounded(defaultBytes) * BYTES);
   }
   static inline typename T::Builder get(PointerBuilder builder,
                                         const void* defaultValue = nullptr,
                                         uint defaultBytes = 0) {
-    return builder.getBlob<T>(defaultValue, guarded(defaultBytes) * BYTES);
+    return builder.getBlob<T>(defaultValue, bounded(defaultBytes) * BYTES);
   }
   static inline void set(PointerBuilder builder, typename T::Reader value) {
     builder.setBlob<T>(value);
@@ -127,7 +127,7 @@ struct PointerHelpers<T, Kind::BLOB> {
     builder.setBlob<T>(value);
   }
   static inline typename T::Builder init(PointerBuilder builder, uint size) {
-    return builder.initBlob<T>(guarded(size) * BYTES);
+    return builder.initBlob<T>(bounded(size) * BYTES);
   }
   static inline void adopt(PointerBuilder builder, Orphan<T>&& value) {
     builder.adopt(kj::mv(value.builder));

--- a/c++/src/capnp/rpc-twoparty.capnp.h
+++ b/c++/src/capnp/rpc-twoparty.capnp.h
@@ -600,121 +600,121 @@ private:
 
 inline  ::capnp::rpc::twoparty::Side VatId::Reader::getSide() const {
   return _reader.getDataField< ::capnp::rpc::twoparty::Side>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::twoparty::Side VatId::Builder::getSide() {
   return _builder.getDataField< ::capnp::rpc::twoparty::Side>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void VatId::Builder::setSide( ::capnp::rpc::twoparty::Side value) {
   _builder.setDataField< ::capnp::rpc::twoparty::Side>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t ProvisionId::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ProvisionId::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void ProvisionId::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinKeyPart::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinKeyPart::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartNum() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartNum() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartNum( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinResult::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinResult::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::getSucceeded() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool JoinResult::Builder::getSucceeded() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setSucceeded(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JoinResult::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader JoinResult::Reader::getCap() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::getCap() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::initCap() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }

--- a/c++/src/capnp/rpc-twoparty.capnp.h
+++ b/c++/src/capnp/rpc-twoparty.capnp.h
@@ -600,119 +600,121 @@ private:
 
 inline  ::capnp::rpc::twoparty::Side VatId::Reader::getSide() const {
   return _reader.getDataField< ::capnp::rpc::twoparty::Side>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::twoparty::Side VatId::Builder::getSide() {
   return _builder.getDataField< ::capnp::rpc::twoparty::Side>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void VatId::Builder::setSide( ::capnp::rpc::twoparty::Side value) {
   _builder.setDataField< ::capnp::rpc::twoparty::Side>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t ProvisionId::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ProvisionId::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void ProvisionId::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinKeyPart::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinKeyPart::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartCount() const {
   return _reader.getDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartCount() {
   return _builder.getDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartNum() const {
   return _reader.getDataField< ::uint16_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartNum() {
   return _builder.getDataField< ::uint16_t>(
-      3 * ::capnp::ELEMENTS);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartNum( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      3 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinResult::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinResult::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::getSucceeded() const {
   return _reader.getDataField<bool>(
-      32 * ::capnp::ELEMENTS);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool JoinResult::Builder::getSucceeded() {
   return _builder.getDataField<bool>(
-      32 * ::capnp::ELEMENTS);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setSucceeded(bool value) {
   _builder.setDataField<bool>(
-      32 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::hasCap() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JoinResult::Builder::hasCap() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader JoinResult::Reader::getCap() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::getCap() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::initCap() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }

--- a/c++/src/capnp/rpc-twoparty.capnp.h
+++ b/c++/src/capnp/rpc-twoparty.capnp.h
@@ -600,121 +600,121 @@ private:
 
 inline  ::capnp::rpc::twoparty::Side VatId::Reader::getSide() const {
   return _reader.getDataField< ::capnp::rpc::twoparty::Side>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::twoparty::Side VatId::Builder::getSide() {
   return _builder.getDataField< ::capnp::rpc::twoparty::Side>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void VatId::Builder::setSide( ::capnp::rpc::twoparty::Side value) {
   _builder.setDataField< ::capnp::rpc::twoparty::Side>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t ProvisionId::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ProvisionId::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void ProvisionId::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinKeyPart::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinKeyPart::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t JoinKeyPart::Reader::getPartNum() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t JoinKeyPart::Builder::getPartNum() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline void JoinKeyPart::Builder::setPartNum( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t JoinResult::Reader::getJoinId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t JoinResult::Builder::getJoinId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setJoinId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::getSucceeded() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool JoinResult::Builder::getSucceeded() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
 }
 inline void JoinResult::Builder::setSucceeded(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool JoinResult::Reader::hasCap() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool JoinResult::Builder::hasCap() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader JoinResult::Reader::getCap() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::getCap() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder JoinResult::Builder::initCap() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }

--- a/c++/src/capnp/rpc.capnp.h
+++ b/c++/src/capnp/rpc.capnp.h
@@ -2471,11 +2471,11 @@ private:
 
 inline  ::capnp::rpc::Message::Which Message::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Message::Which Message::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Message::Reader::isUnimplemented() const {
@@ -2487,49 +2487,49 @@ inline bool Message::Builder::isUnimplemented() {
 inline bool Message::Reader::hasUnimplemented() const {
   if (which() != Message::UNIMPLEMENTED) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasUnimplemented() {
   if (which() != Message::UNIMPLEMENTED) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Message::Reader Message::Reader::getUnimplemented() const {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::getUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setUnimplemented( ::capnp::rpc::Message::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::initUnimplemented() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptUnimplemented(
     ::capnp::Orphan< ::capnp::rpc::Message>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Message> Message::Builder::disownUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAbort() const {
@@ -2541,49 +2541,49 @@ inline bool Message::Builder::isAbort() {
 inline bool Message::Reader::hasAbort() const {
   if (which() != Message::ABORT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAbort() {
   if (which() != Message::ABORT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Message::Reader::getAbort() const {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::getAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAbort( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::initAbort() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAbort(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Message::Builder::disownAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isCall() const {
@@ -2595,49 +2595,49 @@ inline bool Message::Builder::isCall() {
 inline bool Message::Reader::hasCall() const {
   if (which() != Message::CALL) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasCall() {
   if (which() != Message::CALL) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Call::Reader Message::Reader::getCall() const {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::getCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setCall( ::capnp::rpc::Call::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::initCall() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::rpc::Call>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Call> Message::Builder::disownCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isReturn() const {
@@ -2649,49 +2649,49 @@ inline bool Message::Builder::isReturn() {
 inline bool Message::Reader::hasReturn() const {
   if (which() != Message::RETURN) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasReturn() {
   if (which() != Message::RETURN) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Return::Reader Message::Reader::getReturn() const {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::getReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setReturn( ::capnp::rpc::Return::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::initReturn() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptReturn(
     ::capnp::Orphan< ::capnp::rpc::Return>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Return> Message::Builder::disownReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isFinish() const {
@@ -2703,49 +2703,49 @@ inline bool Message::Builder::isFinish() {
 inline bool Message::Reader::hasFinish() const {
   if (which() != Message::FINISH) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasFinish() {
   if (which() != Message::FINISH) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Finish::Reader Message::Reader::getFinish() const {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::getFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setFinish( ::capnp::rpc::Finish::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::initFinish() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptFinish(
     ::capnp::Orphan< ::capnp::rpc::Finish>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Finish> Message::Builder::disownFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isResolve() const {
@@ -2757,49 +2757,49 @@ inline bool Message::Builder::isResolve() {
 inline bool Message::Reader::hasResolve() const {
   if (which() != Message::RESOLVE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasResolve() {
   if (which() != Message::RESOLVE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Resolve::Reader Message::Reader::getResolve() const {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::getResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setResolve( ::capnp::rpc::Resolve::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::initResolve() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptResolve(
     ::capnp::Orphan< ::capnp::rpc::Resolve>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Resolve> Message::Builder::disownResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isRelease() const {
@@ -2811,49 +2811,49 @@ inline bool Message::Builder::isRelease() {
 inline bool Message::Reader::hasRelease() const {
   if (which() != Message::RELEASE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasRelease() {
   if (which() != Message::RELEASE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Release::Reader Message::Reader::getRelease() const {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::getRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setRelease( ::capnp::rpc::Release::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::initRelease() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptRelease(
     ::capnp::Orphan< ::capnp::rpc::Release>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Release> Message::Builder::disownRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteSave() const {
@@ -2865,30 +2865,30 @@ inline bool Message::Builder::isObsoleteSave() {
 inline bool Message::Reader::hasObsoleteSave() const {
   if (which() != Message::OBSOLETE_SAVE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteSave() {
   if (which() != Message::OBSOLETE_SAVE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteSave() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteSave() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteSave() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2902,49 +2902,49 @@ inline bool Message::Builder::isBootstrap() {
 inline bool Message::Reader::hasBootstrap() const {
   if (which() != Message::BOOTSTRAP) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasBootstrap() {
   if (which() != Message::BOOTSTRAP) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Bootstrap::Reader Message::Reader::getBootstrap() const {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::getBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setBootstrap( ::capnp::rpc::Bootstrap::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::initBootstrap() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptBootstrap(
     ::capnp::Orphan< ::capnp::rpc::Bootstrap>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Bootstrap> Message::Builder::disownBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteDelete() const {
@@ -2956,30 +2956,30 @@ inline bool Message::Builder::isObsoleteDelete() {
 inline bool Message::Reader::hasObsoleteDelete() const {
   if (which() != Message::OBSOLETE_DELETE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteDelete() {
   if (which() != Message::OBSOLETE_DELETE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteDelete() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteDelete() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteDelete() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2993,49 +2993,49 @@ inline bool Message::Builder::isProvide() {
 inline bool Message::Reader::hasProvide() const {
   if (which() != Message::PROVIDE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasProvide() {
   if (which() != Message::PROVIDE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Provide::Reader Message::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::getProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setProvide( ::capnp::rpc::Provide::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::initProvide() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptProvide(
     ::capnp::Orphan< ::capnp::rpc::Provide>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Provide> Message::Builder::disownProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAccept() const {
@@ -3047,49 +3047,49 @@ inline bool Message::Builder::isAccept() {
 inline bool Message::Reader::hasAccept() const {
   if (which() != Message::ACCEPT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAccept() {
   if (which() != Message::ACCEPT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Accept::Reader Message::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::getAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAccept( ::capnp::rpc::Accept::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::initAccept() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAccept(
     ::capnp::Orphan< ::capnp::rpc::Accept>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Accept> Message::Builder::disownAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isJoin() const {
@@ -3101,49 +3101,49 @@ inline bool Message::Builder::isJoin() {
 inline bool Message::Reader::hasJoin() const {
   if (which() != Message::JOIN) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasJoin() {
   if (which() != Message::JOIN) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Join::Reader Message::Reader::getJoin() const {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::getJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setJoin( ::capnp::rpc::Join::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::initJoin() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptJoin(
     ::capnp::Orphan< ::capnp::rpc::Join>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Join> Message::Builder::disownJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isDisembargo() const {
@@ -3155,117 +3155,117 @@ inline bool Message::Builder::isDisembargo() {
 inline bool Message::Reader::hasDisembargo() const {
   if (which() != Message::DISEMBARGO) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasDisembargo() {
   if (which() != Message::DISEMBARGO) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Disembargo::Reader Message::Reader::getDisembargo() const {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::getDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setDisembargo( ::capnp::rpc::Disembargo::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::initDisembargo() {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptDisembargo(
     ::capnp::Orphan< ::capnp::rpc::Disembargo>&& value) {
   _builder.setDataField<Message::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Disembargo> Message::Builder::disownDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Bootstrap::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Bootstrap::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Bootstrap::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Bootstrap::Reader::hasDeprecatedObjectId() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Bootstrap::Builder::hasDeprecatedObjectId() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Bootstrap::Reader::getDeprecatedObjectId() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::getDeprecatedObjectId() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::initDeprecatedObjectId() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Call::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Call::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Call::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
@@ -3274,65 +3274,65 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Call::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Call::Reader::getInterfaceId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Call::Builder::getInterfaceId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setInterfaceId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Call::Reader::getMethodId() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Call::Builder::getMethodId() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setMethodId( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Call::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
@@ -3341,20 +3341,20 @@ inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setParams( ::capnp::rpc::Payload::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::initParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Call::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline typename Call::SendResultsTo::Reader Call::Reader::getSendResultsTo() const {
@@ -3369,31 +3369,31 @@ inline typename Call::SendResultsTo::Pipeline Call::Pipeline::getSendResultsTo()
 }
 #endif  // !CAPNP_LITE
 inline typename Call::SendResultsTo::Builder Call::Builder::initSendResultsTo() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<3>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<2>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<3>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<2>() * ::capnp::POINTERS).clear();
   return typename Call::SendResultsTo::Builder(_builder);
 }
 inline bool Call::Reader::getAllowThirdPartyTailCall() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::Builder::getAllowThirdPartyTailCall() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setAllowThirdPartyTailCall(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::SendResultsTo::Reader::isCaller() const {
@@ -3406,20 +3406,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getCaller() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getCaller() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setCaller( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isYourself() const {
@@ -3432,20 +3432,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getYourself() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getYourself() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setYourself( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isThirdParty() const {
@@ -3457,69 +3457,69 @@ inline bool Call::SendResultsTo::Builder::isThirdParty() {
 inline bool Call::SendResultsTo::Reader::hasThirdParty() const {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::SendResultsTo::Builder::hasThirdParty() {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Call::SendResultsTo::Reader::getThirdParty() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::getThirdParty() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::initThirdParty() {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::Return::Which Return::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Return::Which Return::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Reader::getAnswerId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getAnswerId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setAnswerId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::getReleaseParamCaps() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Return::Builder::getReleaseParamCaps() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Return::Builder::setReleaseParamCaps(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, value, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline bool Return::Reader::isResults() const {
@@ -3531,49 +3531,49 @@ inline bool Return::Builder::isResults() {
 inline bool Return::Reader::hasResults() const {
   if (which() != Return::RESULTS) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasResults() {
   if (which() != Return::RESULTS) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Return::Reader::getResults() const {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::getResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setResults( ::capnp::rpc::Payload::Reader value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::initResults() {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptResults(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Return::Builder::disownResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isException() const {
@@ -3585,49 +3585,49 @@ inline bool Return::Builder::isException() {
 inline bool Return::Reader::hasException() const {
   if (which() != Return::EXCEPTION) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasException() {
   if (which() != Return::EXCEPTION) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Return::Reader::getException() const {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::getException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::initException() {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Return::Builder::disownException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isCanceled() const {
@@ -3640,20 +3640,20 @@ inline  ::capnp::Void Return::Reader::getCanceled() const {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getCanceled() {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setCanceled( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::CANCELED);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::CANCELED);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isResultsSentElsewhere() const {
@@ -3666,20 +3666,20 @@ inline  ::capnp::Void Return::Reader::getResultsSentElsewhere() const {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getResultsSentElsewhere() {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setResultsSentElsewhere( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isTakeFromOtherQuestion() const {
@@ -3692,20 +3692,20 @@ inline  ::uint32_t Return::Reader::getTakeFromOtherQuestion() const {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getTakeFromOtherQuestion() {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setTakeFromOtherQuestion( ::uint32_t value) {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isAcceptFromThirdParty() const {
@@ -3717,83 +3717,83 @@ inline bool Return::Builder::isAcceptFromThirdParty() {
 inline bool Return::Reader::hasAcceptFromThirdParty() const {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasAcceptFromThirdParty() {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Return::Reader::getAcceptFromThirdParty() const {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::getAcceptFromThirdParty() {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::initAcceptFromThirdParty() {
   _builder.setDataField<Return::Which>(
-      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
+      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Finish::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Finish::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Finish::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Finish::Reader::getReleaseResultCaps() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Finish::Builder::getReleaseResultCaps() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Finish::Builder::setReleaseResultCaps(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, value, true);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline  ::capnp::rpc::Resolve::Which Resolve::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Resolve::Which Resolve::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Reader::getPromiseId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Builder::getPromiseId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Resolve::Builder::setPromiseId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Resolve::Reader::isCap() const {
@@ -3805,49 +3805,49 @@ inline bool Resolve::Builder::isCap() {
 inline bool Resolve::Reader::hasCap() const {
   if (which() != Resolve::CAP) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasCap() {
   if (which() != Resolve::CAP) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::CapDescriptor::Reader Resolve::Reader::getCap() const {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::getCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setCap( ::capnp::rpc::CapDescriptor::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::initCap() {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::rpc::CapDescriptor>&& value) {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::CapDescriptor> Resolve::Builder::disownCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Resolve::Reader::isException() const {
@@ -3859,94 +3859,94 @@ inline bool Resolve::Builder::isException() {
 inline bool Resolve::Reader::hasException() const {
   if (which() != Resolve::EXCEPTION) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasException() {
   if (which() != Resolve::EXCEPTION) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Resolve::Reader::getException() const {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::getException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::initException() {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Resolve::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Resolve::Builder::disownException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Release::Reader::getId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Release::Reader::getReferenceCount() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getReferenceCount() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setReferenceCount( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Disembargo::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Disembargo::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() {
@@ -3955,20 +3955,20 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() 
 #endif  // !CAPNP_LITE
 inline void Disembargo::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Disembargo::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Disembargo::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Disembargo::Context::Reader Disembargo::Reader::getContext() const {
@@ -3983,17 +3983,17 @@ inline typename Disembargo::Context::Pipeline Disembargo::Pipeline::getContext()
 }
 #endif  // !CAPNP_LITE
 inline typename Disembargo::Context::Builder Disembargo::Builder::initContext() {
-  _builder.setDataField< ::uint32_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Disembargo::Context::Builder(_builder);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool Disembargo::Context::Reader::isSenderLoopback() const {
@@ -4006,20 +4006,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getSenderLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getSenderLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setSenderLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isReceiverLoopback() const {
@@ -4032,20 +4032,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getReceiverLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getReceiverLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setReceiverLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isAccept() const {
@@ -4058,20 +4058,20 @@ inline  ::capnp::Void Disembargo::Context::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Disembargo::Context::Builder::getAccept() {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setAccept( ::capnp::Void value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isProvide() const {
@@ -4084,51 +4084,51 @@ inline  ::uint32_t Disembargo::Context::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getProvide() {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setProvide( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Provide::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Provide::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Provide::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Provide::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Provide::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
@@ -4137,125 +4137,125 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Provide::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Provide::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Provide::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Provide::Reader::hasRecipient() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasRecipient() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Provide::Reader::getRecipient() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::getRecipient() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::initRecipient() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Accept::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Accept::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Accept::Reader::hasProvision() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Accept::Builder::hasProvision() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Accept::Reader::getProvision() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::getProvision() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::initProvision() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Accept::Reader::getEmbargo() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool Accept::Builder::getEmbargo() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setEmbargo(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<32>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Join::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Join::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Join::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Join::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Join::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
@@ -4264,52 +4264,52 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Join::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Join::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Join::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Join::Reader::hasKeyPart() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasKeyPart() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Join::Reader::getKeyPart() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::getKeyPart() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::initKeyPart() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool MessageTarget::Reader::isImportedCap() const {
@@ -4322,20 +4322,20 @@ inline  ::uint32_t MessageTarget::Reader::getImportedCap() const {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t MessageTarget::Builder::getImportedCap() {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void MessageTarget::Builder::setImportedCap( ::uint32_t value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool MessageTarget::Reader::isPromisedAnswer() const {
@@ -4347,115 +4347,115 @@ inline bool MessageTarget::Builder::isPromisedAnswer() {
 inline bool MessageTarget::Reader::hasPromisedAnswer() const {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool MessageTarget::Builder::hasPromisedAnswer() {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader MessageTarget::Reader::getPromisedAnswer() const {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::getPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::setPromisedAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::initPromisedAnswer() {
   _builder.setDataField<MessageTarget::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::adoptPromisedAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> MessageTarget::Builder::disownPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Payload::Reader::hasContent() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasContent() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Payload::Reader::getContent() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::getContent() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::initContent() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Payload::Reader::hasCapTable() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasCapTable() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader Payload::Reader::getCapTable() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::getCapTable() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Payload::Builder::setCapTable( ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::initCapTable(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Payload::Builder::adoptCapTable(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>> Payload::Builder::disownCapTable() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool CapDescriptor::Reader::isNone() const {
@@ -4468,20 +4468,20 @@ inline  ::capnp::Void CapDescriptor::Reader::getNone() const {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void CapDescriptor::Builder::getNone() {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::NONE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderHosted() const {
@@ -4494,20 +4494,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderPromise() const {
@@ -4520,20 +4520,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderPromise() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderPromise() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderPromise( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverHosted() const {
@@ -4546,20 +4546,20 @@ inline  ::uint32_t CapDescriptor::Reader::getReceiverHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getReceiverHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setReceiverHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverAnswer() const {
@@ -4571,49 +4571,49 @@ inline bool CapDescriptor::Builder::isReceiverAnswer() {
 inline bool CapDescriptor::Reader::hasReceiverAnswer() const {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasReceiverAnswer() {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader CapDescriptor::Reader::getReceiverAnswer() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::getReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setReceiverAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::initReceiverAnswer() {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptReceiverAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> CapDescriptor::Builder::disownReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CapDescriptor::Reader::isThirdPartyHosted() const {
@@ -4625,106 +4625,106 @@ inline bool CapDescriptor::Builder::isThirdPartyHosted() {
 inline bool CapDescriptor::Reader::hasThirdPartyHosted() const {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasThirdPartyHosted() {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Reader CapDescriptor::Reader::getThirdPartyHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::getThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setThirdPartyHosted( ::capnp::rpc::ThirdPartyCapDescriptor::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::initThirdPartyHosted() {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptThirdPartyHosted(
     ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor> CapDescriptor::Builder::disownThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t PromisedAnswer::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t PromisedAnswer::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Reader::hasTransform() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool PromisedAnswer::Builder::hasTransform() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader PromisedAnswer::Reader::getTransform() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::getTransform() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void PromisedAnswer::Builder::setTransform( ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::initTransform(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void PromisedAnswer::Builder::adoptTransform(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>> PromisedAnswer::Builder::disownTransform() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool PromisedAnswer::Op::Reader::isNoop() const {
@@ -4737,20 +4737,20 @@ inline  ::capnp::Void PromisedAnswer::Op::Reader::getNoop() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void PromisedAnswer::Op::Builder::getNoop() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setNoop( ::capnp::Void value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Op::Reader::isGetPointerField() const {
@@ -4763,133 +4763,133 @@ inline  ::uint16_t PromisedAnswer::Op::Reader::getGetPointerField() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t PromisedAnswer::Op::Builder::getGetPointerField() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setGetPointerField( ::uint16_t value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ThirdPartyCapDescriptor::Reader::hasId() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ThirdPartyCapDescriptor::Builder::hasId() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader ThirdPartyCapDescriptor::Reader::getId() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::getId() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::initId() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Reader::getVineId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Builder::getVineId() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void ThirdPartyCapDescriptor::Builder::setVineId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Exception::Reader::hasReason() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Exception::Builder::hasReason() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Exception::Reader::getReason() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Exception::Builder::getReason() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Exception::Builder::setReason( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Exception::Builder::initReason(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Exception::Builder::adoptReason(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Exception::Builder::disownReason() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Exception::Reader::getObsoleteIsCallersFault() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Exception::Builder::getObsoleteIsCallersFault() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteIsCallersFault(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Exception::Reader::getObsoleteDurability() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Exception::Builder::getObsoleteDurability() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteDurability( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Reader::getType() const {
   return _reader.getDataField< ::capnp::rpc::Exception::Type>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Builder::getType() {
   return _builder.getDataField< ::capnp::rpc::Exception::Type>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setType( ::capnp::rpc::Exception::Type value) {
   _builder.setDataField< ::capnp::rpc::Exception::Type>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 }  // namespace

--- a/c++/src/capnp/rpc.capnp.h
+++ b/c++/src/capnp/rpc.capnp.h
@@ -2471,11 +2471,11 @@ private:
 
 inline  ::capnp::rpc::Message::Which Message::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Message::Which Message::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Message::Reader::isUnimplemented() const {
@@ -2487,49 +2487,49 @@ inline bool Message::Builder::isUnimplemented() {
 inline bool Message::Reader::hasUnimplemented() const {
   if (which() != Message::UNIMPLEMENTED) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasUnimplemented() {
   if (which() != Message::UNIMPLEMENTED) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Message::Reader Message::Reader::getUnimplemented() const {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::getUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setUnimplemented( ::capnp::rpc::Message::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::initUnimplemented() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptUnimplemented(
     ::capnp::Orphan< ::capnp::rpc::Message>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Message> Message::Builder::disownUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAbort() const {
@@ -2541,49 +2541,49 @@ inline bool Message::Builder::isAbort() {
 inline bool Message::Reader::hasAbort() const {
   if (which() != Message::ABORT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAbort() {
   if (which() != Message::ABORT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Message::Reader::getAbort() const {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::getAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAbort( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::initAbort() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAbort(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ABORT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Message::Builder::disownAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isCall() const {
@@ -2595,49 +2595,49 @@ inline bool Message::Builder::isCall() {
 inline bool Message::Reader::hasCall() const {
   if (which() != Message::CALL) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasCall() {
   if (which() != Message::CALL) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Call::Reader Message::Reader::getCall() const {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::getCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setCall( ::capnp::rpc::Call::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::CALL);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::initCall() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::CALL);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::rpc::Call>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::CALL);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Call> Message::Builder::disownCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isReturn() const {
@@ -2649,49 +2649,49 @@ inline bool Message::Builder::isReturn() {
 inline bool Message::Reader::hasReturn() const {
   if (which() != Message::RETURN) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasReturn() {
   if (which() != Message::RETURN) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Return::Reader Message::Reader::getReturn() const {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::getReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setReturn( ::capnp::rpc::Return::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::initReturn() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptReturn(
     ::capnp::Orphan< ::capnp::rpc::Return>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RETURN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Return> Message::Builder::disownReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isFinish() const {
@@ -2703,49 +2703,49 @@ inline bool Message::Builder::isFinish() {
 inline bool Message::Reader::hasFinish() const {
   if (which() != Message::FINISH) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasFinish() {
   if (which() != Message::FINISH) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Finish::Reader Message::Reader::getFinish() const {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::getFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setFinish( ::capnp::rpc::Finish::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::initFinish() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptFinish(
     ::capnp::Orphan< ::capnp::rpc::Finish>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::FINISH);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Finish> Message::Builder::disownFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isResolve() const {
@@ -2757,49 +2757,49 @@ inline bool Message::Builder::isResolve() {
 inline bool Message::Reader::hasResolve() const {
   if (which() != Message::RESOLVE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasResolve() {
   if (which() != Message::RESOLVE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Resolve::Reader Message::Reader::getResolve() const {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::getResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setResolve( ::capnp::rpc::Resolve::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::initResolve() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptResolve(
     ::capnp::Orphan< ::capnp::rpc::Resolve>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Resolve> Message::Builder::disownResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isRelease() const {
@@ -2811,49 +2811,49 @@ inline bool Message::Builder::isRelease() {
 inline bool Message::Reader::hasRelease() const {
   if (which() != Message::RELEASE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasRelease() {
   if (which() != Message::RELEASE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Release::Reader Message::Reader::getRelease() const {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::getRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setRelease( ::capnp::rpc::Release::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::initRelease() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptRelease(
     ::capnp::Orphan< ::capnp::rpc::Release>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Release> Message::Builder::disownRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteSave() const {
@@ -2865,30 +2865,30 @@ inline bool Message::Builder::isObsoleteSave() {
 inline bool Message::Reader::hasObsoleteSave() const {
   if (which() != Message::OBSOLETE_SAVE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteSave() {
   if (which() != Message::OBSOLETE_SAVE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteSave() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteSave() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteSave() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2902,49 +2902,49 @@ inline bool Message::Builder::isBootstrap() {
 inline bool Message::Reader::hasBootstrap() const {
   if (which() != Message::BOOTSTRAP) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasBootstrap() {
   if (which() != Message::BOOTSTRAP) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Bootstrap::Reader Message::Reader::getBootstrap() const {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::getBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setBootstrap( ::capnp::rpc::Bootstrap::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::initBootstrap() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptBootstrap(
     ::capnp::Orphan< ::capnp::rpc::Bootstrap>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Bootstrap> Message::Builder::disownBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteDelete() const {
@@ -2956,30 +2956,30 @@ inline bool Message::Builder::isObsoleteDelete() {
 inline bool Message::Reader::hasObsoleteDelete() const {
   if (which() != Message::OBSOLETE_DELETE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteDelete() {
   if (which() != Message::OBSOLETE_DELETE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteDelete() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteDelete() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteDelete() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2993,49 +2993,49 @@ inline bool Message::Builder::isProvide() {
 inline bool Message::Reader::hasProvide() const {
   if (which() != Message::PROVIDE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasProvide() {
   if (which() != Message::PROVIDE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Provide::Reader Message::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::getProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setProvide( ::capnp::rpc::Provide::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::initProvide() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptProvide(
     ::capnp::Orphan< ::capnp::rpc::Provide>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Provide> Message::Builder::disownProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAccept() const {
@@ -3047,49 +3047,49 @@ inline bool Message::Builder::isAccept() {
 inline bool Message::Reader::hasAccept() const {
   if (which() != Message::ACCEPT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAccept() {
   if (which() != Message::ACCEPT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Accept::Reader Message::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::getAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAccept( ::capnp::rpc::Accept::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::initAccept() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAccept(
     ::capnp::Orphan< ::capnp::rpc::Accept>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Accept> Message::Builder::disownAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isJoin() const {
@@ -3101,49 +3101,49 @@ inline bool Message::Builder::isJoin() {
 inline bool Message::Reader::hasJoin() const {
   if (which() != Message::JOIN) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasJoin() {
   if (which() != Message::JOIN) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Join::Reader Message::Reader::getJoin() const {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::getJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setJoin( ::capnp::rpc::Join::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::initJoin() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptJoin(
     ::capnp::Orphan< ::capnp::rpc::Join>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::JOIN);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Join> Message::Builder::disownJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isDisembargo() const {
@@ -3155,117 +3155,117 @@ inline bool Message::Builder::isDisembargo() {
 inline bool Message::Reader::hasDisembargo() const {
   if (which() != Message::DISEMBARGO) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasDisembargo() {
   if (which() != Message::DISEMBARGO) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Disembargo::Reader Message::Reader::getDisembargo() const {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::getDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setDisembargo( ::capnp::rpc::Disembargo::Reader value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::initDisembargo() {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptDisembargo(
     ::capnp::Orphan< ::capnp::rpc::Disembargo>&& value) {
   _builder.setDataField<Message::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Disembargo> Message::Builder::disownDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Bootstrap::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Bootstrap::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Bootstrap::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Bootstrap::Reader::hasDeprecatedObjectId() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Bootstrap::Builder::hasDeprecatedObjectId() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Bootstrap::Reader::getDeprecatedObjectId() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::getDeprecatedObjectId() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::initDeprecatedObjectId() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Call::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Call::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Call::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
@@ -3274,65 +3274,65 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Call::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Call::Reader::getInterfaceId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Call::Builder::getInterfaceId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setInterfaceId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Call::Reader::getMethodId() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Call::Builder::getMethodId() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setMethodId( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasParams() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasParams() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Call::Reader::getParams() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::getParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
@@ -3341,20 +3341,20 @@ inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setParams( ::capnp::rpc::Payload::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::initParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Call::Builder::disownParams() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline typename Call::SendResultsTo::Reader Call::Reader::getSendResultsTo() const {
@@ -3369,31 +3369,31 @@ inline typename Call::SendResultsTo::Pipeline Call::Pipeline::getSendResultsTo()
 }
 #endif  // !CAPNP_LITE
 inline typename Call::SendResultsTo::Builder Call::Builder::initSendResultsTo() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<3>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<2>() * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<3>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS).clear();
   return typename Call::SendResultsTo::Builder(_builder);
 }
 inline bool Call::Reader::getAllowThirdPartyTailCall() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::Builder::getAllowThirdPartyTailCall() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setAllowThirdPartyTailCall(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::SendResultsTo::Reader::isCaller() const {
@@ -3406,20 +3406,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getCaller() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getCaller() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setCaller( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isYourself() const {
@@ -3432,20 +3432,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getYourself() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getYourself() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setYourself( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isThirdParty() const {
@@ -3457,69 +3457,69 @@ inline bool Call::SendResultsTo::Builder::isThirdParty() {
 inline bool Call::SendResultsTo::Reader::hasThirdParty() const {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::SendResultsTo::Builder::hasThirdParty() {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Call::SendResultsTo::Reader::getThirdParty() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::getThirdParty() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::initThirdParty() {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::Return::Which Return::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Return::Which Return::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Reader::getAnswerId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getAnswerId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setAnswerId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::getReleaseParamCaps() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Return::Builder::getReleaseParamCaps() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Return::Builder::setReleaseParamCaps(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline bool Return::Reader::isResults() const {
@@ -3531,49 +3531,49 @@ inline bool Return::Builder::isResults() {
 inline bool Return::Reader::hasResults() const {
   if (which() != Return::RESULTS) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasResults() {
   if (which() != Return::RESULTS) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Return::Reader::getResults() const {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::getResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setResults( ::capnp::rpc::Payload::Reader value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::initResults() {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptResults(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Return::Builder::disownResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isException() const {
@@ -3585,49 +3585,49 @@ inline bool Return::Builder::isException() {
 inline bool Return::Reader::hasException() const {
   if (which() != Return::EXCEPTION) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasException() {
   if (which() != Return::EXCEPTION) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Return::Reader::getException() const {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::getException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::initException() {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Return::Builder::disownException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isCanceled() const {
@@ -3640,20 +3640,20 @@ inline  ::capnp::Void Return::Reader::getCanceled() const {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getCanceled() {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setCanceled( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::CANCELED);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::CANCELED);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isResultsSentElsewhere() const {
@@ -3666,20 +3666,20 @@ inline  ::capnp::Void Return::Reader::getResultsSentElsewhere() const {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getResultsSentElsewhere() {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setResultsSentElsewhere( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isTakeFromOtherQuestion() const {
@@ -3692,20 +3692,20 @@ inline  ::uint32_t Return::Reader::getTakeFromOtherQuestion() const {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getTakeFromOtherQuestion() {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setTakeFromOtherQuestion( ::uint32_t value) {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isAcceptFromThirdParty() const {
@@ -3717,83 +3717,83 @@ inline bool Return::Builder::isAcceptFromThirdParty() {
 inline bool Return::Reader::hasAcceptFromThirdParty() const {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasAcceptFromThirdParty() {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Return::Reader::getAcceptFromThirdParty() const {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::getAcceptFromThirdParty() {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::initAcceptFromThirdParty() {
   _builder.setDataField<Return::Which>(
-      ::capnp::guarded<3>() * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
+      ::capnp::bounded<3>() * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Finish::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Finish::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Finish::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Finish::Reader::getReleaseResultCaps() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Finish::Builder::getReleaseResultCaps() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Finish::Builder::setReleaseResultCaps(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value, true);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline  ::capnp::rpc::Resolve::Which Resolve::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Resolve::Which Resolve::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Reader::getPromiseId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Builder::getPromiseId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Resolve::Builder::setPromiseId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Resolve::Reader::isCap() const {
@@ -3805,49 +3805,49 @@ inline bool Resolve::Builder::isCap() {
 inline bool Resolve::Reader::hasCap() const {
   if (which() != Resolve::CAP) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasCap() {
   if (which() != Resolve::CAP) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::CapDescriptor::Reader Resolve::Reader::getCap() const {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::getCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setCap( ::capnp::rpc::CapDescriptor::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::initCap() {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::rpc::CapDescriptor>&& value) {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
   ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::CapDescriptor> Resolve::Builder::disownCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Resolve::Reader::isException() const {
@@ -3859,94 +3859,94 @@ inline bool Resolve::Builder::isException() {
 inline bool Resolve::Reader::hasException() const {
   if (which() != Resolve::EXCEPTION) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasException() {
   if (which() != Resolve::EXCEPTION) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Resolve::Reader::getException() const {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::getException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::initException() {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Resolve::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
   ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Resolve::Builder::disownException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Release::Reader::getId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Release::Reader::getReferenceCount() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getReferenceCount() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setReferenceCount( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Disembargo::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Disembargo::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() {
@@ -3955,20 +3955,20 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() 
 #endif  // !CAPNP_LITE
 inline void Disembargo::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Disembargo::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Disembargo::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Disembargo::Context::Reader Disembargo::Reader::getContext() const {
@@ -3983,17 +3983,17 @@ inline typename Disembargo::Context::Pipeline Disembargo::Pipeline::getContext()
 }
 #endif  // !CAPNP_LITE
 inline typename Disembargo::Context::Builder Disembargo::Builder::initContext() {
-  _builder.setDataField< ::uint32_t>(::capnp::guarded<0>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::capnp::bounded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<2>() * ::capnp::ELEMENTS, 0);
   return typename Disembargo::Context::Builder(_builder);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool Disembargo::Context::Reader::isSenderLoopback() const {
@@ -4006,20 +4006,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getSenderLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getSenderLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setSenderLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isReceiverLoopback() const {
@@ -4032,20 +4032,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getReceiverLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getReceiverLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setReceiverLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isAccept() const {
@@ -4058,20 +4058,20 @@ inline  ::capnp::Void Disembargo::Context::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Disembargo::Context::Builder::getAccept() {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setAccept( ::capnp::Void value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isProvide() const {
@@ -4084,51 +4084,51 @@ inline  ::uint32_t Disembargo::Context::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getProvide() {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setProvide( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Provide::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Provide::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Provide::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Provide::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Provide::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
@@ -4137,125 +4137,125 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Provide::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Provide::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Provide::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Provide::Reader::hasRecipient() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasRecipient() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Provide::Reader::getRecipient() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::getRecipient() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::initRecipient() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Accept::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Accept::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Accept::Reader::hasProvision() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Accept::Builder::hasProvision() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Accept::Reader::getProvision() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::getProvision() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::initProvision() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Accept::Reader::getEmbargo() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool Accept::Builder::getEmbargo() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setEmbargo(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<32>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Join::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Join::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Join::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Join::Reader::hasTarget() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasTarget() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Join::Reader::getTarget() const {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::getTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
@@ -4264,52 +4264,52 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
 #endif  // !CAPNP_LITE
 inline void Join::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::initTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Join::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Join::Builder::disownTarget() {
   return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Join::Reader::hasKeyPart() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasKeyPart() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Join::Reader::getKeyPart() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::getKeyPart() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::initKeyPart() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool MessageTarget::Reader::isImportedCap() const {
@@ -4322,20 +4322,20 @@ inline  ::uint32_t MessageTarget::Reader::getImportedCap() const {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t MessageTarget::Builder::getImportedCap() {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void MessageTarget::Builder::setImportedCap( ::uint32_t value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool MessageTarget::Reader::isPromisedAnswer() const {
@@ -4347,115 +4347,115 @@ inline bool MessageTarget::Builder::isPromisedAnswer() {
 inline bool MessageTarget::Reader::hasPromisedAnswer() const {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool MessageTarget::Builder::hasPromisedAnswer() {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader MessageTarget::Reader::getPromisedAnswer() const {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::getPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::setPromisedAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::initPromisedAnswer() {
   _builder.setDataField<MessageTarget::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::adoptPromisedAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<MessageTarget::Which>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> MessageTarget::Builder::disownPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Payload::Reader::hasContent() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasContent() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Payload::Reader::getContent() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::getContent() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::initContent() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Payload::Reader::hasCapTable() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasCapTable() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader Payload::Reader::getCapTable() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::getCapTable() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Payload::Builder::setCapTable( ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::initCapTable(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Payload::Builder::adoptCapTable(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>> Payload::Builder::disownCapTable() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool CapDescriptor::Reader::isNone() const {
@@ -4468,20 +4468,20 @@ inline  ::capnp::Void CapDescriptor::Reader::getNone() const {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void CapDescriptor::Builder::getNone() {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::NONE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::NONE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderHosted() const {
@@ -4494,20 +4494,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderPromise() const {
@@ -4520,20 +4520,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderPromise() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderPromise() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderPromise( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverHosted() const {
@@ -4546,20 +4546,20 @@ inline  ::uint32_t CapDescriptor::Reader::getReceiverHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getReceiverHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setReceiverHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverAnswer() const {
@@ -4571,49 +4571,49 @@ inline bool CapDescriptor::Builder::isReceiverAnswer() {
 inline bool CapDescriptor::Reader::hasReceiverAnswer() const {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasReceiverAnswer() {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader CapDescriptor::Reader::getReceiverAnswer() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::getReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setReceiverAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::initReceiverAnswer() {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptReceiverAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
   ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> CapDescriptor::Builder::disownReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CapDescriptor::Reader::isThirdPartyHosted() const {
@@ -4625,106 +4625,106 @@ inline bool CapDescriptor::Builder::isThirdPartyHosted() {
 inline bool CapDescriptor::Reader::hasThirdPartyHosted() const {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasThirdPartyHosted() {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Reader CapDescriptor::Reader::getThirdPartyHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::getThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setThirdPartyHosted( ::capnp::rpc::ThirdPartyCapDescriptor::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::initThirdPartyHosted() {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptThirdPartyHosted(
     ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
   ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor> CapDescriptor::Builder::disownThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t PromisedAnswer::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t PromisedAnswer::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Reader::hasTransform() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool PromisedAnswer::Builder::hasTransform() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader PromisedAnswer::Reader::getTransform() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::getTransform() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void PromisedAnswer::Builder::setTransform( ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::initTransform(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void PromisedAnswer::Builder::adoptTransform(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>> PromisedAnswer::Builder::disownTransform() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool PromisedAnswer::Op::Reader::isNoop() const {
@@ -4737,20 +4737,20 @@ inline  ::capnp::Void PromisedAnswer::Op::Reader::getNoop() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void PromisedAnswer::Op::Builder::getNoop() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setNoop( ::capnp::Void value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Op::Reader::isGetPointerField() const {
@@ -4763,133 +4763,133 @@ inline  ::uint16_t PromisedAnswer::Op::Reader::getGetPointerField() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t PromisedAnswer::Op::Builder::getGetPointerField() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setGetPointerField( ::uint16_t value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ThirdPartyCapDescriptor::Reader::hasId() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ThirdPartyCapDescriptor::Builder::hasId() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader ThirdPartyCapDescriptor::Reader::getId() const {
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::getId() {
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::initId() {
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Reader::getVineId() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Builder::getVineId() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void ThirdPartyCapDescriptor::Builder::setVineId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Exception::Reader::hasReason() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Exception::Builder::hasReason() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Exception::Reader::getReason() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Exception::Builder::getReason() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Exception::Builder::setReason( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Exception::Builder::initReason(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Exception::Builder::adoptReason(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Exception::Builder::disownReason() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Exception::Reader::getObsoleteIsCallersFault() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Exception::Builder::getObsoleteIsCallersFault() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteIsCallersFault(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Exception::Reader::getObsoleteDurability() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Exception::Builder::getObsoleteDurability() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteDurability( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Reader::getType() const {
   return _reader.getDataField< ::capnp::rpc::Exception::Type>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Builder::getType() {
   return _builder.getDataField< ::capnp::rpc::Exception::Type>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setType( ::capnp::rpc::Exception::Type value) {
   _builder.setDataField< ::capnp::rpc::Exception::Type>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 }  // namespace

--- a/c++/src/capnp/rpc.capnp.h
+++ b/c++/src/capnp/rpc.capnp.h
@@ -2470,10 +2470,12 @@ private:
 // =======================================================================================
 
 inline  ::capnp::rpc::Message::Which Message::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Message::Which Message::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Message::Reader::isUnimplemented() const {
@@ -2484,48 +2486,50 @@ inline bool Message::Builder::isUnimplemented() {
 }
 inline bool Message::Reader::hasUnimplemented() const {
   if (which() != Message::UNIMPLEMENTED) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasUnimplemented() {
   if (which() != Message::UNIMPLEMENTED) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Message::Reader Message::Reader::getUnimplemented() const {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::getUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setUnimplemented( ::capnp::rpc::Message::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Message::Builder Message::Builder::initUnimplemented() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptUnimplemented(
     ::capnp::Orphan< ::capnp::rpc::Message>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::UNIMPLEMENTED);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Message> Message::Builder::disownUnimplemented() {
   KJ_IREQUIRE((which() == Message::UNIMPLEMENTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Message>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAbort() const {
@@ -2536,48 +2540,50 @@ inline bool Message::Builder::isAbort() {
 }
 inline bool Message::Reader::hasAbort() const {
   if (which() != Message::ABORT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAbort() {
   if (which() != Message::ABORT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Message::Reader::getAbort() const {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::getAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAbort( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ABORT);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Message::Builder::initAbort() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ABORT);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAbort(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ABORT);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ABORT);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Message::Builder::disownAbort() {
   KJ_IREQUIRE((which() == Message::ABORT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isCall() const {
@@ -2588,48 +2594,50 @@ inline bool Message::Builder::isCall() {
 }
 inline bool Message::Reader::hasCall() const {
   if (which() != Message::CALL) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasCall() {
   if (which() != Message::CALL) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Call::Reader Message::Reader::getCall() const {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::getCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setCall( ::capnp::rpc::Call::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::CALL);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Call::Builder Message::Builder::initCall() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::CALL);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptCall(
     ::capnp::Orphan< ::capnp::rpc::Call>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::CALL);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::CALL);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Call> Message::Builder::disownCall() {
   KJ_IREQUIRE((which() == Message::CALL),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Call>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isReturn() const {
@@ -2640,48 +2648,50 @@ inline bool Message::Builder::isReturn() {
 }
 inline bool Message::Reader::hasReturn() const {
   if (which() != Message::RETURN) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasReturn() {
   if (which() != Message::RETURN) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Return::Reader Message::Reader::getReturn() const {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::getReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setReturn( ::capnp::rpc::Return::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RETURN);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Return::Builder Message::Builder::initReturn() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RETURN);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptReturn(
     ::capnp::Orphan< ::capnp::rpc::Return>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RETURN);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RETURN);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Return> Message::Builder::disownReturn() {
   KJ_IREQUIRE((which() == Message::RETURN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Return>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isFinish() const {
@@ -2692,48 +2702,50 @@ inline bool Message::Builder::isFinish() {
 }
 inline bool Message::Reader::hasFinish() const {
   if (which() != Message::FINISH) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasFinish() {
   if (which() != Message::FINISH) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Finish::Reader Message::Reader::getFinish() const {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::getFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setFinish( ::capnp::rpc::Finish::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::FINISH);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Finish::Builder Message::Builder::initFinish() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::FINISH);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptFinish(
     ::capnp::Orphan< ::capnp::rpc::Finish>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::FINISH);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::FINISH);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Finish> Message::Builder::disownFinish() {
   KJ_IREQUIRE((which() == Message::FINISH),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Finish>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isResolve() const {
@@ -2744,48 +2756,50 @@ inline bool Message::Builder::isResolve() {
 }
 inline bool Message::Reader::hasResolve() const {
   if (which() != Message::RESOLVE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasResolve() {
   if (which() != Message::RESOLVE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Resolve::Reader Message::Reader::getResolve() const {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::getResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setResolve( ::capnp::rpc::Resolve::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RESOLVE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Resolve::Builder Message::Builder::initResolve() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RESOLVE);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptResolve(
     ::capnp::Orphan< ::capnp::rpc::Resolve>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RESOLVE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RESOLVE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Resolve> Message::Builder::disownResolve() {
   KJ_IREQUIRE((which() == Message::RESOLVE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Resolve>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isRelease() const {
@@ -2796,48 +2810,50 @@ inline bool Message::Builder::isRelease() {
 }
 inline bool Message::Reader::hasRelease() const {
   if (which() != Message::RELEASE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasRelease() {
   if (which() != Message::RELEASE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Release::Reader Message::Reader::getRelease() const {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::getRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setRelease( ::capnp::rpc::Release::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RELEASE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Release::Builder Message::Builder::initRelease() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RELEASE);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptRelease(
     ::capnp::Orphan< ::capnp::rpc::Release>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::RELEASE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::RELEASE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Release> Message::Builder::disownRelease() {
   KJ_IREQUIRE((which() == Message::RELEASE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Release>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteSave() const {
@@ -2848,29 +2864,31 @@ inline bool Message::Builder::isObsoleteSave() {
 }
 inline bool Message::Reader::hasObsoleteSave() const {
   if (which() != Message::OBSOLETE_SAVE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteSave() {
   if (which() != Message::OBSOLETE_SAVE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteSave() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteSave() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_SAVE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteSave() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_SAVE);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2883,48 +2901,50 @@ inline bool Message::Builder::isBootstrap() {
 }
 inline bool Message::Reader::hasBootstrap() const {
   if (which() != Message::BOOTSTRAP) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasBootstrap() {
   if (which() != Message::BOOTSTRAP) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Bootstrap::Reader Message::Reader::getBootstrap() const {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::getBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setBootstrap( ::capnp::rpc::Bootstrap::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::BOOTSTRAP);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Bootstrap::Builder Message::Builder::initBootstrap() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::BOOTSTRAP);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptBootstrap(
     ::capnp::Orphan< ::capnp::rpc::Bootstrap>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::BOOTSTRAP);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::BOOTSTRAP);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Bootstrap> Message::Builder::disownBootstrap() {
   KJ_IREQUIRE((which() == Message::BOOTSTRAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Bootstrap>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isObsoleteDelete() const {
@@ -2935,29 +2955,31 @@ inline bool Message::Builder::isObsoleteDelete() {
 }
 inline bool Message::Reader::hasObsoleteDelete() const {
   if (which() != Message::OBSOLETE_DELETE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasObsoleteDelete() {
   if (which() != Message::OBSOLETE_DELETE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Message::Reader::getObsoleteDelete() const {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::getObsoleteDelete() {
   KJ_IREQUIRE((which() == Message::OBSOLETE_DELETE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Message::Builder::initObsoleteDelete() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::OBSOLETE_DELETE);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -2970,48 +2992,50 @@ inline bool Message::Builder::isProvide() {
 }
 inline bool Message::Reader::hasProvide() const {
   if (which() != Message::PROVIDE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasProvide() {
   if (which() != Message::PROVIDE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Provide::Reader Message::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::getProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setProvide( ::capnp::rpc::Provide::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::PROVIDE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Provide::Builder Message::Builder::initProvide() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::PROVIDE);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptProvide(
     ::capnp::Orphan< ::capnp::rpc::Provide>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::PROVIDE);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::PROVIDE);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Provide> Message::Builder::disownProvide() {
   KJ_IREQUIRE((which() == Message::PROVIDE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Provide>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isAccept() const {
@@ -3022,48 +3046,50 @@ inline bool Message::Builder::isAccept() {
 }
 inline bool Message::Reader::hasAccept() const {
   if (which() != Message::ACCEPT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasAccept() {
   if (which() != Message::ACCEPT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Accept::Reader Message::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::getAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setAccept( ::capnp::rpc::Accept::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ACCEPT);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Accept::Builder Message::Builder::initAccept() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ACCEPT);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptAccept(
     ::capnp::Orphan< ::capnp::rpc::Accept>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::ACCEPT);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::ACCEPT);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Accept> Message::Builder::disownAccept() {
   KJ_IREQUIRE((which() == Message::ACCEPT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Accept>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isJoin() const {
@@ -3074,48 +3100,50 @@ inline bool Message::Builder::isJoin() {
 }
 inline bool Message::Reader::hasJoin() const {
   if (which() != Message::JOIN) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasJoin() {
   if (which() != Message::JOIN) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Join::Reader Message::Reader::getJoin() const {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::getJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setJoin( ::capnp::rpc::Join::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::JOIN);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Join::Builder Message::Builder::initJoin() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::JOIN);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptJoin(
     ::capnp::Orphan< ::capnp::rpc::Join>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::JOIN);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::JOIN);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Join> Message::Builder::disownJoin() {
   KJ_IREQUIRE((which() == Message::JOIN),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Join>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Message::Reader::isDisembargo() const {
@@ -3126,112 +3154,118 @@ inline bool Message::Builder::isDisembargo() {
 }
 inline bool Message::Reader::hasDisembargo() const {
   if (which() != Message::DISEMBARGO) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Message::Builder::hasDisembargo() {
   if (which() != Message::DISEMBARGO) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Disembargo::Reader Message::Reader::getDisembargo() const {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::getDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::setDisembargo( ::capnp::rpc::Disembargo::Reader value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::DISEMBARGO);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Disembargo::Builder Message::Builder::initDisembargo() {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::DISEMBARGO);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Message::Builder::adoptDisembargo(
     ::capnp::Orphan< ::capnp::rpc::Disembargo>&& value) {
   _builder.setDataField<Message::Which>(
-      0 * ::capnp::ELEMENTS, Message::DISEMBARGO);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Message::DISEMBARGO);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Disembargo> Message::Builder::disownDisembargo() {
   KJ_IREQUIRE((which() == Message::DISEMBARGO),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Disembargo>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Bootstrap::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Bootstrap::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Bootstrap::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Bootstrap::Reader::hasDeprecatedObjectId() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Bootstrap::Builder::hasDeprecatedObjectId() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Bootstrap::Reader::getDeprecatedObjectId() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::getDeprecatedObjectId() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Bootstrap::Builder::initDeprecatedObjectId() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Call::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Call::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasTarget() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasTarget() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Call::Reader::getTarget() const {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::getTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
@@ -3239,64 +3273,66 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Call::Pipeline::getTarget() {
 }
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Call::Builder::initTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Call::Builder::disownTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Call::Reader::getInterfaceId() const {
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Call::Builder::getInterfaceId() {
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setInterfaceId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Call::Reader::getMethodId() const {
   return _reader.getDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Call::Builder::getMethodId() {
   return _builder.getDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setMethodId( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::Reader::hasParams() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::Builder::hasParams() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Call::Reader::getParams() const {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::getParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
@@ -3304,21 +3340,21 @@ inline  ::capnp::rpc::Payload::Pipeline Call::Pipeline::getParams() {
 }
 #endif  // !CAPNP_LITE
 inline void Call::Builder::setParams( ::capnp::rpc::Payload::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Call::Builder::initParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Call::Builder::adoptParams(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Call::Builder::disownParams() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline typename Call::SendResultsTo::Reader Call::Reader::getSendResultsTo() const {
@@ -3333,29 +3369,31 @@ inline typename Call::SendResultsTo::Pipeline Call::Pipeline::getSendResultsTo()
 }
 #endif  // !CAPNP_LITE
 inline typename Call::SendResultsTo::Builder Call::Builder::initSendResultsTo() {
-  _builder.setDataField< ::uint16_t>(3 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(2 * ::capnp::POINTERS).clear();
+  _builder.setDataField< ::uint16_t>(::kj::guarded<3>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<2>() * ::capnp::POINTERS).clear();
   return typename Call::SendResultsTo::Builder(_builder);
 }
 inline bool Call::Reader::getAllowThirdPartyTailCall() const {
   return _reader.getDataField<bool>(
-      128 * ::capnp::ELEMENTS);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::Builder::getAllowThirdPartyTailCall() {
   return _builder.getDataField<bool>(
-      128 * ::capnp::ELEMENTS);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS);
 }
 inline void Call::Builder::setAllowThirdPartyTailCall(bool value) {
   _builder.setDataField<bool>(
-      128 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Reader::which() const {
-  return _reader.getDataField<Which>(3 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Call::SendResultsTo::Which Call::SendResultsTo::Builder::which() {
-  return _builder.getDataField<Which>(3 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline bool Call::SendResultsTo::Reader::isCaller() const {
@@ -3368,20 +3406,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getCaller() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getCaller() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::CALLER),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setCaller( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      3 * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::CALLER);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isYourself() const {
@@ -3394,20 +3432,20 @@ inline  ::capnp::Void Call::SendResultsTo::Reader::getYourself() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Call::SendResultsTo::Builder::getYourself() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::YOURSELF),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Call::SendResultsTo::Builder::setYourself( ::capnp::Void value) {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      3 * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::YOURSELF);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Call::SendResultsTo::Reader::isThirdParty() const {
@@ -3418,66 +3456,70 @@ inline bool Call::SendResultsTo::Builder::isThirdParty() {
 }
 inline bool Call::SendResultsTo::Reader::hasThirdParty() const {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Call::SendResultsTo::Builder::hasThirdParty() {
   if (which() != Call::SendResultsTo::THIRD_PARTY) return false;
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Call::SendResultsTo::Reader::getThirdParty() const {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::getThirdParty() {
   KJ_IREQUIRE((which() == Call::SendResultsTo::THIRD_PARTY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Call::SendResultsTo::Builder::initThirdParty() {
   _builder.setDataField<Call::SendResultsTo::Which>(
-      3 * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Call::SendResultsTo::THIRD_PARTY);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::Return::Which Return::Reader::which() const {
-  return _reader.getDataField<Which>(3 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Return::Which Return::Builder::which() {
-  return _builder.getDataField<Which>(3 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<3>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Reader::getAnswerId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getAnswerId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setAnswerId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::getReleaseParamCaps() const {
   return _reader.getDataField<bool>(
-      32 * ::capnp::ELEMENTS, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Return::Builder::getReleaseParamCaps() {
   return _builder.getDataField<bool>(
-      32 * ::capnp::ELEMENTS, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Return::Builder::setReleaseParamCaps(bool value) {
   _builder.setDataField<bool>(
-      32 * ::capnp::ELEMENTS, value, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline bool Return::Reader::isResults() const {
@@ -3488,48 +3530,50 @@ inline bool Return::Builder::isResults() {
 }
 inline bool Return::Reader::hasResults() const {
   if (which() != Return::RESULTS) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasResults() {
   if (which() != Return::RESULTS) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Payload::Reader Return::Reader::getResults() const {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::getResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setResults( ::capnp::rpc::Payload::Reader value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::RESULTS);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Payload::Builder Return::Builder::initResults() {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::RESULTS);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptResults(
     ::capnp::Orphan< ::capnp::rpc::Payload>&& value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::RESULTS);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Payload> Return::Builder::disownResults() {
   KJ_IREQUIRE((which() == Return::RESULTS),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Payload>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isException() const {
@@ -3540,48 +3584,50 @@ inline bool Return::Builder::isException() {
 }
 inline bool Return::Reader::hasException() const {
   if (which() != Return::EXCEPTION) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasException() {
   if (which() != Return::EXCEPTION) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Return::Reader::getException() const {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::getException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::EXCEPTION);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Return::Builder::initException() {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::EXCEPTION);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Return::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::EXCEPTION);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::EXCEPTION);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Return::Builder::disownException() {
   KJ_IREQUIRE((which() == Return::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Return::Reader::isCanceled() const {
@@ -3594,20 +3640,20 @@ inline  ::capnp::Void Return::Reader::getCanceled() const {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getCanceled() {
   KJ_IREQUIRE((which() == Return::CANCELED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setCanceled( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::CANCELED);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::CANCELED);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isResultsSentElsewhere() const {
@@ -3620,20 +3666,20 @@ inline  ::capnp::Void Return::Reader::getResultsSentElsewhere() const {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Return::Builder::getResultsSentElsewhere() {
   KJ_IREQUIRE((which() == Return::RESULTS_SENT_ELSEWHERE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setResultsSentElsewhere( ::capnp::Void value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::RESULTS_SENT_ELSEWHERE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isTakeFromOtherQuestion() const {
@@ -3646,20 +3692,20 @@ inline  ::uint32_t Return::Reader::getTakeFromOtherQuestion() const {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Return::Builder::getTakeFromOtherQuestion() {
   KJ_IREQUIRE((which() == Return::TAKE_FROM_OTHER_QUESTION),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Return::Builder::setTakeFromOtherQuestion( ::uint32_t value) {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::TAKE_FROM_OTHER_QUESTION);
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Return::Reader::isAcceptFromThirdParty() const {
@@ -3670,80 +3716,84 @@ inline bool Return::Builder::isAcceptFromThirdParty() {
 }
 inline bool Return::Reader::hasAcceptFromThirdParty() const {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Return::Builder::hasAcceptFromThirdParty() {
   if (which() != Return::ACCEPT_FROM_THIRD_PARTY) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Return::Reader::getAcceptFromThirdParty() const {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::getAcceptFromThirdParty() {
   KJ_IREQUIRE((which() == Return::ACCEPT_FROM_THIRD_PARTY),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Return::Builder::initAcceptFromThirdParty() {
   _builder.setDataField<Return::Which>(
-      3 * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<3>() * ::capnp::ELEMENTS, Return::ACCEPT_FROM_THIRD_PARTY);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Finish::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Finish::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Finish::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Finish::Reader::getReleaseResultCaps() const {
   return _reader.getDataField<bool>(
-      32 * ::capnp::ELEMENTS, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 
 inline bool Finish::Builder::getReleaseResultCaps() {
   return _builder.getDataField<bool>(
-      32 * ::capnp::ELEMENTS, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, true);
 }
 inline void Finish::Builder::setReleaseResultCaps(bool value) {
   _builder.setDataField<bool>(
-      32 * ::capnp::ELEMENTS, value, true);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, value, true);
 }
 
 inline  ::capnp::rpc::Resolve::Which Resolve::Reader::which() const {
-  return _reader.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Resolve::Which Resolve::Builder::which() {
-  return _builder.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Reader::getPromiseId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Resolve::Builder::getPromiseId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Resolve::Builder::setPromiseId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Resolve::Reader::isCap() const {
@@ -3754,48 +3804,50 @@ inline bool Resolve::Builder::isCap() {
 }
 inline bool Resolve::Reader::hasCap() const {
   if (which() != Resolve::CAP) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasCap() {
   if (which() != Resolve::CAP) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::CapDescriptor::Reader Resolve::Reader::getCap() const {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::getCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setCap( ::capnp::rpc::CapDescriptor::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::CAP);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::CapDescriptor::Builder Resolve::Builder::initCap() {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::CAP);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptCap(
     ::capnp::Orphan< ::capnp::rpc::CapDescriptor>&& value) {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::CAP);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::CAP);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::CapDescriptor> Resolve::Builder::disownCap() {
   KJ_IREQUIRE((which() == Resolve::CAP),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::CapDescriptor>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Resolve::Reader::isException() const {
@@ -3806,91 +3858,95 @@ inline bool Resolve::Builder::isException() {
 }
 inline bool Resolve::Reader::hasException() const {
   if (which() != Resolve::EXCEPTION) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Resolve::Builder::hasException() {
   if (which() != Resolve::EXCEPTION) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::Exception::Reader Resolve::Reader::getException() const {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::getException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::setException( ::capnp::rpc::Exception::Reader value) {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::EXCEPTION);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::Exception::Builder Resolve::Builder::initException() {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::EXCEPTION);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Resolve::Builder::adoptException(
     ::capnp::Orphan< ::capnp::rpc::Exception>&& value) {
   _builder.setDataField<Resolve::Which>(
-      2 * ::capnp::ELEMENTS, Resolve::EXCEPTION);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Resolve::EXCEPTION);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::Exception> Resolve::Builder::disownException() {
   KJ_IREQUIRE((which() == Resolve::EXCEPTION),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::Exception>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Release::Reader::getId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Release::Reader::getReferenceCount() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Release::Builder::getReferenceCount() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Release::Builder::setReferenceCount( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Reader::hasTarget() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Disembargo::Builder::hasTarget() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Disembargo::Reader::getTarget() const {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::getTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() {
@@ -3898,21 +3954,21 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Disembargo::Pipeline::getTarget() 
 }
 #endif  // !CAPNP_LITE
 inline void Disembargo::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Disembargo::Builder::initTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Disembargo::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Disembargo::Builder::disownTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline typename Disembargo::Context::Reader Disembargo::Reader::getContext() const {
@@ -3927,15 +3983,17 @@ inline typename Disembargo::Context::Pipeline Disembargo::Pipeline::getContext()
 }
 #endif  // !CAPNP_LITE
 inline typename Disembargo::Context::Builder Disembargo::Builder::initContext() {
-  _builder.setDataField< ::uint32_t>(0 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(2 * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::kj::guarded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Disembargo::Context::Builder(_builder);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Reader::which() const {
-  return _reader.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::Disembargo::Context::Which Disembargo::Context::Builder::which() {
-  return _builder.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool Disembargo::Context::Reader::isSenderLoopback() const {
@@ -3948,20 +4006,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getSenderLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getSenderLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::SENDER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setSenderLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      2 * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::SENDER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isReceiverLoopback() const {
@@ -3974,20 +4032,20 @@ inline  ::uint32_t Disembargo::Context::Reader::getReceiverLoopback() const {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getReceiverLoopback() {
   KJ_IREQUIRE((which() == Disembargo::Context::RECEIVER_LOOPBACK),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setReceiverLoopback( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      2 * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::RECEIVER_LOOPBACK);
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isAccept() const {
@@ -4000,20 +4058,20 @@ inline  ::capnp::Void Disembargo::Context::Reader::getAccept() const {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Disembargo::Context::Builder::getAccept() {
   KJ_IREQUIRE((which() == Disembargo::Context::ACCEPT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setAccept( ::capnp::Void value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      2 * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::ACCEPT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Disembargo::Context::Reader::isProvide() const {
@@ -4026,49 +4084,51 @@ inline  ::uint32_t Disembargo::Context::Reader::getProvide() const {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Disembargo::Context::Builder::getProvide() {
   KJ_IREQUIRE((which() == Disembargo::Context::PROVIDE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Disembargo::Context::Builder::setProvide( ::uint32_t value) {
   _builder.setDataField<Disembargo::Context::Which>(
-      2 * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, Disembargo::Context::PROVIDE);
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Provide::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Provide::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Provide::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Provide::Reader::hasTarget() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasTarget() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Provide::Reader::getTarget() const {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::getTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
@@ -4076,120 +4136,126 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Provide::Pipeline::getTarget() {
 }
 #endif  // !CAPNP_LITE
 inline void Provide::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Provide::Builder::initTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Provide::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Provide::Builder::disownTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Provide::Reader::hasRecipient() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Provide::Builder::hasRecipient() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Provide::Reader::getRecipient() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::getRecipient() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Provide::Builder::initRecipient() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t Accept::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Accept::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Accept::Reader::hasProvision() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Accept::Builder::hasProvision() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Accept::Reader::getProvision() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::getProvision() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Accept::Builder::initProvision() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Accept::Reader::getEmbargo() const {
   return _reader.getDataField<bool>(
-      32 * ::capnp::ELEMENTS);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS);
 }
 
 inline bool Accept::Builder::getEmbargo() {
   return _builder.getDataField<bool>(
-      32 * ::capnp::ELEMENTS);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS);
 }
 inline void Accept::Builder::setEmbargo(bool value) {
   _builder.setDataField<bool>(
-      32 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<32>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Join::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Join::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Join::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Join::Reader::hasTarget() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasTarget() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::MessageTarget::Reader Join::Reader::getTarget() const {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::getTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
@@ -4197,49 +4263,53 @@ inline  ::capnp::rpc::MessageTarget::Pipeline Join::Pipeline::getTarget() {
 }
 #endif  // !CAPNP_LITE
 inline void Join::Builder::setTarget( ::capnp::rpc::MessageTarget::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::MessageTarget::Builder Join::Builder::initTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Join::Builder::adoptTarget(
     ::capnp::Orphan< ::capnp::rpc::MessageTarget>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::MessageTarget> Join::Builder::disownTarget() {
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::MessageTarget>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Join::Reader::hasKeyPart() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Join::Builder::hasKeyPart() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Join::Reader::getKeyPart() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::getKeyPart() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Join::Builder::initKeyPart() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Reader::which() const {
-  return _reader.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::MessageTarget::Which MessageTarget::Builder::which() {
-  return _builder.getDataField<Which>(2 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline bool MessageTarget::Reader::isImportedCap() const {
@@ -4252,20 +4322,20 @@ inline  ::uint32_t MessageTarget::Reader::getImportedCap() const {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t MessageTarget::Builder::getImportedCap() {
   KJ_IREQUIRE((which() == MessageTarget::IMPORTED_CAP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void MessageTarget::Builder::setImportedCap( ::uint32_t value) {
   _builder.setDataField<MessageTarget::Which>(
-      2 * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::IMPORTED_CAP);
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool MessageTarget::Reader::isPromisedAnswer() const {
@@ -4276,108 +4346,116 @@ inline bool MessageTarget::Builder::isPromisedAnswer() {
 }
 inline bool MessageTarget::Reader::hasPromisedAnswer() const {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool MessageTarget::Builder::hasPromisedAnswer() {
   if (which() != MessageTarget::PROMISED_ANSWER) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader MessageTarget::Reader::getPromisedAnswer() const {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::getPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::setPromisedAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<MessageTarget::Which>(
-      2 * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder MessageTarget::Builder::initPromisedAnswer() {
   _builder.setDataField<MessageTarget::Which>(
-      2 * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void MessageTarget::Builder::adoptPromisedAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<MessageTarget::Which>(
-      2 * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, MessageTarget::PROMISED_ANSWER);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> MessageTarget::Builder::disownPromisedAnswer() {
   KJ_IREQUIRE((which() == MessageTarget::PROMISED_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Payload::Reader::hasContent() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasContent() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Payload::Reader::getContent() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::getContent() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Payload::Builder::initContent() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline bool Payload::Reader::hasCapTable() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Payload::Builder::hasCapTable() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader Payload::Reader::getCapTable() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::getCapTable() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Payload::Builder::setCapTable( ::capnp::List< ::capnp::rpc::CapDescriptor>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::CapDescriptor>::Builder Payload::Builder::initCapTable(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Payload::Builder::adoptCapTable(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::CapDescriptor>> Payload::Builder::disownCapTable() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::CapDescriptor>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::CapDescriptor::Which CapDescriptor::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool CapDescriptor::Reader::isNone() const {
@@ -4390,20 +4468,20 @@ inline  ::capnp::Void CapDescriptor::Reader::getNone() const {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void CapDescriptor::Builder::getNone() {
   KJ_IREQUIRE((which() == CapDescriptor::NONE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setNone( ::capnp::Void value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::NONE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::NONE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderHosted() const {
@@ -4416,20 +4494,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isSenderPromise() const {
@@ -4442,20 +4520,20 @@ inline  ::uint32_t CapDescriptor::Reader::getSenderPromise() const {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getSenderPromise() {
   KJ_IREQUIRE((which() == CapDescriptor::SENDER_PROMISE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setSenderPromise( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::SENDER_PROMISE);
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverHosted() const {
@@ -4468,20 +4546,20 @@ inline  ::uint32_t CapDescriptor::Reader::getReceiverHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t CapDescriptor::Builder::getReceiverHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_HOSTED),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void CapDescriptor::Builder::setReceiverHosted( ::uint32_t value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_HOSTED);
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CapDescriptor::Reader::isReceiverAnswer() const {
@@ -4492,48 +4570,50 @@ inline bool CapDescriptor::Builder::isReceiverAnswer() {
 }
 inline bool CapDescriptor::Reader::hasReceiverAnswer() const {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasReceiverAnswer() {
   if (which() != CapDescriptor::RECEIVER_ANSWER) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::PromisedAnswer::Reader CapDescriptor::Reader::getReceiverAnswer() const {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::getReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setReceiverAnswer( ::capnp::rpc::PromisedAnswer::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::PromisedAnswer::Builder CapDescriptor::Builder::initReceiverAnswer() {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptReceiverAnswer(
     ::capnp::Orphan< ::capnp::rpc::PromisedAnswer>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::RECEIVER_ANSWER);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::PromisedAnswer> CapDescriptor::Builder::disownReceiverAnswer() {
   KJ_IREQUIRE((which() == CapDescriptor::RECEIVER_ANSWER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::PromisedAnswer>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CapDescriptor::Reader::isThirdPartyHosted() const {
@@ -4544,101 +4624,107 @@ inline bool CapDescriptor::Builder::isThirdPartyHosted() {
 }
 inline bool CapDescriptor::Reader::hasThirdPartyHosted() const {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CapDescriptor::Builder::hasThirdPartyHosted() {
   if (which() != CapDescriptor::THIRD_PARTY_HOSTED) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Reader CapDescriptor::Reader::getThirdPartyHosted() const {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::getThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::setThirdPartyHosted( ::capnp::rpc::ThirdPartyCapDescriptor::Reader value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::rpc::ThirdPartyCapDescriptor::Builder CapDescriptor::Builder::initThirdPartyHosted() {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CapDescriptor::Builder::adoptThirdPartyHosted(
     ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor>&& value) {
   _builder.setDataField<CapDescriptor::Which>(
-      0 * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
-  ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, CapDescriptor::THIRD_PARTY_HOSTED);
+  ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::rpc::ThirdPartyCapDescriptor> CapDescriptor::Builder::disownThirdPartyHosted() {
   KJ_IREQUIRE((which() == CapDescriptor::THIRD_PARTY_HOSTED),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::rpc::ThirdPartyCapDescriptor>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t PromisedAnswer::Reader::getQuestionId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t PromisedAnswer::Builder::getQuestionId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Builder::setQuestionId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Reader::hasTransform() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool PromisedAnswer::Builder::hasTransform() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader PromisedAnswer::Reader::getTransform() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::getTransform() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void PromisedAnswer::Builder::setTransform( ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>::Builder PromisedAnswer::Builder::initTransform(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void PromisedAnswer::Builder::adoptTransform(
     ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>> PromisedAnswer::Builder::disownTransform() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::rpc::PromisedAnswer::Op>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::rpc::PromisedAnswer::Op::Which PromisedAnswer::Op::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool PromisedAnswer::Op::Reader::isNoop() const {
@@ -4651,20 +4737,20 @@ inline  ::capnp::Void PromisedAnswer::Op::Reader::getNoop() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void PromisedAnswer::Op::Builder::getNoop() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::NOOP),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setNoop( ::capnp::Void value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      0 * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::NOOP);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool PromisedAnswer::Op::Reader::isGetPointerField() const {
@@ -4677,129 +4763,133 @@ inline  ::uint16_t PromisedAnswer::Op::Reader::getGetPointerField() const {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t PromisedAnswer::Op::Builder::getGetPointerField() {
   KJ_IREQUIRE((which() == PromisedAnswer::Op::GET_POINTER_FIELD),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void PromisedAnswer::Op::Builder::setGetPointerField( ::uint16_t value) {
   _builder.setDataField<PromisedAnswer::Op::Which>(
-      0 * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, PromisedAnswer::Op::GET_POINTER_FIELD);
   _builder.setDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool ThirdPartyCapDescriptor::Reader::hasId() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool ThirdPartyCapDescriptor::Builder::hasId() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader ThirdPartyCapDescriptor::Reader::getId() const {
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::getId() {
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder ThirdPartyCapDescriptor::Builder::initId() {
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Reader::getVineId() const {
   return _reader.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t ThirdPartyCapDescriptor::Builder::getVineId() {
   return _builder.getDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void ThirdPartyCapDescriptor::Builder::setVineId( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Exception::Reader::hasReason() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Exception::Builder::hasReason() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Exception::Reader::getReason() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Exception::Builder::getReason() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Exception::Builder::setReason( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Exception::Builder::initReason(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Exception::Builder::adoptReason(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Exception::Builder::disownReason() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Exception::Reader::getObsoleteIsCallersFault() const {
   return _reader.getDataField<bool>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Exception::Builder::getObsoleteIsCallersFault() {
   return _builder.getDataField<bool>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteIsCallersFault(bool value) {
   _builder.setDataField<bool>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Exception::Reader::getObsoleteDurability() const {
   return _reader.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Exception::Builder::getObsoleteDurability() {
   return _builder.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setObsoleteDurability( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Reader::getType() const {
   return _reader.getDataField< ::capnp::rpc::Exception::Type>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::rpc::Exception::Type Exception::Builder::getType() {
   return _builder.getDataField< ::capnp::rpc::Exception::Type>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Exception::Builder::setType( ::capnp::rpc::Exception::Type value) {
   _builder.setDataField< ::capnp::rpc::Exception::Type>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 }  // namespace

--- a/c++/src/capnp/schema.capnp.h
+++ b/c++/src/capnp/schema.capnp.h
@@ -3988,155 +3988,155 @@ private:
 
 inline  ::capnp::schema::Node::Which Node::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Node::Which Node::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasDisplayName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasDisplayName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Reader::getDisplayName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Builder::getDisplayName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setDisplayName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Builder::initDisplayName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptDisplayName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Builder::disownDisplayName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Node::Reader::getDisplayNamePrefixLength() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Builder::getDisplayNamePrefixLength() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setDisplayNamePrefixLength( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Node::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasNestedNodes() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasNestedNodes() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader Node::Reader::getNestedNodes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::getNestedNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setNestedNodes( ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::initNestedNodes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptNestedNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>> Node::Builder::disownNestedNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Node::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Node::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::isFile() const {
@@ -4149,20 +4149,20 @@ inline  ::capnp::Void Node::Reader::getFile() const {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Node::Builder::getFile() {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::FILE);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::FILE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::isStruct() const {
@@ -4183,14 +4183,14 @@ inline typename Node::Struct::Builder Node::Builder::getStruct() {
 }
 inline typename Node::Struct::Builder Node::Builder::initStruct() {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::STRUCT);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<7>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<12>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<13>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<224>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<15>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint32_t>(::capnp::guarded<8>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::STRUCT);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<7>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<12>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<13>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<224>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<15>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::capnp::bounded<8>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Struct::Builder(_builder);
 }
 inline bool Node::Reader::isEnum() const {
@@ -4211,8 +4211,8 @@ inline typename Node::Enum::Builder Node::Builder::getEnum() {
 }
 inline typename Node::Enum::Builder Node::Builder::initEnum() {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::ENUM);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::ENUM);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Enum::Builder(_builder);
 }
 inline bool Node::Reader::isInterface() const {
@@ -4233,9 +4233,9 @@ inline typename Node::Interface::Builder Node::Builder::getInterface() {
 }
 inline typename Node::Interface::Builder Node::Builder::initInterface() {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::INTERFACE);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<4>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::INTERFACE);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Interface::Builder(_builder);
 }
 inline bool Node::Reader::isConst() const {
@@ -4256,9 +4256,9 @@ inline typename Node::Const::Builder Node::Builder::getConst() {
 }
 inline typename Node::Const::Builder Node::Builder::initConst() {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::CONST);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<4>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::CONST);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Const::Builder(_builder);
 }
 inline bool Node::Reader::isAnnotation() const {
@@ -4279,387 +4279,387 @@ inline typename Node::Annotation::Builder Node::Builder::getAnnotation() {
 }
 inline typename Node::Annotation::Builder Node::Builder::initAnnotation() {
   _builder.setDataField<Node::Which>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::ANNOTATION);
-  _builder.setDataField<bool>(::capnp::guarded<112>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<113>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<114>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<115>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<116>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<117>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<118>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<119>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<120>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<121>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<122>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<123>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, Node::ANNOTATION);
+  _builder.setDataField<bool>(::capnp::bounded<112>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<113>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<114>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<115>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<116>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<117>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<118>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<119>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<120>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<121>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<122>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<123>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Annotation::Builder(_builder);
 }
 inline bool Node::Reader::hasParameters() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasParameters() {
   return !_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Node::Reader::getParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::getParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::initParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<5>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Node::Builder::disownParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
-      ::capnp::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::bounded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::getIsGeneric() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<288>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<288>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Builder::getIsGeneric() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<288>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<288>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setIsGeneric(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<288>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<288>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Parameter::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Parameter::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Parameter::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Parameter::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Parameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Parameter::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Node::NestedNode::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::NestedNode::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::NestedNode::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Node::NestedNode::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::NestedNode::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::NestedNode::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Node::NestedNode::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::NestedNode::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::NestedNode::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDataWordCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<7>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<7>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDataWordCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<7>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<7>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDataWordCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<7>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<7>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getPointerCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<12>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<12>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getPointerCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<12>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<12>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPointerCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<12>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<12>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Reader::getPreferredListEncoding() const {
   return _reader.getDataField< ::capnp::schema::ElementSize>(
-      ::capnp::guarded<13>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<13>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Builder::getPreferredListEncoding() {
   return _builder.getDataField< ::capnp::schema::ElementSize>(
-      ::capnp::guarded<13>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<13>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPreferredListEncoding( ::capnp::schema::ElementSize value) {
   _builder.setDataField< ::capnp::schema::ElementSize>(
-      ::capnp::guarded<13>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<13>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::getIsGroup() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<224>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<224>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Struct::Builder::getIsGroup() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<224>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<224>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setIsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<224>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<224>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDiscriminantCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<15>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<15>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDiscriminantCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<15>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<15>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<15>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<15>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Node::Struct::Reader::getDiscriminantOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<8>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<8>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Struct::Builder::getDiscriminantOffset() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<8>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<8>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<8>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<8>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::hasFields() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Struct::Builder::hasFields() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Reader Node::Struct::Reader::getFields() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::getFields() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Struct::Builder::setFields( ::capnp::List< ::capnp::schema::Field>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::initFields(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Struct::Builder::adoptFields(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>> Node::Struct::Builder::disownFields() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Enum::Reader::hasEnumerants() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Enum::Builder::hasEnumerants() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Reader Node::Enum::Reader::getEnumerants() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::getEnumerants() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Enum::Builder::setEnumerants( ::capnp::List< ::capnp::schema::Enumerant>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::initEnumerants(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Enum::Builder::adoptEnumerants(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>> Node::Enum::Builder::disownEnumerants() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasMethods() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasMethods() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Reader Node::Interface::Reader::getMethods() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::getMethods() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setMethods( ::capnp::List< ::capnp::schema::Method>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::initMethods(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptMethods(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>> Node::Interface::Builder::disownMethods() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasSuperclasses() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasSuperclasses() {
   return !_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Reader Node::Interface::Reader::getSuperclasses() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::getSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::schema::Superclass>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::set(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::initSuperclasses(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::init(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>> Node::Interface::Builder::disownSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::disown(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Const::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
@@ -4668,37 +4668,37 @@ inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Const::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Node::Const::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
@@ -4707,37 +4707,37 @@ inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Node::Const::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Annotation::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Annotation::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
@@ -4746,293 +4746,293 @@ inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Node::Annotation::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Annotation::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<112>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<112>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<112>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<112>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<112>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<112>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<113>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<113>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<113>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<113>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<113>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<113>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<114>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<114>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<114>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<114>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<114>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<114>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<115>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<115>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<115>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<115>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<115>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<115>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<116>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<116>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<116>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<116>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<116>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<116>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<117>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<117>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<117>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<117>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<117>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<117>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<118>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<118>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<118>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<118>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<118>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<118>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<119>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<119>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<119>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<119>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<119>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<119>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<120>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<120>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<120>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<120>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<120>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<120>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<121>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<121>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<121>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<121>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<121>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<121>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<122>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<122>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<122>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<122>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<122>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<122>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<123>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<123>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<123>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<123>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<123>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<123>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Which Field::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Which Field::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Field::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Field::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Field::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Field::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Field::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Field::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getDiscriminantValue() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, 65535u);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 
 inline  ::uint16_t Field::Builder::getDiscriminantValue() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, 65535u);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 inline void Field::Builder::setDiscriminantValue( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value, 65535u);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value, 65535u);
 }
 
 inline bool Field::Reader::isSlot() const {
@@ -5053,11 +5053,11 @@ inline typename Field::Slot::Builder Field::Builder::getSlot() {
 }
 inline typename Field::Slot::Builder Field::Builder::initSlot() {
   _builder.setDataField<Field::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Field::SLOT);
-  _builder.setDataField< ::uint32_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::capnp::guarded<128>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<2>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Field::SLOT);
+  _builder.setDataField< ::uint32_t>(::capnp::bounded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::bounded<128>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::bounded<3>() * ::capnp::POINTERS).clear();
   return typename Field::Slot::Builder(_builder);
 }
 inline bool Field::Reader::isGroup() const {
@@ -5078,8 +5078,8 @@ inline typename Field::Group::Builder Field::Builder::getGroup() {
 }
 inline typename Field::Group::Builder Field::Builder::initGroup() {
   _builder.setDataField<Field::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Field::GROUP);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Field::GROUP);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<2>() * ::capnp::ELEMENTS, 0);
   return typename Field::Group::Builder(_builder);
 }
 inline typename Field::Ordinal::Reader Field::Reader::getOrdinal() const {
@@ -5094,39 +5094,39 @@ inline typename Field::Ordinal::Pipeline Field::Pipeline::getOrdinal() {
 }
 #endif  // !CAPNP_LITE
 inline typename Field::Ordinal::Builder Field::Builder::initOrdinal() {
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<6>() * ::capnp::ELEMENTS, 0);
   return typename Field::Ordinal::Builder(_builder);
 }
 inline  ::uint32_t Field::Slot::Reader::getOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Field::Slot::Builder::getOffset() {
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Slot::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Field::Slot::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
@@ -5135,37 +5135,37 @@ inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Field::Slot::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::hasDefaultValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasDefaultValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Field::Slot::Reader::getDefaultValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::getDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue() {
@@ -5174,57 +5174,57 @@ inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue(
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setDefaultValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::initDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptDefaultValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Field::Slot::Builder::disownDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::getHadExplicitDefault() const {
   return _reader.getDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Slot::Builder::getHadExplicitDefault() {
   return _builder.getDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setHadExplicitDefault(bool value) {
   _builder.setDataField<bool>(
-      ::capnp::guarded<128>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Field::Group::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Field::Group::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Field::Group::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Ordinal::Reader::isImplicit() const {
@@ -5237,20 +5237,20 @@ inline  ::capnp::Void Field::Ordinal::Reader::getImplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Field::Ordinal::Builder::getImplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setImplicit( ::capnp::Void value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Ordinal::Reader::isExplicit() const {
@@ -5263,133 +5263,133 @@ inline  ::uint16_t Field::Ordinal::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Ordinal::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setExplicit( ::uint16_t value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<6>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<6>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Enumerant::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Enumerant::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Enumerant::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Enumerant::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Enumerant::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Enumerant::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Enumerant::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Superclass::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Superclass::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Superclass::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Superclass::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Superclass::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Superclass::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
@@ -5398,147 +5398,147 @@ inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Superclass::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Superclass::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Superclass::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Method::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Method::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Method::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Method::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Method::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Method::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getParamStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getParamStructType() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setParamStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getResultStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getResultStructType() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setResultStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Method::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Method::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Method::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasParamBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasParamBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getParamBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
@@ -5547,37 +5547,37 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setParamBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptParamBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::bounded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasResultBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasResultBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getResultBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
@@ -5586,63 +5586,63 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setResultBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptResultBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::bounded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasImplicitParameters() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasImplicitParameters() {
   return !_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Method::Reader::getImplicitParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::getImplicitParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setImplicitParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::initImplicitParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<4>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptImplicitParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Method::Builder::disownImplicitParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
-      ::capnp::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::bounded<4>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::Which Type::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::Which Type::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::Reader::isVoid() const {
@@ -5655,20 +5655,20 @@ inline  ::capnp::Void Type::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getVoid() {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::VOID);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isBool() const {
@@ -5681,20 +5681,20 @@ inline  ::capnp::Void Type::Reader::getBool() const {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getBool() {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setBool( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::BOOL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::BOOL);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt8() const {
@@ -5707,20 +5707,20 @@ inline  ::capnp::Void Type::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt8() {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT8);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt16() const {
@@ -5733,20 +5733,20 @@ inline  ::capnp::Void Type::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt16() {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT16);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt32() const {
@@ -5759,20 +5759,20 @@ inline  ::capnp::Void Type::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt32() {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt64() const {
@@ -5785,20 +5785,20 @@ inline  ::capnp::Void Type::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt64() {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint8() const {
@@ -5811,20 +5811,20 @@ inline  ::capnp::Void Type::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint8() {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT8);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::UINT8);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint16() const {
@@ -5837,20 +5837,20 @@ inline  ::capnp::Void Type::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint16() {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT16);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::UINT16);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint32() const {
@@ -5863,20 +5863,20 @@ inline  ::capnp::Void Type::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint32() {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::UINT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint64() const {
@@ -5889,20 +5889,20 @@ inline  ::capnp::Void Type::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint64() {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::UINT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat32() const {
@@ -5915,20 +5915,20 @@ inline  ::capnp::Void Type::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat64() const {
@@ -5941,20 +5941,20 @@ inline  ::capnp::Void Type::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isText() const {
@@ -5967,20 +5967,20 @@ inline  ::capnp::Void Type::Reader::getText() const {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getText() {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setText( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::TEXT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::TEXT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isData() const {
@@ -5993,20 +5993,20 @@ inline  ::capnp::Void Type::Reader::getData() const {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getData() {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setData( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::DATA);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::DATA);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isList() const {
@@ -6027,8 +6027,8 @@ inline typename Type::List::Builder Type::Builder::getList() {
 }
 inline typename Type::List::Builder Type::Builder::initList() {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::LIST);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::LIST);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
   return typename Type::List::Builder(_builder);
 }
 inline bool Type::Reader::isEnum() const {
@@ -6049,9 +6049,9 @@ inline typename Type::Enum::Builder Type::Builder::getEnum() {
 }
 inline typename Type::Enum::Builder Type::Builder::initEnum() {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::ENUM);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::ENUM);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Enum::Builder(_builder);
 }
 inline bool Type::Reader::isStruct() const {
@@ -6072,9 +6072,9 @@ inline typename Type::Struct::Builder Type::Builder::getStruct() {
 }
 inline typename Type::Struct::Builder Type::Builder::initStruct() {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::STRUCT);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::STRUCT);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Struct::Builder(_builder);
 }
 inline bool Type::Reader::isInterface() const {
@@ -6095,9 +6095,9 @@ inline typename Type::Interface::Builder Type::Builder::getInterface() {
 }
 inline typename Type::Interface::Builder Type::Builder::initInterface() {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INTERFACE);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::INTERFACE);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Interface::Builder(_builder);
 }
 inline bool Type::Reader::isAnyPointer() const {
@@ -6118,27 +6118,27 @@ inline typename Type::AnyPointer::Builder Type::Builder::getAnyPointer() {
 }
 inline typename Type::AnyPointer::Builder Type::Builder::initAnyPointer() {
   _builder.setDataField<Type::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::ANY_POINTER);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<4>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Type::ANY_POINTER);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<4>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Builder(_builder);
 }
 inline bool Type::List::Reader::hasElementType() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::List::Builder::hasElementType() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Type::List::Reader::getElementType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::getElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
@@ -6147,51 +6147,51 @@ inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
 #endif  // !CAPNP_LITE
 inline void Type::List::Builder::setElementType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::initElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Type::List::Builder::adoptElementType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Type::List::Builder::disownElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Enum::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Enum::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Enum::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Enum::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Enum::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Enum::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
@@ -6200,51 +6200,51 @@ inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Enum::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Enum::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Enum::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Struct::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Struct::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Struct::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Struct::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Struct::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Struct::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
@@ -6253,51 +6253,51 @@ inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Struct::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Struct::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Struct::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Interface::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Interface::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Interface::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Interface::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Interface::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Interface::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
@@ -6306,29 +6306,29 @@ inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Interface::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Interface::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Interface::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Reader::isUnconstrained() const {
@@ -6349,8 +6349,8 @@ inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Build
 }
 inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Builder::initUnconstrained() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Unconstrained::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isParameter() const {
@@ -6371,9 +6371,9 @@ inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::
 }
 inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::initParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::capnp::bounded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Parameter::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isImplicitMethodParameter() const {
@@ -6394,17 +6394,17 @@ inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPoin
 }
 inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPointer::Builder::initImplicitMethodParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
-  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::ImplicitMethodParameter::Builder(_builder);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isAnyKind() const {
@@ -6417,20 +6417,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getAnyKind() cons
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getAnyKind() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setAnyKind( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isStruct() const {
@@ -6443,20 +6443,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getStruct() const
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getStruct() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isList() const {
@@ -6469,20 +6469,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getList() const {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getList() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setList( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isCapability() const {
@@ -6495,119 +6495,119 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getCapability() c
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getCapability() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setCapability( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::ImplicitMethodParameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<5>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Reader::hasScopes() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Builder::hasScopes() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Reader Brand::Reader::getScopes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::getScopes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Builder::setScopes( ::capnp::List< ::capnp::schema::Brand::Scope>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::initScopes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Builder::adoptScopes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>> Brand::Builder::disownScopes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Scope::Reader::isBind() const {
@@ -6619,49 +6619,49 @@ inline bool Brand::Scope::Builder::isBind() {
 inline bool Brand::Scope::Reader::hasBind() const {
   if (which() != Brand::Scope::BIND) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Scope::Builder::hasBind() {
   if (which() != Brand::Scope::BIND) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Reader Brand::Scope::Reader::getBind() const {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::getBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Scope::Builder::setBind( ::capnp::List< ::capnp::schema::Brand::Binding>::Reader value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::initBind(unsigned int size) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Scope::Builder::adoptBind(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>>&& value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>> Brand::Scope::Builder::disownBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Brand::Scope::Reader::isInherit() const {
@@ -6674,29 +6674,29 @@ inline  ::capnp::Void Brand::Scope::Reader::getInherit() const {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Scope::Builder::getInherit() {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setInherit( ::capnp::Void value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
+      ::capnp::bounded<4>() * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Brand::Binding::Reader::isUnbound() const {
@@ -6709,20 +6709,20 @@ inline  ::capnp::Void Brand::Binding::Reader::getUnbound() const {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Binding::Builder::getUnbound() {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Binding::Builder::setUnbound( ::capnp::Void value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Binding::Reader::isType() const {
@@ -6734,58 +6734,58 @@ inline bool Brand::Binding::Builder::isType() {
 inline bool Brand::Binding::Reader::hasType() const {
   if (which() != Brand::Binding::TYPE) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Binding::Builder::hasType() {
   if (which() != Brand::Binding::TYPE) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Brand::Binding::Reader::getType() const {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::getType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::setType( ::capnp::schema::Type::Reader value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::initType() {
   _builder.setDataField<Brand::Binding::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Brand::Binding::Builder::disownType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Value::Which Value::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Value::Which Value::Builder::which() {
   return _builder.getDataField<Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Reader::isVoid() const {
@@ -6798,20 +6798,20 @@ inline  ::capnp::Void Value::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getVoid() {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::VOID);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isBool() const {
@@ -6824,20 +6824,20 @@ inline bool Value::Reader::getBool() const {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Builder::getBool() {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setBool(bool value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::BOOL);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::BOOL);
   _builder.setDataField<bool>(
-      ::capnp::guarded<16>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt8() const {
@@ -6850,20 +6850,20 @@ inline  ::int8_t Value::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int8_t Value::Builder::getInt8() {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt8( ::int8_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT8);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::INT8);
   _builder.setDataField< ::int8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt16() const {
@@ -6876,20 +6876,20 @@ inline  ::int16_t Value::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int16_t Value::Builder::getInt16() {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt16( ::int16_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT16);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::INT16);
   _builder.setDataField< ::int16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt32() const {
@@ -6902,20 +6902,20 @@ inline  ::int32_t Value::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int32_t Value::Builder::getInt32() {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt32( ::int32_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::INT32);
   _builder.setDataField< ::int32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt64() const {
@@ -6928,20 +6928,20 @@ inline  ::int64_t Value::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int64_t Value::Builder::getInt64() {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt64( ::int64_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::INT64);
   _builder.setDataField< ::int64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint8() const {
@@ -6954,20 +6954,20 @@ inline  ::uint8_t Value::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint8_t Value::Builder::getUint8() {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint8( ::uint8_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT8);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::UINT8);
   _builder.setDataField< ::uint8_t>(
-      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint16() const {
@@ -6980,20 +6980,20 @@ inline  ::uint16_t Value::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getUint16() {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint16( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT16);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::UINT16);
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint32() const {
@@ -7006,20 +7006,20 @@ inline  ::uint32_t Value::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Value::Builder::getUint32() {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint32( ::uint32_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::UINT32);
   _builder.setDataField< ::uint32_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint64() const {
@@ -7032,20 +7032,20 @@ inline  ::uint64_t Value::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Value::Builder::getUint64() {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint64( ::uint64_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::UINT64);
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat32() const {
@@ -7058,20 +7058,20 @@ inline float Value::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<float>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline float Value::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<float>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat32(float value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT32);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::FLOAT32);
   _builder.setDataField<float>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat64() const {
@@ -7084,20 +7084,20 @@ inline double Value::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Value::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat64(double value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT64);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::FLOAT64);
   _builder.setDataField<double>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isText() const {
@@ -7109,49 +7109,49 @@ inline bool Value::Builder::isText() {
 inline bool Value::Reader::hasText() const {
   if (which() != Value::TEXT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasText() {
   if (which() != Value::TEXT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Value::Reader::getText() const {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Value::Builder::getText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setText( ::capnp::Text::Reader value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Value::Builder::initText(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptText(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Value::Builder::disownText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isData() const {
@@ -7163,49 +7163,49 @@ inline bool Value::Builder::isData() {
 inline bool Value::Reader::hasData() const {
   if (which() != Value::DATA) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasData() {
   if (which() != Value::DATA) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Value::Reader::getData() const {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Value::Builder::getData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setData( ::capnp::Data::Reader value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::DATA);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Value::Builder::initData(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::DATA);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptData(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::DATA);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Value::Builder::disownData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isList() const {
@@ -7217,30 +7217,30 @@ inline bool Value::Builder::isList() {
 inline bool Value::Reader::hasList() const {
   if (which() != Value::LIST) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasList() {
   if (which() != Value::LIST) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getList() const {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getList() {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initList() {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::LIST);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::LIST);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7255,20 +7255,20 @@ inline  ::uint16_t Value::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getEnum() {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setEnum( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::ENUM);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::ENUM);
   _builder.setDataField< ::uint16_t>(
-      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isStruct() const {
@@ -7280,30 +7280,30 @@ inline bool Value::Builder::isStruct() {
 inline bool Value::Reader::hasStruct() const {
   if (which() != Value::STRUCT) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasStruct() {
   if (which() != Value::STRUCT) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getStruct() {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initStruct() {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::STRUCT);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::STRUCT);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7318,20 +7318,20 @@ inline  ::capnp::Void Value::Reader::getInterface() const {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getInterface() {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInterface( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INTERFACE);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::INTERFACE);
   _builder.setDataField< ::capnp::Void>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isAnyPointer() const {
@@ -7343,63 +7343,63 @@ inline bool Value::Builder::isAnyPointer() {
 inline bool Value::Reader::hasAnyPointer() const {
   if (which() != Value::ANY_POINTER) return false;
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasAnyPointer() {
   if (which() != Value::ANY_POINTER) return false;
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getAnyPointer() const {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getAnyPointer() {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initAnyPointer() {
   _builder.setDataField<Value::Which>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::ANY_POINTER);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, Value::ANY_POINTER);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint64_t Annotation::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Annotation::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void Annotation::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Annotation::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Annotation::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
@@ -7408,37 +7408,37 @@ inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Annotation::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Annotation::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Annotation::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
@@ -7447,218 +7447,218 @@ inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Annotation::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasNodes() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasNodes() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Reader CodeGeneratorRequest::Reader::getNodes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::getNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setNodes( ::capnp::List< ::capnp::schema::Node>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::initNodes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>> CodeGeneratorRequest::Builder::disownNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasRequestedFiles() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasRequestedFiles() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader CodeGeneratorRequest::Reader::getRequestedFiles() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::getRequestedFiles() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setRequestedFiles( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::initRequestedFiles(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptRequestedFiles(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>> CodeGeneratorRequest::Builder::disownRequestedFiles() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasFilename() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasFilename() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Reader::getFilename() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::getFilename() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setFilename( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::initFilename(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptFilename(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Builder::disownFilename() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasImports() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasImports() {
   return !_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader CodeGeneratorRequest::RequestedFile::Reader::getImports() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_reader.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::getImports() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setImports( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::set(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::initImports(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::init(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptImports(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::adopt(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>> CodeGeneratorRequest::RequestedFile::Builder::disownImports() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::disown(_builder.getPointerField(
-      ::capnp::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Import::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Import::Builder::hasName() {
   return !_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Import::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::bounded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Import::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::capnp::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/schema.capnp.h
+++ b/c++/src/capnp/schema.capnp.h
@@ -3987,148 +3987,156 @@ private:
 // =======================================================================================
 
 inline  ::capnp::schema::Node::Which Node::Reader::which() const {
-  return _reader.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Node::Which Node::Builder::which() {
-  return _builder.getDataField<Which>(6 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasDisplayName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasDisplayName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Reader::getDisplayName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Builder::getDisplayName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setDisplayName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Builder::initDisplayName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptDisplayName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Builder::disownDisplayName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Node::Reader::getDisplayNamePrefixLength() const {
   return _reader.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Builder::getDisplayNamePrefixLength() {
   return _builder.getDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setDisplayNamePrefixLength( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Node::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasNestedNodes() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasNestedNodes() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader Node::Reader::getNestedNodes() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::getNestedNodes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setNestedNodes( ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::initNestedNodes(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptNestedNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>> Node::Builder::disownNestedNodes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasAnnotations() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Node::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Node::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::isFile() const {
@@ -4141,20 +4149,20 @@ inline  ::capnp::Void Node::Reader::getFile() const {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Node::Builder::getFile() {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::FILE);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::FILE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::isStruct() const {
@@ -4175,14 +4183,14 @@ inline typename Node::Struct::Builder Node::Builder::getStruct() {
 }
 inline typename Node::Struct::Builder Node::Builder::initStruct() {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::STRUCT);
-  _builder.setDataField< ::uint16_t>(7 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(12 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(13 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(224 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(15 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint32_t>(8 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::STRUCT);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<7>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<12>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<13>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<224>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<15>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::kj::guarded<8>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Struct::Builder(_builder);
 }
 inline bool Node::Reader::isEnum() const {
@@ -4203,8 +4211,8 @@ inline typename Node::Enum::Builder Node::Builder::getEnum() {
 }
 inline typename Node::Enum::Builder Node::Builder::initEnum() {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::ENUM);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::ENUM);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Enum::Builder(_builder);
 }
 inline bool Node::Reader::isInterface() const {
@@ -4225,9 +4233,9 @@ inline typename Node::Interface::Builder Node::Builder::getInterface() {
 }
 inline typename Node::Interface::Builder Node::Builder::initInterface() {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::INTERFACE);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(4 * ::capnp::POINTERS).clear();
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::INTERFACE);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Interface::Builder(_builder);
 }
 inline bool Node::Reader::isConst() const {
@@ -4248,9 +4256,9 @@ inline typename Node::Const::Builder Node::Builder::getConst() {
 }
 inline typename Node::Const::Builder Node::Builder::initConst() {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::CONST);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(4 * ::capnp::POINTERS).clear();
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::CONST);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Const::Builder(_builder);
 }
 inline bool Node::Reader::isAnnotation() const {
@@ -4271,371 +4279,387 @@ inline typename Node::Annotation::Builder Node::Builder::getAnnotation() {
 }
 inline typename Node::Annotation::Builder Node::Builder::initAnnotation() {
   _builder.setDataField<Node::Which>(
-      6 * ::capnp::ELEMENTS, Node::ANNOTATION);
-  _builder.setDataField<bool>(112 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(113 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(114 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(115 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(116 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(117 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(118 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(119 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(120 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(121 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(122 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(123 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::ANNOTATION);
+  _builder.setDataField<bool>(::kj::guarded<112>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<113>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<114>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<115>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<116>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<117>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<118>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<119>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<120>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<121>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<122>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<123>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Annotation::Builder(_builder);
 }
 inline bool Node::Reader::hasParameters() const {
-  return !_reader.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasParameters() {
-  return !_builder.getPointerField(5 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Node::Reader::getParameters() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(
-      _reader.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::getParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(
-      _builder.getPointerField(5 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::initParameters(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(
-      _builder.getPointerField(5 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(
-      _builder.getPointerField(5 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Node::Builder::disownParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(
-      _builder.getPointerField(5 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
+      ::kj::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::getIsGeneric() const {
   return _reader.getDataField<bool>(
-      288 * ::capnp::ELEMENTS);
+      ::kj::guarded<288>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Builder::getIsGeneric() {
   return _builder.getDataField<bool>(
-      288 * ::capnp::ELEMENTS);
+      ::kj::guarded<288>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setIsGeneric(bool value) {
   _builder.setDataField<bool>(
-      288 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<288>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Parameter::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Parameter::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Parameter::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Parameter::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Parameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Parameter::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Node::NestedNode::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::NestedNode::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::NestedNode::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::NestedNode::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::NestedNode::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::NestedNode::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Node::NestedNode::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::NestedNode::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::NestedNode::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDataWordCount() const {
   return _reader.getDataField< ::uint16_t>(
-      7 * ::capnp::ELEMENTS);
+      ::kj::guarded<7>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDataWordCount() {
   return _builder.getDataField< ::uint16_t>(
-      7 * ::capnp::ELEMENTS);
+      ::kj::guarded<7>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDataWordCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      7 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<7>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getPointerCount() const {
   return _reader.getDataField< ::uint16_t>(
-      12 * ::capnp::ELEMENTS);
+      ::kj::guarded<12>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getPointerCount() {
   return _builder.getDataField< ::uint16_t>(
-      12 * ::capnp::ELEMENTS);
+      ::kj::guarded<12>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPointerCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      12 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<12>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Reader::getPreferredListEncoding() const {
   return _reader.getDataField< ::capnp::schema::ElementSize>(
-      13 * ::capnp::ELEMENTS);
+      ::kj::guarded<13>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Builder::getPreferredListEncoding() {
   return _builder.getDataField< ::capnp::schema::ElementSize>(
-      13 * ::capnp::ELEMENTS);
+      ::kj::guarded<13>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPreferredListEncoding( ::capnp::schema::ElementSize value) {
   _builder.setDataField< ::capnp::schema::ElementSize>(
-      13 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<13>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::getIsGroup() const {
   return _reader.getDataField<bool>(
-      224 * ::capnp::ELEMENTS);
+      ::kj::guarded<224>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Struct::Builder::getIsGroup() {
   return _builder.getDataField<bool>(
-      224 * ::capnp::ELEMENTS);
+      ::kj::guarded<224>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setIsGroup(bool value) {
   _builder.setDataField<bool>(
-      224 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<224>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDiscriminantCount() const {
   return _reader.getDataField< ::uint16_t>(
-      15 * ::capnp::ELEMENTS);
+      ::kj::guarded<15>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDiscriminantCount() {
   return _builder.getDataField< ::uint16_t>(
-      15 * ::capnp::ELEMENTS);
+      ::kj::guarded<15>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      15 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<15>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Node::Struct::Reader::getDiscriminantOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      8 * ::capnp::ELEMENTS);
+      ::kj::guarded<8>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Struct::Builder::getDiscriminantOffset() {
   return _builder.getDataField< ::uint32_t>(
-      8 * ::capnp::ELEMENTS);
+      ::kj::guarded<8>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      8 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<8>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::hasFields() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Struct::Builder::hasFields() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Reader Node::Struct::Reader::getFields() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::getFields() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Struct::Builder::setFields( ::capnp::List< ::capnp::schema::Field>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::initFields(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Struct::Builder::adoptFields(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>> Node::Struct::Builder::disownFields() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Enum::Reader::hasEnumerants() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Enum::Builder::hasEnumerants() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Reader Node::Enum::Reader::getEnumerants() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::getEnumerants() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Enum::Builder::setEnumerants( ::capnp::List< ::capnp::schema::Enumerant>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::initEnumerants(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Enum::Builder::adoptEnumerants(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>> Node::Enum::Builder::disownEnumerants() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasMethods() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasMethods() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Reader Node::Interface::Reader::getMethods() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::getMethods() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setMethods( ::capnp::List< ::capnp::schema::Method>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::initMethods(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptMethods(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>> Node::Interface::Builder::disownMethods() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasSuperclasses() const {
-  return !_reader.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasSuperclasses() {
-  return !_builder.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Reader Node::Interface::Reader::getSuperclasses() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(
-      _reader.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::getSuperclasses() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::schema::Superclass>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::set(
-      _builder.getPointerField(4 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::set(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::initSuperclasses(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::init(
-      _builder.getPointerField(4 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::init(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::adopt(
-      _builder.getPointerField(4 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::adopt(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>> Node::Interface::Builder::disownSuperclasses() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::disown(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::disown(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasType() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasType() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Const::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
@@ -4643,36 +4667,38 @@ inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
 }
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setType( ::capnp::schema::Type::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Const::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasValue() const {
-  return !_reader.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasValue() {
-  return !_builder.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Node::Const::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _reader.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
@@ -4680,36 +4706,38 @@ inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
 }
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setValue( ::capnp::schema::Value::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(
-      _builder.getPointerField(4 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::initValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(
-      _builder.getPointerField(4 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Node::Const::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::hasType() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Annotation::Builder::hasType() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Annotation::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
@@ -4717,288 +4745,294 @@ inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
 }
 #endif  // !CAPNP_LITE
 inline void Node::Annotation::Builder::setType( ::capnp::schema::Type::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Annotation::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      112 * ::capnp::ELEMENTS);
+      ::kj::guarded<112>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      112 * ::capnp::ELEMENTS);
+      ::kj::guarded<112>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      112 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<112>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      113 * ::capnp::ELEMENTS);
+      ::kj::guarded<113>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      113 * ::capnp::ELEMENTS);
+      ::kj::guarded<113>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      113 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<113>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      114 * ::capnp::ELEMENTS);
+      ::kj::guarded<114>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      114 * ::capnp::ELEMENTS);
+      ::kj::guarded<114>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      114 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<114>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      115 * ::capnp::ELEMENTS);
+      ::kj::guarded<115>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      115 * ::capnp::ELEMENTS);
+      ::kj::guarded<115>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      115 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<115>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      116 * ::capnp::ELEMENTS);
+      ::kj::guarded<116>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      116 * ::capnp::ELEMENTS);
+      ::kj::guarded<116>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      116 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<116>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      117 * ::capnp::ELEMENTS);
+      ::kj::guarded<117>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      117 * ::capnp::ELEMENTS);
+      ::kj::guarded<117>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      117 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<117>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      118 * ::capnp::ELEMENTS);
+      ::kj::guarded<118>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      118 * ::capnp::ELEMENTS);
+      ::kj::guarded<118>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      118 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<118>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      119 * ::capnp::ELEMENTS);
+      ::kj::guarded<119>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      119 * ::capnp::ELEMENTS);
+      ::kj::guarded<119>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      119 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<119>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      120 * ::capnp::ELEMENTS);
+      ::kj::guarded<120>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      120 * ::capnp::ELEMENTS);
+      ::kj::guarded<120>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      120 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<120>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      121 * ::capnp::ELEMENTS);
+      ::kj::guarded<121>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      121 * ::capnp::ELEMENTS);
+      ::kj::guarded<121>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      121 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<121>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      122 * ::capnp::ELEMENTS);
+      ::kj::guarded<122>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      122 * ::capnp::ELEMENTS);
+      ::kj::guarded<122>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      122 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<122>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      123 * ::capnp::ELEMENTS);
+      ::kj::guarded<123>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      123 * ::capnp::ELEMENTS);
+      ::kj::guarded<123>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      123 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<123>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Which Field::Reader::which() const {
-  return _reader.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Which Field::Builder::which() {
-  return _builder.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Field::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Field::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Field::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Field::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasAnnotations() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Field::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Field::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getDiscriminantValue() const {
   return _reader.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, 65535u);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 
 inline  ::uint16_t Field::Builder::getDiscriminantValue() {
   return _builder.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, 65535u);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 inline void Field::Builder::setDiscriminantValue( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, value, 65535u);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value, 65535u);
 }
 
 inline bool Field::Reader::isSlot() const {
@@ -5019,11 +5053,11 @@ inline typename Field::Slot::Builder Field::Builder::getSlot() {
 }
 inline typename Field::Slot::Builder Field::Builder::initSlot() {
   _builder.setDataField<Field::Which>(
-      4 * ::capnp::ELEMENTS, Field::SLOT);
-  _builder.setDataField< ::uint32_t>(1 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(128 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(2 * ::capnp::POINTERS).clear();
-  _builder.getPointerField(3 * ::capnp::POINTERS).clear();
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Field::SLOT);
+  _builder.setDataField< ::uint32_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::kj::guarded<128>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<2>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Field::Slot::Builder(_builder);
 }
 inline bool Field::Reader::isGroup() const {
@@ -5044,8 +5078,8 @@ inline typename Field::Group::Builder Field::Builder::getGroup() {
 }
 inline typename Field::Group::Builder Field::Builder::initGroup() {
   _builder.setDataField<Field::Which>(
-      4 * ::capnp::ELEMENTS, Field::GROUP);
-  _builder.setDataField< ::uint64_t>(2 * ::capnp::ELEMENTS, 0);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Field::GROUP);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Field::Group::Builder(_builder);
 }
 inline typename Field::Ordinal::Reader Field::Reader::getOrdinal() const {
@@ -5060,37 +5094,39 @@ inline typename Field::Ordinal::Pipeline Field::Pipeline::getOrdinal() {
 }
 #endif  // !CAPNP_LITE
 inline typename Field::Ordinal::Builder Field::Builder::initOrdinal() {
-  _builder.setDataField< ::uint16_t>(5 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(6 * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
   return typename Field::Ordinal::Builder(_builder);
 }
 inline  ::uint32_t Field::Slot::Reader::getOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Field::Slot::Builder::getOffset() {
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Slot::Reader::hasType() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasType() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Field::Slot::Reader::getType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::getType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
@@ -5098,36 +5134,38 @@ inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
 }
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setType( ::capnp::schema::Type::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::initType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Field::Slot::Builder::disownType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::hasDefaultValue() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasDefaultValue() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Field::Slot::Reader::getDefaultValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::getDefaultValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue() {
@@ -5135,56 +5173,58 @@ inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue(
 }
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setDefaultValue( ::capnp::schema::Value::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::initDefaultValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptDefaultValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Field::Slot::Builder::disownDefaultValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::getHadExplicitDefault() const {
   return _reader.getDataField<bool>(
-      128 * ::capnp::ELEMENTS);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Slot::Builder::getHadExplicitDefault() {
   return _builder.getDataField<bool>(
-      128 * ::capnp::ELEMENTS);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setHadExplicitDefault(bool value) {
   _builder.setDataField<bool>(
-      128 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Field::Group::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Field::Group::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Field::Group::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Reader::which() const {
-  return _reader.getDataField<Which>(5 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Builder::which() {
-  return _builder.getDataField<Which>(5 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Ordinal::Reader::isImplicit() const {
@@ -5197,20 +5237,20 @@ inline  ::capnp::Void Field::Ordinal::Reader::getImplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Field::Ordinal::Builder::getImplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setImplicit( ::capnp::Void value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      5 * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Ordinal::Reader::isExplicit() const {
@@ -5223,127 +5263,133 @@ inline  ::uint16_t Field::Ordinal::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      6 * ::capnp::ELEMENTS);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Ordinal::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      6 * ::capnp::ELEMENTS);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setExplicit( ::uint16_t value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      5 * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
   _builder.setDataField< ::uint16_t>(
-      6 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<6>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Enumerant::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Enumerant::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Enumerant::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Enumerant::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Enumerant::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasAnnotations() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Enumerant::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Enumerant::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Superclass::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Superclass::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Superclass::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Superclass::Reader::hasBrand() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Superclass::Builder::hasBrand() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Superclass::Reader::getBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::getBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
@@ -5351,142 +5397,148 @@ inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Superclass::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::initBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Superclass::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Superclass::Builder::disownBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Method::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Method::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Method::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Method::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Method::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Method::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getParamStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getParamStructType() {
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setParamStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getResultStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getResultStructType() {
   return _builder.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setResultStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Method::Reader::hasAnnotations() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasAnnotations() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Method::Reader::getAnnotations() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::getAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::initAnnotations(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Method::Builder::disownAnnotations() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasParamBrand() const {
-  return !_reader.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasParamBrand() {
-  return !_builder.getPointerField(2 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getParamBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getParamBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
@@ -5494,36 +5546,38 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setParamBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(2 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initParamBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptParamBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(2 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownParamBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(2 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasResultBrand() const {
-  return !_reader.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasResultBrand() {
-  return !_builder.getPointerField(3 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getResultBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getResultBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
@@ -5531,60 +5585,64 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setResultBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(3 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initResultBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptResultBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(3 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownResultBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(3 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasImplicitParameters() const {
-  return !_reader.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasImplicitParameters() {
-  return !_builder.getPointerField(4 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Method::Reader::getImplicitParameters() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(
-      _reader.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::getImplicitParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setImplicitParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(
-      _builder.getPointerField(4 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::initImplicitParameters(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(
-      _builder.getPointerField(4 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptImplicitParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(
-      _builder.getPointerField(4 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Method::Builder::disownImplicitParameters() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(
-      _builder.getPointerField(4 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
+      ::kj::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::Which Type::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::Which Type::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::Reader::isVoid() const {
@@ -5597,20 +5655,20 @@ inline  ::capnp::Void Type::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getVoid() {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::VOID);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::VOID);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isBool() const {
@@ -5623,20 +5681,20 @@ inline  ::capnp::Void Type::Reader::getBool() const {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getBool() {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setBool( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::BOOL);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::BOOL);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt8() const {
@@ -5649,20 +5707,20 @@ inline  ::capnp::Void Type::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt8() {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::INT8);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT8);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt16() const {
@@ -5675,20 +5733,20 @@ inline  ::capnp::Void Type::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt16() {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::INT16);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT16);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt32() const {
@@ -5701,20 +5759,20 @@ inline  ::capnp::Void Type::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt32() {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::INT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt64() const {
@@ -5727,20 +5785,20 @@ inline  ::capnp::Void Type::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt64() {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::INT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint8() const {
@@ -5753,20 +5811,20 @@ inline  ::capnp::Void Type::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint8() {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::UINT8);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT8);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint16() const {
@@ -5779,20 +5837,20 @@ inline  ::capnp::Void Type::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint16() {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::UINT16);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT16);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint32() const {
@@ -5805,20 +5863,20 @@ inline  ::capnp::Void Type::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint32() {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::UINT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint64() const {
@@ -5831,20 +5889,20 @@ inline  ::capnp::Void Type::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint64() {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::UINT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat32() const {
@@ -5857,20 +5915,20 @@ inline  ::capnp::Void Type::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::FLOAT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat64() const {
@@ -5883,20 +5941,20 @@ inline  ::capnp::Void Type::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::FLOAT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isText() const {
@@ -5909,20 +5967,20 @@ inline  ::capnp::Void Type::Reader::getText() const {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getText() {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setText( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::TEXT);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::TEXT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isData() const {
@@ -5935,20 +5993,20 @@ inline  ::capnp::Void Type::Reader::getData() const {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getData() {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setData( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::DATA);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::DATA);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isList() const {
@@ -5969,8 +6027,8 @@ inline typename Type::List::Builder Type::Builder::getList() {
 }
 inline typename Type::List::Builder Type::Builder::initList() {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::LIST);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::LIST);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::List::Builder(_builder);
 }
 inline bool Type::Reader::isEnum() const {
@@ -5991,9 +6049,9 @@ inline typename Type::Enum::Builder Type::Builder::getEnum() {
 }
 inline typename Type::Enum::Builder Type::Builder::initEnum() {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::ENUM);
-  _builder.setDataField< ::uint64_t>(1 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::ENUM);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Enum::Builder(_builder);
 }
 inline bool Type::Reader::isStruct() const {
@@ -6014,9 +6072,9 @@ inline typename Type::Struct::Builder Type::Builder::getStruct() {
 }
 inline typename Type::Struct::Builder Type::Builder::initStruct() {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::STRUCT);
-  _builder.setDataField< ::uint64_t>(1 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::STRUCT);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Struct::Builder(_builder);
 }
 inline bool Type::Reader::isInterface() const {
@@ -6037,9 +6095,9 @@ inline typename Type::Interface::Builder Type::Builder::getInterface() {
 }
 inline typename Type::Interface::Builder Type::Builder::initInterface() {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::INTERFACE);
-  _builder.setDataField< ::uint64_t>(1 * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(0 * ::capnp::POINTERS).clear();
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INTERFACE);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Interface::Builder(_builder);
 }
 inline bool Type::Reader::isAnyPointer() const {
@@ -6060,25 +6118,27 @@ inline typename Type::AnyPointer::Builder Type::Builder::getAnyPointer() {
 }
 inline typename Type::AnyPointer::Builder Type::Builder::initAnyPointer() {
   _builder.setDataField<Type::Which>(
-      0 * ::capnp::ELEMENTS, Type::ANY_POINTER);
-  _builder.setDataField< ::uint16_t>(4 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(5 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(2 * ::capnp::ELEMENTS, 0);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::ANY_POINTER);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<4>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Builder(_builder);
 }
 inline bool Type::List::Reader::hasElementType() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::List::Builder::hasElementType() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Type::List::Reader::getElementType() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::getElementType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
@@ -6086,50 +6146,52 @@ inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
 }
 #endif  // !CAPNP_LITE
 inline void Type::List::Builder::setElementType( ::capnp::schema::Type::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::initElementType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::List::Builder::adoptElementType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Type::List::Builder::disownElementType() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Enum::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Enum::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Enum::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Enum::Reader::hasBrand() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Enum::Builder::hasBrand() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Enum::Reader::getBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::getBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
@@ -6137,50 +6199,52 @@ inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Type::Enum::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::initBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Enum::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Enum::Builder::disownBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Struct::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Struct::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Struct::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Struct::Reader::hasBrand() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Struct::Builder::hasBrand() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Struct::Reader::getBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::getBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
@@ -6188,50 +6252,52 @@ inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Type::Struct::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::initBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Struct::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Struct::Builder::disownBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Interface::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Interface::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Interface::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Interface::Reader::hasBrand() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Interface::Builder::hasBrand() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Interface::Reader::getBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::getBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
@@ -6239,28 +6305,30 @@ inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Type::Interface::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::initBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Interface::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Interface::Builder::disownBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Reader::which() const {
-  return _reader.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Builder::which() {
-  return _builder.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Reader::isUnconstrained() const {
@@ -6281,8 +6349,8 @@ inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Build
 }
 inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Builder::initUnconstrained() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      4 * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
-  _builder.setDataField< ::uint16_t>(5 * ::capnp::ELEMENTS, 0);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Unconstrained::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isParameter() const {
@@ -6303,9 +6371,9 @@ inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::
 }
 inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::initParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      4 * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
-  _builder.setDataField< ::uint16_t>(5 * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(2 * ::capnp::ELEMENTS, 0);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Parameter::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isImplicitMethodParameter() const {
@@ -6326,15 +6394,17 @@ inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPoin
 }
 inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPointer::Builder::initImplicitMethodParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      4 * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
-  _builder.setDataField< ::uint16_t>(5 * ::capnp::ELEMENTS, 0);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
+  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::ImplicitMethodParameter::Builder(_builder);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Reader::which() const {
-  return _reader.getDataField<Which>(5 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Builder::which() {
-  return _builder.getDataField<Which>(5 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isAnyKind() const {
@@ -6347,20 +6417,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getAnyKind() cons
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getAnyKind() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setAnyKind( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      5 * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isStruct() const {
@@ -6373,20 +6443,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getStruct() const
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getStruct() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      5 * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isList() const {
@@ -6399,20 +6469,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getList() const {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getList() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setList( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      5 * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isCapability() const {
@@ -6425,115 +6495,119 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getCapability() c
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getCapability() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setCapability( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      5 * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::ImplicitMethodParameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      5 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Reader::hasScopes() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Builder::hasScopes() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Reader Brand::Reader::getScopes() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::getScopes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Builder::setScopes( ::capnp::List< ::capnp::schema::Brand::Scope>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::initScopes(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Builder::adoptScopes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>> Brand::Builder::disownScopes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Reader::which() const {
-  return _reader.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Builder::which() {
-  return _builder.getDataField<Which>(4 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Scope::Reader::isBind() const {
@@ -6544,48 +6618,50 @@ inline bool Brand::Scope::Builder::isBind() {
 }
 inline bool Brand::Scope::Reader::hasBind() const {
   if (which() != Brand::Scope::BIND) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Scope::Builder::hasBind() {
   if (which() != Brand::Scope::BIND) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Reader Brand::Scope::Reader::getBind() const {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::getBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Scope::Builder::setBind( ::capnp::List< ::capnp::schema::Brand::Binding>::Reader value) {
   _builder.setDataField<Brand::Scope::Which>(
-      4 * ::capnp::ELEMENTS, Brand::Scope::BIND);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::initBind(unsigned int size) {
   _builder.setDataField<Brand::Scope::Which>(
-      4 * ::capnp::ELEMENTS, Brand::Scope::BIND);
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Scope::Builder::adoptBind(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>>&& value) {
   _builder.setDataField<Brand::Scope::Which>(
-      4 * ::capnp::ELEMENTS, Brand::Scope::BIND);
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>> Brand::Scope::Builder::disownBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Brand::Scope::Reader::isInherit() const {
@@ -6598,27 +6674,29 @@ inline  ::capnp::Void Brand::Scope::Reader::getInherit() const {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Scope::Builder::getInherit() {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setInherit( ::capnp::Void value) {
   _builder.setDataField<Brand::Scope::Which>(
-      4 * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
+      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Brand::Binding::Reader::isUnbound() const {
@@ -6631,20 +6709,20 @@ inline  ::capnp::Void Brand::Binding::Reader::getUnbound() const {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Binding::Builder::getUnbound() {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Binding::Builder::setUnbound( ::capnp::Void value) {
   _builder.setDataField<Brand::Binding::Which>(
-      0 * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Binding::Reader::isType() const {
@@ -6655,55 +6733,59 @@ inline bool Brand::Binding::Builder::isType() {
 }
 inline bool Brand::Binding::Reader::hasType() const {
   if (which() != Brand::Binding::TYPE) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Binding::Builder::hasType() {
   if (which() != Brand::Binding::TYPE) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Brand::Binding::Reader::getType() const {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::getType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::setType( ::capnp::schema::Type::Reader value) {
   _builder.setDataField<Brand::Binding::Which>(
-      0 * ::capnp::ELEMENTS, Brand::Binding::TYPE);
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::initType() {
   _builder.setDataField<Brand::Binding::Which>(
-      0 * ::capnp::ELEMENTS, Brand::Binding::TYPE);
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   _builder.setDataField<Brand::Binding::Which>(
-      0 * ::capnp::ELEMENTS, Brand::Binding::TYPE);
-  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Brand::Binding::Builder::disownType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Value::Which Value::Reader::which() const {
-  return _reader.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _reader.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Value::Which Value::Builder::which() {
-  return _builder.getDataField<Which>(0 * ::capnp::ELEMENTS);
+  return _builder.getDataField<Which>(
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Reader::isVoid() const {
@@ -6716,20 +6798,20 @@ inline  ::capnp::Void Value::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getVoid() {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::VOID);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::VOID);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isBool() const {
@@ -6742,20 +6824,20 @@ inline bool Value::Reader::getBool() const {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      16 * ::capnp::ELEMENTS);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Builder::getBool() {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      16 * ::capnp::ELEMENTS);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setBool(bool value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::BOOL);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::BOOL);
   _builder.setDataField<bool>(
-      16 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt8() const {
@@ -6768,20 +6850,20 @@ inline  ::int8_t Value::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int8_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int8_t Value::Builder::getInt8() {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int8_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt8( ::int8_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::INT8);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT8);
   _builder.setDataField< ::int8_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt16() const {
@@ -6794,20 +6876,20 @@ inline  ::int16_t Value::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int16_t Value::Builder::getInt16() {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt16( ::int16_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::INT16);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT16);
   _builder.setDataField< ::int16_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt32() const {
@@ -6820,20 +6902,20 @@ inline  ::int32_t Value::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int32_t Value::Builder::getInt32() {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt32( ::int32_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::INT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT32);
   _builder.setDataField< ::int32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt64() const {
@@ -6846,20 +6928,20 @@ inline  ::int64_t Value::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int64_t Value::Builder::getInt64() {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt64( ::int64_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::INT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT64);
   _builder.setDataField< ::int64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint8() const {
@@ -6872,20 +6954,20 @@ inline  ::uint8_t Value::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint8_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint8_t Value::Builder::getUint8() {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint8_t>(
-      2 * ::capnp::ELEMENTS);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint8( ::uint8_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::UINT8);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT8);
   _builder.setDataField< ::uint8_t>(
-      2 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint16() const {
@@ -6898,20 +6980,20 @@ inline  ::uint16_t Value::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getUint16() {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint16( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::UINT16);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT16);
   _builder.setDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint32() const {
@@ -6924,20 +7006,20 @@ inline  ::uint32_t Value::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Value::Builder::getUint32() {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint32( ::uint32_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::UINT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT32);
   _builder.setDataField< ::uint32_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint64() const {
@@ -6950,20 +7032,20 @@ inline  ::uint64_t Value::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Value::Builder::getUint64() {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint64( ::uint64_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::UINT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT64);
   _builder.setDataField< ::uint64_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat32() const {
@@ -6976,20 +7058,20 @@ inline float Value::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<float>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline float Value::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<float>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat32(float value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::FLOAT32);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT32);
   _builder.setDataField<float>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat64() const {
@@ -7002,20 +7084,20 @@ inline double Value::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Value::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat64(double value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::FLOAT64);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT64);
   _builder.setDataField<double>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isText() const {
@@ -7026,48 +7108,50 @@ inline bool Value::Builder::isText() {
 }
 inline bool Value::Reader::hasText() const {
   if (which() != Value::TEXT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasText() {
   if (which() != Value::TEXT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Value::Reader::getText() const {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Value::Builder::getText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setText( ::capnp::Text::Reader value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::TEXT);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Value::Builder::initText(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::TEXT);
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptText(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::TEXT);
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Value::Builder::disownText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isData() const {
@@ -7078,48 +7162,50 @@ inline bool Value::Builder::isData() {
 }
 inline bool Value::Reader::hasData() const {
   if (which() != Value::DATA) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasData() {
   if (which() != Value::DATA) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Value::Reader::getData() const {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Value::Builder::getData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setData( ::capnp::Data::Reader value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::DATA);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Value::Builder::initData(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::DATA);
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptData(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::DATA);
-  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+  ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Value::Builder::disownData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
-  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isList() const {
@@ -7130,29 +7216,31 @@ inline bool Value::Builder::isList() {
 }
 inline bool Value::Reader::hasList() const {
   if (which() != Value::LIST) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasList() {
   if (which() != Value::LIST) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getList() const {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getList() {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initList() {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::LIST);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::LIST);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7167,20 +7255,20 @@ inline  ::uint16_t Value::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getEnum() {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setEnum( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::ENUM);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::ENUM);
   _builder.setDataField< ::uint16_t>(
-      1 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isStruct() const {
@@ -7191,29 +7279,31 @@ inline bool Value::Builder::isStruct() {
 }
 inline bool Value::Reader::hasStruct() const {
   if (which() != Value::STRUCT) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasStruct() {
   if (which() != Value::STRUCT) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getStruct() {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initStruct() {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::STRUCT);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::STRUCT);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7228,20 +7318,20 @@ inline  ::capnp::Void Value::Reader::getInterface() const {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getInterface() {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInterface( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::INTERFACE);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INTERFACE);
   _builder.setDataField< ::capnp::Void>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isAnyPointer() const {
@@ -7252,60 +7342,64 @@ inline bool Value::Builder::isAnyPointer() {
 }
 inline bool Value::Reader::hasAnyPointer() const {
   if (which() != Value::ANY_POINTER) return false;
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasAnyPointer() {
   if (which() != Value::ANY_POINTER) return false;
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getAnyPointer() const {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Reader(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Reader(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getAnyPointer() {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
-  return ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initAnyPointer() {
   _builder.setDataField<Value::Which>(
-      0 * ::capnp::ELEMENTS, Value::ANY_POINTER);
-  auto result = ::capnp::AnyPointer::Builder(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::ANY_POINTER);
+  auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint64_t Annotation::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Annotation::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Annotation::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Annotation::Reader::hasValue() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasValue() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Annotation::Reader::getValue() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::getValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
@@ -7313,36 +7407,38 @@ inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
 }
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setValue( ::capnp::schema::Value::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::initValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Annotation::Builder::disownValue() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Annotation::Reader::hasBrand() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasBrand() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Annotation::Reader::getBrand() const {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::getBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
@@ -7350,209 +7446,219 @@ inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
 }
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::initBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Annotation::Builder::disownBrand() {
-  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasNodes() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasNodes() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Reader CodeGeneratorRequest::Reader::getNodes() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::getNodes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setNodes( ::capnp::List< ::capnp::schema::Node>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::initNodes(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>> CodeGeneratorRequest::Builder::disownNodes() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasRequestedFiles() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasRequestedFiles() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader CodeGeneratorRequest::Reader::getRequestedFiles() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::getRequestedFiles() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setRequestedFiles( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::initRequestedFiles(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptRequestedFiles(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>> CodeGeneratorRequest::Builder::disownRequestedFiles() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasFilename() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasFilename() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Reader::getFilename() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::getFilename() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setFilename( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::initFilename(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptFilename(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Builder::disownFilename() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasImports() const {
-  return !_reader.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasImports() {
-  return !_builder.getPointerField(1 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader CodeGeneratorRequest::RequestedFile::Reader::getImports() const {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(
-      _reader.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_reader.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::getImports() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setImports( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::set(
-      _builder.getPointerField(1 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::set(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::initImports(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::init(
-      _builder.getPointerField(1 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::init(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptImports(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::adopt(
-      _builder.getPointerField(1 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::adopt(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>> CodeGeneratorRequest::RequestedFile::Builder::disownImports() {
-  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::disown(
-      _builder.getPointerField(1 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::disown(_builder.getPointerField(
+      ::kj::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      0 * ::capnp::ELEMENTS, value);
+      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Import::Reader::hasName() const {
-  return !_reader.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Import::Builder::hasName() {
-  return !_builder.getPointerField(0 * ::capnp::POINTERS).isNull();
+  return !_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Import::Reader::getName() const {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _reader.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::getName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setName( ::capnp::Text::Reader value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::set(
-      _builder.getPointerField(0 * ::capnp::POINTERS), value);
+  ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::initName(unsigned int size) {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(
-      _builder.getPointerField(0 * ::capnp::POINTERS), size);
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
-  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(
-      _builder.getPointerField(0 * ::capnp::POINTERS), kj::mv(value));
+  ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Import::Builder::disownName() {
-  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(
-      _builder.getPointerField(0 * ::capnp::POINTERS));
+  return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
+      ::kj::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/capnp/schema.capnp.h
+++ b/c++/src/capnp/schema.capnp.h
@@ -3988,155 +3988,155 @@ private:
 
 inline  ::capnp::schema::Node::Which Node::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Node::Which Node::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasDisplayName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasDisplayName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Reader::getDisplayName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Builder::getDisplayName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setDisplayName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Builder::initDisplayName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptDisplayName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Builder::disownDisplayName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint32_t Node::Reader::getDisplayNamePrefixLength() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Builder::getDisplayNamePrefixLength() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setDisplayNamePrefixLength( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Node::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::hasNestedNodes() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasNestedNodes() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader Node::Reader::getNestedNodes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::getNestedNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setNestedNodes( ::capnp::List< ::capnp::schema::Node::NestedNode>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::NestedNode>::Builder Node::Builder::initNestedNodes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptNestedNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::NestedNode>> Node::Builder::disownNestedNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::NestedNode>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Node::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Node::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Node::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::isFile() const {
@@ -4149,20 +4149,20 @@ inline  ::capnp::Void Node::Reader::getFile() const {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Node::Builder::getFile() {
   KJ_IREQUIRE((which() == Node::FILE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setFile( ::capnp::Void value) {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::FILE);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::FILE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Reader::isStruct() const {
@@ -4183,14 +4183,14 @@ inline typename Node::Struct::Builder Node::Builder::getStruct() {
 }
 inline typename Node::Struct::Builder Node::Builder::initStruct() {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::STRUCT);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<7>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<12>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<13>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<224>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<15>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint32_t>(::kj::guarded<8>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::STRUCT);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<7>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<12>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<13>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<224>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<15>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint32_t>(::capnp::guarded<8>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Struct::Builder(_builder);
 }
 inline bool Node::Reader::isEnum() const {
@@ -4211,8 +4211,8 @@ inline typename Node::Enum::Builder Node::Builder::getEnum() {
 }
 inline typename Node::Enum::Builder Node::Builder::initEnum() {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::ENUM);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::ENUM);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Enum::Builder(_builder);
 }
 inline bool Node::Reader::isInterface() const {
@@ -4233,9 +4233,9 @@ inline typename Node::Interface::Builder Node::Builder::getInterface() {
 }
 inline typename Node::Interface::Builder Node::Builder::initInterface() {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::INTERFACE);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<4>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::INTERFACE);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Interface::Builder(_builder);
 }
 inline bool Node::Reader::isConst() const {
@@ -4256,9 +4256,9 @@ inline typename Node::Const::Builder Node::Builder::getConst() {
 }
 inline typename Node::Const::Builder Node::Builder::initConst() {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::CONST);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<4>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::CONST);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<4>() * ::capnp::POINTERS).clear();
   return typename Node::Const::Builder(_builder);
 }
 inline bool Node::Reader::isAnnotation() const {
@@ -4279,387 +4279,387 @@ inline typename Node::Annotation::Builder Node::Builder::getAnnotation() {
 }
 inline typename Node::Annotation::Builder Node::Builder::initAnnotation() {
   _builder.setDataField<Node::Which>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, Node::ANNOTATION);
-  _builder.setDataField<bool>(::kj::guarded<112>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<113>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<114>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<115>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<116>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<117>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<118>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<119>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<120>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<121>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<122>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<123>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, Node::ANNOTATION);
+  _builder.setDataField<bool>(::capnp::guarded<112>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<113>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<114>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<115>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<116>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<117>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<118>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<119>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<120>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<121>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<122>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<123>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Node::Annotation::Builder(_builder);
 }
 inline bool Node::Reader::hasParameters() const {
   return !_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Builder::hasParameters() {
   return !_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<5>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Node::Reader::getParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::getParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 inline void Node::Builder::setParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Node::Builder::initParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<5>() * ::capnp::POINTERS), size);
 }
 inline void Node::Builder::adoptParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<5>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Node::Builder::disownParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
-      ::kj::guarded<5>() * ::capnp::POINTERS));
+      ::capnp::guarded<5>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Reader::getIsGeneric() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<288>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<288>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Builder::getIsGeneric() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<288>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<288>() * ::capnp::ELEMENTS);
 }
 inline void Node::Builder::setIsGeneric(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<288>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<288>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Parameter::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Parameter::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::Parameter::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::Parameter::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::Parameter::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::Parameter::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::Parameter::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Node::NestedNode::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::NestedNode::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Node::NestedNode::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Node::NestedNode::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Node::NestedNode::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Node::NestedNode::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Node::NestedNode::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Node::NestedNode::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Node::NestedNode::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Node::NestedNode::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDataWordCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<7>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<7>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDataWordCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<7>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<7>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDataWordCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<7>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<7>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getPointerCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<12>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<12>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getPointerCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<12>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<12>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPointerCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<12>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<12>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Reader::getPreferredListEncoding() const {
   return _reader.getDataField< ::capnp::schema::ElementSize>(
-      ::kj::guarded<13>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<13>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::schema::ElementSize Node::Struct::Builder::getPreferredListEncoding() {
   return _builder.getDataField< ::capnp::schema::ElementSize>(
-      ::kj::guarded<13>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<13>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setPreferredListEncoding( ::capnp::schema::ElementSize value) {
   _builder.setDataField< ::capnp::schema::ElementSize>(
-      ::kj::guarded<13>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<13>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::getIsGroup() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<224>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<224>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Struct::Builder::getIsGroup() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<224>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<224>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setIsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<224>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<224>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Node::Struct::Reader::getDiscriminantCount() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<15>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<15>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Node::Struct::Builder::getDiscriminantCount() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<15>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<15>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantCount( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<15>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<15>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint32_t Node::Struct::Reader::getDiscriminantOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<8>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<8>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Node::Struct::Builder::getDiscriminantOffset() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<8>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<8>() * ::capnp::ELEMENTS);
 }
 inline void Node::Struct::Builder::setDiscriminantOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<8>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<8>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Struct::Reader::hasFields() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Struct::Builder::hasFields() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Reader Node::Struct::Reader::getFields() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::getFields() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Struct::Builder::setFields( ::capnp::List< ::capnp::schema::Field>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Field>::Builder Node::Struct::Builder::initFields(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Struct::Builder::adoptFields(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Field>> Node::Struct::Builder::disownFields() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Field>>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Enum::Reader::hasEnumerants() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Enum::Builder::hasEnumerants() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Reader Node::Enum::Reader::getEnumerants() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::getEnumerants() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Enum::Builder::setEnumerants( ::capnp::List< ::capnp::schema::Enumerant>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Enumerant>::Builder Node::Enum::Builder::initEnumerants(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Enum::Builder::adoptEnumerants(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Enumerant>> Node::Enum::Builder::disownEnumerants() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Enumerant>>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasMethods() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasMethods() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Reader Node::Interface::Reader::getMethods() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::getMethods() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setMethods( ::capnp::List< ::capnp::schema::Method>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Method>::Builder Node::Interface::Builder::initMethods(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptMethods(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Method>> Node::Interface::Builder::disownMethods() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Method>>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Interface::Reader::hasSuperclasses() const {
   return !_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Interface::Builder::hasSuperclasses() {
   return !_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Reader Node::Interface::Reader::getSuperclasses() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::getSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::get(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Interface::Builder::setSuperclasses( ::capnp::List< ::capnp::schema::Superclass>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::set(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Superclass>::Builder Node::Interface::Builder::initSuperclasses(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::init(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Node::Interface::Builder::adoptSuperclasses(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::adopt(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Superclass>> Node::Interface::Builder::disownSuperclasses() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Superclass>>::disown(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Const::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
@@ -4668,37 +4668,37 @@ inline  ::capnp::schema::Type::Pipeline Node::Const::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Const::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Const::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Const::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Const::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Node::Const::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
@@ -4707,37 +4707,37 @@ inline  ::capnp::schema::Value::Pipeline Node::Const::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void Node::Const::Builder::setValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Node::Const::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Node::Const::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Node::Const::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Node::Annotation::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Node::Annotation::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
@@ -4746,293 +4746,293 @@ inline  ::capnp::schema::Type::Pipeline Node::Annotation::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Node::Annotation::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Node::Annotation::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Node::Annotation::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Node::Annotation::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Node::Annotation::Reader::getTargetsFile() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<112>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<112>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsFile() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<112>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<112>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsFile(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<112>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<112>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsConst() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<113>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<113>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsConst() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<113>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<113>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsConst(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<113>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<113>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnum() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<114>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<114>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnum() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<114>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<114>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnum(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<114>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<114>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsEnumerant() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<115>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<115>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsEnumerant() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<115>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<115>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsEnumerant(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<115>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<115>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsStruct() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<116>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<116>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsStruct() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<116>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<116>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsStruct(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<116>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<116>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsField() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<117>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<117>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsField() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<117>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<117>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsField(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<117>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<117>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsUnion() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<118>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<118>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsUnion() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<118>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<118>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsUnion(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<118>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<118>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsGroup() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<119>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<119>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsGroup() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<119>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<119>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsGroup(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<119>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<119>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsInterface() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<120>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<120>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsInterface() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<120>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<120>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsInterface(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<120>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<120>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsMethod() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<121>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<121>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsMethod() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<121>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<121>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsMethod(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<121>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<121>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsParam() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<122>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<122>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsParam() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<122>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<122>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsParam(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<122>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<122>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Node::Annotation::Reader::getTargetsAnnotation() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<123>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<123>() * ::capnp::ELEMENTS);
 }
 
 inline bool Node::Annotation::Builder::getTargetsAnnotation() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<123>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<123>() * ::capnp::ELEMENTS);
 }
 inline void Node::Annotation::Builder::setTargetsAnnotation(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<123>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<123>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Which Field::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Which Field::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Field::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Field::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Field::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Field::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Field::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Field::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Field::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Field::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Field::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Field::Reader::getDiscriminantValue() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, 65535u);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 
 inline  ::uint16_t Field::Builder::getDiscriminantValue() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, 65535u);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, 65535u);
 }
 inline void Field::Builder::setDiscriminantValue( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value, 65535u);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value, 65535u);
 }
 
 inline bool Field::Reader::isSlot() const {
@@ -5053,11 +5053,11 @@ inline typename Field::Slot::Builder Field::Builder::getSlot() {
 }
 inline typename Field::Slot::Builder Field::Builder::initSlot() {
   _builder.setDataField<Field::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Field::SLOT);
-  _builder.setDataField< ::uint32_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField<bool>(::kj::guarded<128>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<2>() * ::capnp::POINTERS).clear();
-  _builder.getPointerField(::kj::guarded<3>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Field::SLOT);
+  _builder.setDataField< ::uint32_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField<bool>(::capnp::guarded<128>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<2>() * ::capnp::POINTERS).clear();
+  _builder.getPointerField(::capnp::guarded<3>() * ::capnp::POINTERS).clear();
   return typename Field::Slot::Builder(_builder);
 }
 inline bool Field::Reader::isGroup() const {
@@ -5078,8 +5078,8 @@ inline typename Field::Group::Builder Field::Builder::getGroup() {
 }
 inline typename Field::Group::Builder Field::Builder::initGroup() {
   _builder.setDataField<Field::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Field::GROUP);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Field::GROUP);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Field::Group::Builder(_builder);
 }
 inline typename Field::Ordinal::Reader Field::Reader::getOrdinal() const {
@@ -5094,39 +5094,39 @@ inline typename Field::Ordinal::Pipeline Field::Pipeline::getOrdinal() {
 }
 #endif  // !CAPNP_LITE
 inline typename Field::Ordinal::Builder Field::Builder::initOrdinal() {
-  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<6>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<6>() * ::capnp::ELEMENTS, 0);
   return typename Field::Ordinal::Builder(_builder);
 }
 inline  ::uint32_t Field::Slot::Reader::getOffset() const {
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Field::Slot::Builder::getOffset() {
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setOffset( ::uint32_t value) {
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Slot::Reader::hasType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasType() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Field::Slot::Reader::getType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::getType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
@@ -5135,37 +5135,37 @@ inline  ::capnp::schema::Type::Pipeline Field::Slot::Pipeline::getType() {
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Field::Slot::Builder::initType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Field::Slot::Builder::disownType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::hasDefaultValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Field::Slot::Builder::hasDefaultValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Field::Slot::Reader::getDefaultValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::getDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue() {
@@ -5174,57 +5174,57 @@ inline  ::capnp::schema::Value::Pipeline Field::Slot::Pipeline::getDefaultValue(
 #endif  // !CAPNP_LITE
 inline void Field::Slot::Builder::setDefaultValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Field::Slot::Builder::initDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Field::Slot::Builder::adoptDefaultValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Field::Slot::Builder::disownDefaultValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Field::Slot::Reader::getHadExplicitDefault() const {
   return _reader.getDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Slot::Builder::getHadExplicitDefault() {
   return _builder.getDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS);
 }
 inline void Field::Slot::Builder::setHadExplicitDefault(bool value) {
   _builder.setDataField<bool>(
-      ::kj::guarded<128>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<128>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Field::Group::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Field::Group::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Field::Group::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Field::Ordinal::Which Field::Ordinal::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Field::Ordinal::Reader::isImplicit() const {
@@ -5237,20 +5237,20 @@ inline  ::capnp::Void Field::Ordinal::Reader::getImplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Field::Ordinal::Builder::getImplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::IMPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setImplicit( ::capnp::Void value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::IMPLICIT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Field::Ordinal::Reader::isExplicit() const {
@@ -5263,133 +5263,133 @@ inline  ::uint16_t Field::Ordinal::Reader::getExplicit() const {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Field::Ordinal::Builder::getExplicit() {
   KJ_IREQUIRE((which() == Field::Ordinal::EXPLICIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS);
 }
 inline void Field::Ordinal::Builder::setExplicit( ::uint16_t value) {
   _builder.setDataField<Field::Ordinal::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Field::Ordinal::EXPLICIT);
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<6>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<6>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Enumerant::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Enumerant::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Enumerant::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Enumerant::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Enumerant::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Enumerant::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Enumerant::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Enumerant::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Enumerant::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Enumerant::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Enumerant::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Enumerant::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Enumerant::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Superclass::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Superclass::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Superclass::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Superclass::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Superclass::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Superclass::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
@@ -5398,147 +5398,147 @@ inline  ::capnp::schema::Brand::Pipeline Superclass::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Superclass::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Superclass::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Superclass::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Superclass::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Method::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Method::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Method::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Method::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint16_t Method::Reader::getCodeOrder() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Method::Builder::getCodeOrder() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setCodeOrder( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getParamStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getParamStructType() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setParamStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Method::Reader::getResultStructType() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Method::Builder::getResultStructType() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Method::Builder::setResultStructType( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Method::Reader::hasAnnotations() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasAnnotations() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Reader Method::Reader::getAnnotations() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::getAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setAnnotations( ::capnp::List< ::capnp::schema::Annotation>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Annotation>::Builder Method::Builder::initAnnotations(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptAnnotations(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Annotation>> Method::Builder::disownAnnotations() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Annotation>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasParamBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasParamBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<2>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getParamBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
@@ -5547,37 +5547,37 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getParamBrand() {
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setParamBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<2>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptParamBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<2>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownParamBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<2>() * ::capnp::POINTERS));
+      ::capnp::guarded<2>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasResultBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasResultBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<3>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Method::Reader::getResultBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::getResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
@@ -5586,63 +5586,63 @@ inline  ::capnp::schema::Brand::Pipeline Method::Pipeline::getResultBrand() {
 #endif  // !CAPNP_LITE
 inline void Method::Builder::setResultBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<3>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Method::Builder::initResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::adoptResultBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<3>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Method::Builder::disownResultBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<3>() * ::capnp::POINTERS));
+      ::capnp::guarded<3>() * ::capnp::POINTERS));
 }
 
 inline bool Method::Reader::hasImplicitParameters() const {
   return !_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline bool Method::Builder::hasImplicitParameters() {
   return !_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<4>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Reader Method::Reader::getImplicitParameters() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_reader.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::getImplicitParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::get(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 inline void Method::Builder::setImplicitParameters( ::capnp::List< ::capnp::schema::Node::Parameter>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::set(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node::Parameter>::Builder Method::Builder::initImplicitParameters(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::init(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<4>() * ::capnp::POINTERS), size);
 }
 inline void Method::Builder::adoptImplicitParameters(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::adopt(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<4>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node::Parameter>> Method::Builder::disownImplicitParameters() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node::Parameter>>::disown(_builder.getPointerField(
-      ::kj::guarded<4>() * ::capnp::POINTERS));
+      ::capnp::guarded<4>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::Which Type::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::Which Type::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::Reader::isVoid() const {
@@ -5655,20 +5655,20 @@ inline  ::capnp::Void Type::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getVoid() {
   KJ_IREQUIRE((which() == Type::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::VOID);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isBool() const {
@@ -5681,20 +5681,20 @@ inline  ::capnp::Void Type::Reader::getBool() const {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getBool() {
   KJ_IREQUIRE((which() == Type::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setBool( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::BOOL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::BOOL);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt8() const {
@@ -5707,20 +5707,20 @@ inline  ::capnp::Void Type::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt8() {
   KJ_IREQUIRE((which() == Type::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT8);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT8);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt16() const {
@@ -5733,20 +5733,20 @@ inline  ::capnp::Void Type::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt16() {
   KJ_IREQUIRE((which() == Type::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT16);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT16);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt32() const {
@@ -5759,20 +5759,20 @@ inline  ::capnp::Void Type::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt32() {
   KJ_IREQUIRE((which() == Type::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isInt64() const {
@@ -5785,20 +5785,20 @@ inline  ::capnp::Void Type::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getInt64() {
   KJ_IREQUIRE((which() == Type::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setInt64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint8() const {
@@ -5811,20 +5811,20 @@ inline  ::capnp::Void Type::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint8() {
   KJ_IREQUIRE((which() == Type::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint8( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT8);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT8);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint16() const {
@@ -5837,20 +5837,20 @@ inline  ::capnp::Void Type::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint16() {
   KJ_IREQUIRE((which() == Type::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint16( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT16);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT16);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint32() const {
@@ -5863,20 +5863,20 @@ inline  ::capnp::Void Type::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint32() {
   KJ_IREQUIRE((which() == Type::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isUint64() const {
@@ -5889,20 +5889,20 @@ inline  ::capnp::Void Type::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getUint64() {
   KJ_IREQUIRE((which() == Type::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setUint64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::UINT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::UINT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat32() const {
@@ -5915,20 +5915,20 @@ inline  ::capnp::Void Type::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Type::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat32( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT32);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isFloat64() const {
@@ -5941,20 +5941,20 @@ inline  ::capnp::Void Type::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Type::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setFloat64( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::FLOAT64);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isText() const {
@@ -5967,20 +5967,20 @@ inline  ::capnp::Void Type::Reader::getText() const {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getText() {
   KJ_IREQUIRE((which() == Type::TEXT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setText( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::TEXT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::TEXT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isData() const {
@@ -5993,20 +5993,20 @@ inline  ::capnp::Void Type::Reader::getData() const {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::Builder::getData() {
   KJ_IREQUIRE((which() == Type::DATA),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::Builder::setData( ::capnp::Void value) {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::DATA);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::DATA);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Reader::isList() const {
@@ -6027,8 +6027,8 @@ inline typename Type::List::Builder Type::Builder::getList() {
 }
 inline typename Type::List::Builder Type::Builder::initList() {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::LIST);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::LIST);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::List::Builder(_builder);
 }
 inline bool Type::Reader::isEnum() const {
@@ -6049,9 +6049,9 @@ inline typename Type::Enum::Builder Type::Builder::getEnum() {
 }
 inline typename Type::Enum::Builder Type::Builder::initEnum() {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::ENUM);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::ENUM);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Enum::Builder(_builder);
 }
 inline bool Type::Reader::isStruct() const {
@@ -6072,9 +6072,9 @@ inline typename Type::Struct::Builder Type::Builder::getStruct() {
 }
 inline typename Type::Struct::Builder Type::Builder::initStruct() {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::STRUCT);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::STRUCT);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Struct::Builder(_builder);
 }
 inline bool Type::Reader::isInterface() const {
@@ -6095,9 +6095,9 @@ inline typename Type::Interface::Builder Type::Builder::getInterface() {
 }
 inline typename Type::Interface::Builder Type::Builder::initInterface() {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::INTERFACE);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<1>() * ::capnp::ELEMENTS, 0);
-  _builder.getPointerField(::kj::guarded<0>() * ::capnp::POINTERS).clear();
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::INTERFACE);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<1>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::guarded<0>() * ::capnp::POINTERS).clear();
   return typename Type::Interface::Builder(_builder);
 }
 inline bool Type::Reader::isAnyPointer() const {
@@ -6118,27 +6118,27 @@ inline typename Type::AnyPointer::Builder Type::Builder::getAnyPointer() {
 }
 inline typename Type::AnyPointer::Builder Type::Builder::initAnyPointer() {
   _builder.setDataField<Type::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Type::ANY_POINTER);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<4>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Type::ANY_POINTER);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<4>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Builder(_builder);
 }
 inline bool Type::List::Reader::hasElementType() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::List::Builder::hasElementType() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Type::List::Reader::getElementType() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::getElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
@@ -6147,51 +6147,51 @@ inline  ::capnp::schema::Type::Pipeline Type::List::Pipeline::getElementType() {
 #endif  // !CAPNP_LITE
 inline void Type::List::Builder::setElementType( ::capnp::schema::Type::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Type::List::Builder::initElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::List::Builder::adoptElementType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Type::List::Builder::disownElementType() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Enum::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Enum::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Enum::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Enum::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Enum::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Enum::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
@@ -6200,51 +6200,51 @@ inline  ::capnp::schema::Brand::Pipeline Type::Enum::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Enum::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Enum::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Enum::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Enum::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Struct::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Struct::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Struct::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Struct::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Struct::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Struct::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
@@ -6253,51 +6253,51 @@ inline  ::capnp::schema::Brand::Pipeline Type::Struct::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Struct::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Struct::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Struct::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Struct::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t Type::Interface::Reader::getTypeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::Interface::Builder::getTypeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Type::Interface::Builder::setTypeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::Interface::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Type::Interface::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Type::Interface::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
@@ -6306,29 +6306,29 @@ inline  ::capnp::schema::Brand::Pipeline Type::Interface::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Type::Interface::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Type::Interface::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Type::Interface::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Type::Interface::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Which Type::AnyPointer::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Reader::isUnconstrained() const {
@@ -6349,8 +6349,8 @@ inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Build
 }
 inline typename Type::AnyPointer::Unconstrained::Builder Type::AnyPointer::Builder::initUnconstrained() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::UNCONSTRAINED);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Unconstrained::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isParameter() const {
@@ -6371,9 +6371,9 @@ inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::
 }
 inline typename Type::AnyPointer::Parameter::Builder Type::AnyPointer::Builder::initParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
-  _builder.setDataField< ::uint64_t>(::kj::guarded<2>() * ::capnp::ELEMENTS, 0);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::PARAMETER);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
+  _builder.setDataField< ::uint64_t>(::capnp::guarded<2>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::Parameter::Builder(_builder);
 }
 inline bool Type::AnyPointer::Reader::isImplicitMethodParameter() const {
@@ -6394,17 +6394,17 @@ inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPoin
 }
 inline typename Type::AnyPointer::ImplicitMethodParameter::Builder Type::AnyPointer::Builder::initImplicitMethodParameter() {
   _builder.setDataField<Type::AnyPointer::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
-  _builder.setDataField< ::uint16_t>(::kj::guarded<5>() * ::capnp::ELEMENTS, 0);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Type::AnyPointer::IMPLICIT_METHOD_PARAMETER);
+  _builder.setDataField< ::uint16_t>(::capnp::guarded<5>() * ::capnp::ELEMENTS, 0);
   return typename Type::AnyPointer::ImplicitMethodParameter::Builder(_builder);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Type::AnyPointer::Unconstrained::Which Type::AnyPointer::Unconstrained::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isAnyKind() const {
@@ -6417,20 +6417,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getAnyKind() cons
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getAnyKind() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::ANY_KIND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setAnyKind( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::ANY_KIND);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isStruct() const {
@@ -6443,20 +6443,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getStruct() const
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getStruct() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::STRUCT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setStruct( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::STRUCT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isList() const {
@@ -6469,20 +6469,20 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getList() const {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getList() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::LIST),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setList( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::LIST);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Type::AnyPointer::Unconstrained::Reader::isCapability() const {
@@ -6495,119 +6495,119 @@ inline  ::capnp::Void Type::AnyPointer::Unconstrained::Reader::getCapability() c
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Type::AnyPointer::Unconstrained::Builder::getCapability() {
   KJ_IREQUIRE((which() == Type::AnyPointer::Unconstrained::CAPABILITY),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Unconstrained::Builder::setCapability( ::capnp::Void value) {
   _builder.setDataField<Type::AnyPointer::Unconstrained::Which>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, Type::AnyPointer::Unconstrained::CAPABILITY);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Type::AnyPointer::Parameter::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::Parameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::Parameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Reader::getParameterIndex() const {
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Type::AnyPointer::ImplicitMethodParameter::Builder::getParameterIndex() {
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS);
 }
 inline void Type::AnyPointer::ImplicitMethodParameter::Builder::setParameterIndex( ::uint16_t value) {
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<5>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<5>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Reader::hasScopes() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Builder::hasScopes() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Reader Brand::Reader::getScopes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::getScopes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Builder::setScopes( ::capnp::List< ::capnp::schema::Brand::Scope>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Scope>::Builder Brand::Builder::initScopes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Builder::adoptScopes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Scope>> Brand::Builder::disownScopes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Scope>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Scope::Which Brand::Scope::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Reader::getScopeId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Brand::Scope::Builder::getScopeId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setScopeId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Scope::Reader::isBind() const {
@@ -6619,49 +6619,49 @@ inline bool Brand::Scope::Builder::isBind() {
 inline bool Brand::Scope::Reader::hasBind() const {
   if (which() != Brand::Scope::BIND) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Scope::Builder::hasBind() {
   if (which() != Brand::Scope::BIND) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Reader Brand::Scope::Reader::getBind() const {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::getBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Scope::Builder::setBind( ::capnp::List< ::capnp::schema::Brand::Binding>::Reader value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Brand::Binding>::Builder Brand::Scope::Builder::initBind(unsigned int size) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Brand::Scope::Builder::adoptBind(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>>&& value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::BIND);
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Brand::Binding>> Brand::Scope::Builder::disownBind() {
   KJ_IREQUIRE((which() == Brand::Scope::BIND),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Brand::Binding>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Brand::Scope::Reader::isInherit() const {
@@ -6674,29 +6674,29 @@ inline  ::capnp::Void Brand::Scope::Reader::getInherit() const {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Scope::Builder::getInherit() {
   KJ_IREQUIRE((which() == Brand::Scope::INHERIT),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Scope::Builder::setInherit( ::capnp::Void value) {
   _builder.setDataField<Brand::Scope::Which>(
-      ::kj::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
+      ::capnp::guarded<4>() * ::capnp::ELEMENTS, Brand::Scope::INHERIT);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Brand::Binding::Which Brand::Binding::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Brand::Binding::Reader::isUnbound() const {
@@ -6709,20 +6709,20 @@ inline  ::capnp::Void Brand::Binding::Reader::getUnbound() const {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Brand::Binding::Builder::getUnbound() {
   KJ_IREQUIRE((which() == Brand::Binding::UNBOUND),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Brand::Binding::Builder::setUnbound( ::capnp::Void value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::UNBOUND);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Brand::Binding::Reader::isType() const {
@@ -6734,58 +6734,58 @@ inline bool Brand::Binding::Builder::isType() {
 inline bool Brand::Binding::Reader::hasType() const {
   if (which() != Brand::Binding::TYPE) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Brand::Binding::Builder::hasType() {
   if (which() != Brand::Binding::TYPE) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Type::Reader Brand::Binding::Reader::getType() const {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::getType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::setType( ::capnp::schema::Type::Reader value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Type::Builder Brand::Binding::Builder::initType() {
   _builder.setDataField<Brand::Binding::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Brand::Binding::Builder::adoptType(
     ::capnp::Orphan< ::capnp::schema::Type>&& value) {
   _builder.setDataField<Brand::Binding::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Brand::Binding::TYPE);
   ::capnp::_::PointerHelpers< ::capnp::schema::Type>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Type> Brand::Binding::Builder::disownType() {
   KJ_IREQUIRE((which() == Brand::Binding::TYPE),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::schema::Type>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline  ::capnp::schema::Value::Which Value::Reader::which() const {
   return _reader.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline  ::capnp::schema::Value::Which Value::Builder::which() {
   return _builder.getDataField<Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Reader::isVoid() const {
@@ -6798,20 +6798,20 @@ inline  ::capnp::Void Value::Reader::getVoid() const {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getVoid() {
   KJ_IREQUIRE((which() == Value::VOID),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setVoid( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::VOID);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::VOID);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isBool() const {
@@ -6824,20 +6824,20 @@ inline bool Value::Reader::getBool() const {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
 }
 
 inline bool Value::Builder::getBool() {
   KJ_IREQUIRE((which() == Value::BOOL),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setBool(bool value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::BOOL);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::BOOL);
   _builder.setDataField<bool>(
-      ::kj::guarded<16>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<16>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt8() const {
@@ -6850,20 +6850,20 @@ inline  ::int8_t Value::Reader::getInt8() const {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int8_t Value::Builder::getInt8() {
   KJ_IREQUIRE((which() == Value::INT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt8( ::int8_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT8);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT8);
   _builder.setDataField< ::int8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt16() const {
@@ -6876,20 +6876,20 @@ inline  ::int16_t Value::Reader::getInt16() const {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int16_t Value::Builder::getInt16() {
   KJ_IREQUIRE((which() == Value::INT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt16( ::int16_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT16);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT16);
   _builder.setDataField< ::int16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt32() const {
@@ -6902,20 +6902,20 @@ inline  ::int32_t Value::Reader::getInt32() const {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int32_t Value::Builder::getInt32() {
   KJ_IREQUIRE((which() == Value::INT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt32( ::int32_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT32);
   _builder.setDataField< ::int32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isInt64() const {
@@ -6928,20 +6928,20 @@ inline  ::int64_t Value::Reader::getInt64() const {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::int64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::int64_t Value::Builder::getInt64() {
   KJ_IREQUIRE((which() == Value::INT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::int64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInt64( ::int64_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INT64);
   _builder.setDataField< ::int64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint8() const {
@@ -6954,20 +6954,20 @@ inline  ::uint8_t Value::Reader::getUint8() const {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint8_t Value::Builder::getUint8() {
   KJ_IREQUIRE((which() == Value::UINT8),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint8( ::uint8_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT8);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT8);
   _builder.setDataField< ::uint8_t>(
-      ::kj::guarded<2>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<2>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint16() const {
@@ -6980,20 +6980,20 @@ inline  ::uint16_t Value::Reader::getUint16() const {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getUint16() {
   KJ_IREQUIRE((which() == Value::UINT16),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint16( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT16);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT16);
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint32() const {
@@ -7006,20 +7006,20 @@ inline  ::uint32_t Value::Reader::getUint32() const {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint32_t Value::Builder::getUint32() {
   KJ_IREQUIRE((which() == Value::UINT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint32( ::uint32_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT32);
   _builder.setDataField< ::uint32_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isUint64() const {
@@ -7032,20 +7032,20 @@ inline  ::uint64_t Value::Reader::getUint64() const {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Value::Builder::getUint64() {
   KJ_IREQUIRE((which() == Value::UINT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setUint64( ::uint64_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::UINT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::UINT64);
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat32() const {
@@ -7058,20 +7058,20 @@ inline float Value::Reader::getFloat32() const {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<float>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline float Value::Builder::getFloat32() {
   KJ_IREQUIRE((which() == Value::FLOAT32),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<float>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat32(float value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT32);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT32);
   _builder.setDataField<float>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isFloat64() const {
@@ -7084,20 +7084,20 @@ inline double Value::Reader::getFloat64() const {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline double Value::Builder::getFloat64() {
   KJ_IREQUIRE((which() == Value::FLOAT64),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setFloat64(double value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT64);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::FLOAT64);
   _builder.setDataField<double>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isText() const {
@@ -7109,49 +7109,49 @@ inline bool Value::Builder::isText() {
 inline bool Value::Reader::hasText() const {
   if (which() != Value::TEXT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasText() {
   if (which() != Value::TEXT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader Value::Reader::getText() const {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder Value::Builder::getText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setText( ::capnp::Text::Reader value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder Value::Builder::initText(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptText(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::TEXT);
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> Value::Builder::disownText() {
   KJ_IREQUIRE((which() == Value::TEXT),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isData() const {
@@ -7163,49 +7163,49 @@ inline bool Value::Builder::isData() {
 inline bool Value::Reader::hasData() const {
   if (which() != Value::DATA) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasData() {
   if (which() != Value::DATA) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Data::Reader Value::Reader::getData() const {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Data::Builder Value::Builder::getData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Value::Builder::setData( ::capnp::Data::Reader value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
   ::capnp::_::PointerHelpers< ::capnp::Data>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Data::Builder Value::Builder::initData(unsigned int size) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
   return ::capnp::_::PointerHelpers< ::capnp::Data>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void Value::Builder::adoptData(
     ::capnp::Orphan< ::capnp::Data>&& value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::DATA);
   ::capnp::_::PointerHelpers< ::capnp::Data>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Data> Value::Builder::disownData() {
   KJ_IREQUIRE((which() == Value::DATA),
               "Must check which() before get()ing a union member.");
   return ::capnp::_::PointerHelpers< ::capnp::Data>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Value::Reader::isList() const {
@@ -7217,30 +7217,30 @@ inline bool Value::Builder::isList() {
 inline bool Value::Reader::hasList() const {
   if (which() != Value::LIST) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasList() {
   if (which() != Value::LIST) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getList() const {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getList() {
   KJ_IREQUIRE((which() == Value::LIST),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initList() {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::LIST);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::LIST);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7255,20 +7255,20 @@ inline  ::uint16_t Value::Reader::getEnum() const {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint16_t Value::Builder::getEnum() {
   KJ_IREQUIRE((which() == Value::ENUM),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setEnum( ::uint16_t value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::ENUM);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::ENUM);
   _builder.setDataField< ::uint16_t>(
-      ::kj::guarded<1>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<1>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isStruct() const {
@@ -7280,30 +7280,30 @@ inline bool Value::Builder::isStruct() {
 inline bool Value::Reader::hasStruct() const {
   if (which() != Value::STRUCT) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasStruct() {
   if (which() != Value::STRUCT) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getStruct() const {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getStruct() {
   KJ_IREQUIRE((which() == Value::STRUCT),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initStruct() {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::STRUCT);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::STRUCT);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
@@ -7318,20 +7318,20 @@ inline  ::capnp::Void Value::Reader::getInterface() const {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _reader.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::capnp::Void Value::Builder::getInterface() {
   KJ_IREQUIRE((which() == Value::INTERFACE),
               "Must check which() before get()ing a union member.");
   return _builder.getDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Value::Builder::setInterface( ::capnp::Void value) {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::INTERFACE);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::INTERFACE);
   _builder.setDataField< ::capnp::Void>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Value::Reader::isAnyPointer() const {
@@ -7343,63 +7343,63 @@ inline bool Value::Builder::isAnyPointer() {
 inline bool Value::Reader::hasAnyPointer() const {
   if (which() != Value::ANY_POINTER) return false;
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Value::Builder::hasAnyPointer() {
   if (which() != Value::ANY_POINTER) return false;
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline ::capnp::AnyPointer::Reader Value::Reader::getAnyPointer() const {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Reader(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::getAnyPointer() {
   KJ_IREQUIRE((which() == Value::ANY_POINTER),
               "Must check which() before get()ing a union member.");
   return ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline ::capnp::AnyPointer::Builder Value::Builder::initAnyPointer() {
   _builder.setDataField<Value::Which>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, Value::ANY_POINTER);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, Value::ANY_POINTER);
   auto result = ::capnp::AnyPointer::Builder(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
   result.clear();
   return result;
 }
 
 inline  ::uint64_t Annotation::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t Annotation::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void Annotation::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool Annotation::Reader::hasValue() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasValue() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Value::Reader Annotation::Reader::getValue() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::getValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
@@ -7408,37 +7408,37 @@ inline  ::capnp::schema::Value::Pipeline Annotation::Pipeline::getValue() {
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setValue( ::capnp::schema::Value::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Value::Builder Annotation::Builder::initValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptValue(
     ::capnp::Orphan< ::capnp::schema::Value>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Value>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Value> Annotation::Builder::disownValue() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Value>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool Annotation::Reader::hasBrand() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool Annotation::Builder::hasBrand() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::schema::Brand::Reader Annotation::Reader::getBrand() const {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::getBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
@@ -7447,218 +7447,218 @@ inline  ::capnp::schema::Brand::Pipeline Annotation::Pipeline::getBrand() {
 #endif  // !CAPNP_LITE
 inline void Annotation::Builder::setBrand( ::capnp::schema::Brand::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::schema::Brand::Builder Annotation::Builder::initBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void Annotation::Builder::adoptBrand(
     ::capnp::Orphan< ::capnp::schema::Brand>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::schema::Brand> Annotation::Builder::disownBrand() {
   return ::capnp::_::PointerHelpers< ::capnp::schema::Brand>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasNodes() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasNodes() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Reader CodeGeneratorRequest::Reader::getNodes() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::getNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setNodes( ::capnp::List< ::capnp::schema::Node>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::Node>::Builder CodeGeneratorRequest::Builder::initNodes(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptNodes(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::Node>> CodeGeneratorRequest::Builder::disownNodes() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::Node>>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::Reader::hasRequestedFiles() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::Builder::hasRequestedFiles() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader CodeGeneratorRequest::Reader::getRequestedFiles() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::getRequestedFiles() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::Builder::setRequestedFiles( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>::Builder CodeGeneratorRequest::Builder::initRequestedFiles(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::Builder::adoptRequestedFiles(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>> CodeGeneratorRequest::Builder::disownRequestedFiles() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasFilename() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasFilename() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Reader::getFilename() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::getFilename() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setFilename( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Builder::initFilename(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptFilename(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Builder::disownFilename() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Reader::hasImports() const {
   return !_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Builder::hasImports() {
   return !_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<1>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader CodeGeneratorRequest::RequestedFile::Reader::getImports() const {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_reader.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::getImports() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::get(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::setImports( ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::set(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>::Builder CodeGeneratorRequest::RequestedFile::Builder::initImports(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::init(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<1>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Builder::adoptImports(
     ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::adopt(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<1>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>> CodeGeneratorRequest::RequestedFile::Builder::disownImports() {
   return ::capnp::_::PointerHelpers< ::capnp::List< ::capnp::schema::CodeGeneratorRequest::RequestedFile::Import>>::disown(_builder.getPointerField(
-      ::kj::guarded<1>() * ::capnp::POINTERS));
+      ::capnp::guarded<1>() * ::capnp::POINTERS));
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Reader::getId() const {
   return _reader.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 
 inline  ::uint64_t CodeGeneratorRequest::RequestedFile::Import::Builder::getId() {
   return _builder.getDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setId( ::uint64_t value) {
   _builder.setDataField< ::uint64_t>(
-      ::kj::guarded<0>() * ::capnp::ELEMENTS, value);
+      ::capnp::guarded<0>() * ::capnp::ELEMENTS, value);
 }
 
 inline bool CodeGeneratorRequest::RequestedFile::Import::Reader::hasName() const {
   return !_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline bool CodeGeneratorRequest::RequestedFile::Import::Builder::hasName() {
   return !_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS).isNull();
+      ::capnp::guarded<0>() * ::capnp::POINTERS).isNull();
 }
 inline  ::capnp::Text::Reader CodeGeneratorRequest::RequestedFile::Import::Reader::getName() const {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_reader.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::getName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::get(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::setName( ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::set(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), value);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), value);
 }
 inline  ::capnp::Text::Builder CodeGeneratorRequest::RequestedFile::Import::Builder::initName(unsigned int size) {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::init(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), size);
+      ::capnp::guarded<0>() * ::capnp::POINTERS), size);
 }
 inline void CodeGeneratorRequest::RequestedFile::Import::Builder::adoptName(
     ::capnp::Orphan< ::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers< ::capnp::Text>::adopt(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
+      ::capnp::guarded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
 inline ::capnp::Orphan< ::capnp::Text> CodeGeneratorRequest::RequestedFile::Import::Builder::disownName() {
   return ::capnp::_::PointerHelpers< ::capnp::Text>::disown(_builder.getPointerField(
-      ::kj::guarded<0>() * ::capnp::POINTERS));
+      ::capnp::guarded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -37,6 +37,14 @@ KJ_TEST("kj::size() on native arrays") {
   KJ_EXPECT(expected == 4u);
 }
 
+struct ImplicitToInt {
+  int i;
+
+  operator int() const {
+    return i;
+  }
+};
+
 TEST(Common, Maybe) {
   {
     Maybe<int> m = 123;
@@ -164,6 +172,23 @@ TEST(Common, Maybe) {
     KJ_IF_MAYBE(v, mv(m)) {
       ADD_FAILURE();
       EXPECT_EQ(0, *v);  // avoid unused warning
+    }
+  }
+
+  {
+    // Test a case where an implicit conversion didn't used to happen correctly.
+    Maybe<ImplicitToInt> m(ImplicitToInt { 123 });
+    Maybe<uint> m2(m);
+    Maybe<uint> m3(kj::mv(m));
+    KJ_IF_MAYBE(v, m2) {
+      EXPECT_EQ(123, *v);
+    } else {
+      ADD_FAILURE();
+    }
+    KJ_IF_MAYBE(v, m3) {
+      EXPECT_EQ(123, *v);
+    } else {
+      ADD_FAILURE();
     }
   }
 }

--- a/c++/src/kj/common-test.c++
+++ b/c++/src/kj/common-test.c++
@@ -445,5 +445,19 @@ TEST(Common, ArrayAsBytes) {
   }
 }
 
+KJ_TEST("kj::range()") {
+  uint expected = 5;
+  for (uint i: range(5, 10)) {
+    KJ_EXPECT(i == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+
+  expected = 0;
+  for (uint i: range(0, 8)) {
+    KJ_EXPECT(i == expected++);
+  }
+  KJ_EXPECT(expected == 8);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -643,6 +643,7 @@ template <typename T>
 class Range {
 public:
   inline constexpr Range(const T& begin, const T& end): begin_(begin), end_(end) {}
+  inline explicit constexpr Range(const T& end): begin_(0), end_(end) {}
 
   class Iterator {
   public:
@@ -689,6 +690,14 @@ inline constexpr Range<Decay<T>> range(T begin, T end) { return Range<Decay<T>>(
 //
 //     // Prints 1, 2, 3, 4, 5, 6, 7, 8, 9.
 //     for (int i: kj::range(1, 10)) { print(i); }
+
+template <typename T>
+inline constexpr Range<Decay<T>> zeroTo(T end) { return Range<Decay<T>>(end); }
+// Returns a fake iterable container containing all values of T from zero (inclusive) to `end`
+// (exclusive).  Example:
+//
+//     // Prints 0, 1, 2, 3, 4, 5, 6, 7, 8, 9.
+//     for (int i: kj::zeroTo(10)) { print(i); }
 
 template <typename T>
 inline constexpr Range<size_t> indices(T&& container) {

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -1031,13 +1031,13 @@ public:
   template <typename U>
   Maybe(Maybe<U>&& other) noexcept(noexcept(T(instance<U&&>()))) {
     KJ_IF_MAYBE(val, kj::mv(other)) {
-      ptr = *val;
+      ptr.emplace(kj::mv(*val));
     }
   }
   template <typename U>
   Maybe(const Maybe<U>& other) {
     KJ_IF_MAYBE(val, other) {
-      ptr = *val;
+      ptr.emplace(*val);
     }
   }
 

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -592,6 +592,21 @@ static KJ_CONSTEXPR(const) MinValue_ minValue = MinValue_();
 //
 // `char` is not supported, but `signed char` and `unsigned char` are.
 
+template <uint bits>
+inline constexpr unsigned long long maxValueForBits() {
+  // Get the maximum integer representable in the given number of bits.
+
+  // 1ull << 64 is unfortunately undefined.
+  return (bits == 64 ? 0 : (1ull << bits)) - 1;
+}
+
+struct ThrowOverflow {
+  // Functor which throws an exception complaining about integer overflow. Usually this is used
+  // with the interfaces in units.h, but is defined here because Cap'n Proto wants to avoid
+  // including units.h when not using CAPNP_DEBUG_TYPES.
+  void operator()() const;
+};
+
 #if __GNUC__
 inline constexpr float inf() { return __builtin_huge_valf(); }
 inline constexpr float nan() { return __builtin_nanf(""); }

--- a/c++/src/kj/common.h
+++ b/c++/src/kj/common.h
@@ -149,13 +149,13 @@ typedef unsigned char byte;
 #endif
 
 #if defined(KJ_DEBUG) || __NO_INLINE__
-#define KJ_ALWAYS_INLINE(prototype) inline prototype
+#define KJ_ALWAYS_INLINE(...) inline __VA_ARGS__
 // Don't force inline in debug mode.
 #else
 #if defined(_MSC_VER)
-#define KJ_ALWAYS_INLINE(prototype) __forceinline prototype
+#define KJ_ALWAYS_INLINE(...) __forceinline __VA_ARGS__
 #else
-#define KJ_ALWAYS_INLINE(prototype) inline prototype __attribute__((always_inline))
+#define KJ_ALWAYS_INLINE(...) inline __VA_ARGS__ __attribute__((always_inline))
 #endif
 // Force a function to always be inlined.  Apply only to the prototype, not to the definition.
 #endif

--- a/c++/src/kj/mutex.h
+++ b/c++/src/kj/mutex.h
@@ -158,7 +158,7 @@ private:
 
 template <typename T>
 class Locked {
-  // Return type for `MutexGuarded<T>::lock()`.  `Locked<T>` provides access to the guarded object
+  // Return type for `MutexGuarded<T>::lock()`.  `Locked<T>` provides access to the bounded object
   // and unlocks the mutex when it goes out of scope.
 
 public:
@@ -208,7 +208,7 @@ private:
 
 template <typename T>
 class MutexGuarded {
-  // An object of type T, guarded by a mutex.  In order to access the object, you must lock it.
+  // An object of type T, bounded by a mutex.  In order to access the object, you must lock it.
   //
   // Write locks are not "recursive" -- trying to lock again in a thread that already holds a lock
   // will deadlock.  Recursive write locks are usually a sign of bad design.
@@ -223,7 +223,7 @@ class MutexGuarded {
 public:
   template <typename... Params>
   explicit MutexGuarded(Params&&... params);
-  // Initialize the mutex-guarded object by passing the given parameters to its constructor.
+  // Initialize the mutex-bounded object by passing the given parameters to its constructor.
 
   Locked<T> lockExclusive() const;
   // Exclusively locks the object and returns it.  The returned `Locked<T>` can be passed by

--- a/c++/src/kj/units-test.c++
+++ b/c++/src/kj/units-test.c++
@@ -96,92 +96,92 @@ TEST(UnitMeasure, AtLeastUInt) {
   // COMPILE ERROR: assertSameType<uint64_t, AtLeastUInt<65>>();
 }
 
-TEST(UnitMeasure, GuardedConst) {
+TEST(UnitMeasure, BoundedConst) {
   // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
   //   line restored to verify that they actually error out.
 
-  KJ_EXPECT((guarded<456>() + guarded<123>()).unwrap() == 456 + 123);
-  KJ_EXPECT((guarded<456>() - guarded<123>()).unwrap() == 456 - 123);
-  KJ_EXPECT((guarded<456>() * guarded<123>()).unwrap() == 456 * 123);
-  KJ_EXPECT((guarded<456>() / guarded<123>()).unwrap() == 456 / 123);
-  KJ_EXPECT((guarded<456>() % guarded<123>()).unwrap() == 456 % 123);
-  KJ_EXPECT((guarded<456>() << guarded<5>()).unwrap() == 456 << 5);
-  KJ_EXPECT((guarded<456>() >> guarded<2>()).unwrap() == 456 >> 2);
+  KJ_EXPECT((bounded<456>() + bounded<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT((bounded<456>() - bounded<123>()).unwrap() == 456 - 123);
+  KJ_EXPECT((bounded<456>() * bounded<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((bounded<456>() / bounded<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((bounded<456>() % bounded<123>()).unwrap() == 456 % 123);
+  KJ_EXPECT((bounded<456>() << bounded<5>()).unwrap() == 456 << 5);
+  KJ_EXPECT((bounded<456>() >> bounded<2>()).unwrap() == 456 >> 2);
 
-  KJ_EXPECT(guarded<123>() == guarded<123>());
-  KJ_EXPECT(guarded<123>() != guarded<456>());
-  KJ_EXPECT(guarded<123>() <  guarded<456>());
-  KJ_EXPECT(guarded<456>() >  guarded<123>());
-  KJ_EXPECT(guarded<123>() <= guarded<456>());
-  KJ_EXPECT(guarded<456>() >= guarded<123>());
+  KJ_EXPECT(bounded<123>() == bounded<123>());
+  KJ_EXPECT(bounded<123>() != bounded<456>());
+  KJ_EXPECT(bounded<123>() <  bounded<456>());
+  KJ_EXPECT(bounded<456>() >  bounded<123>());
+  KJ_EXPECT(bounded<123>() <= bounded<456>());
+  KJ_EXPECT(bounded<456>() >= bounded<123>());
 
-  KJ_EXPECT(!(guarded<123>() == guarded<456>()));
-  KJ_EXPECT(!(guarded<123>() != guarded<123>()));
-  KJ_EXPECT(!(guarded<456>() <  guarded<123>()));
-  KJ_EXPECT(!(guarded<123>() >  guarded<456>()));
-  KJ_EXPECT(!(guarded<456>() <= guarded<123>()));
-  KJ_EXPECT(!(guarded<123>() >= guarded<456>()));
+  KJ_EXPECT(!(bounded<123>() == bounded<456>()));
+  KJ_EXPECT(!(bounded<123>() != bounded<123>()));
+  KJ_EXPECT(!(bounded<456>() <  bounded<123>()));
+  KJ_EXPECT(!(bounded<123>() >  bounded<456>()));
+  KJ_EXPECT(!(bounded<456>() <= bounded<123>()));
+  KJ_EXPECT(!(bounded<123>() >= bounded<456>()));
 
   {
-    uint16_t succ = unguard(guarded<12345>());
+    uint16_t succ = unbound(bounded<12345>());
     KJ_EXPECT(succ == 12345);
 
-    // COMPILE ERROR: uint8_t err KJ_UNUSED = unguard(guarded<12345>());
+    // COMPILE ERROR: uint8_t err KJ_UNUSED = unbound(bounded<12345>());
   }
 
-  // COMPILE ERROR: auto err1 KJ_UNUSED = guarded<(0xffffffffffffffffull)>() + guarded<1>();
-  // COMPILE ERROR: auto err2 KJ_UNUSED = guarded<1>() - guarded<2>();
-  // COMPILE ERROR: auto err3 KJ_UNUSED = guarded<(1ull << 60)>() * guarded<(1ull << 60)>();
-  // COMPILE ERROR: auto err4 KJ_UNUSED = guarded<1>() / guarded<0>();
-  // COMPILE ERROR: auto err5 KJ_UNUSED = guarded<1>() % guarded<0>();
-  // COMPILE ERROR: auto err6 KJ_UNUSED = guarded<1>() << guarded<64>();
-  // COMPILE ERROR: auto err7 KJ_UNUSED = guarded<(1ull << 60)>() << guarded<4>();
-  // COMPILE ERROR: auto err8 KJ_UNUSED = guarded<1>() >> guarded<64>();
+  // COMPILE ERROR: auto err1 KJ_UNUSED = bounded<(0xffffffffffffffffull)>() + bounded<1>();
+  // COMPILE ERROR: auto err2 KJ_UNUSED = bounded<1>() - bounded<2>();
+  // COMPILE ERROR: auto err3 KJ_UNUSED = bounded<(1ull << 60)>() * bounded<(1ull << 60)>();
+  // COMPILE ERROR: auto err4 KJ_UNUSED = bounded<1>() / bounded<0>();
+  // COMPILE ERROR: auto err5 KJ_UNUSED = bounded<1>() % bounded<0>();
+  // COMPILE ERROR: auto err6 KJ_UNUSED = bounded<1>() << bounded<64>();
+  // COMPILE ERROR: auto err7 KJ_UNUSED = bounded<(1ull << 60)>() << bounded<4>();
+  // COMPILE ERROR: auto err8 KJ_UNUSED = bounded<1>() >> bounded<64>();
 
-  // COMPILE ERROR: guardedAdd<0xffffffffffffffffull, 1>();
-  // COMPILE ERROR: guardedSub<1, 2>();
-  // COMPILE ERROR: guardedMul<0x100000000, 0x100000000>();
-  // COMPILE ERROR: guardedLShift<0x10, 60>();
+  // COMPILE ERROR: boundedAdd<0xffffffffffffffffull, 1>();
+  // COMPILE ERROR: boundedSub<1, 2>();
+  // COMPILE ERROR: boundedMul<0x100000000, 0x100000000>();
+  // COMPILE ERROR: boundedLShift<0x10, 60>();
 }
 
 template <uint value, typename T = uint>
-constexpr Guarded<value, T> guardedValue(NoInfer<T> runtimeValue = value) {
-  return Guarded<value, T>(runtimeValue, unsafe);
+constexpr Bounded<value, T> boundedValue(NoInfer<T> runtimeValue = value) {
+  return Bounded<value, T>(runtimeValue, unsafe);
 }
 
-TEST(UnitMeasure, Guarded) {
+TEST(UnitMeasure, Bounded) {
   // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
   //   line restored to verify that they actually error out.
 
-  KJ_EXPECT((guardedValue<456>() + guardedValue<123>()).unwrap() == 456 + 123);
-  KJ_EXPECT(guardedValue<456>().subtractChecked(guardedValue<123>(), [](){}).unwrap() == 456 - 123);
-  KJ_EXPECT((guardedValue<456>() * guardedValue<123>()).unwrap() == 456 * 123);
-  KJ_EXPECT((guardedValue<456>() / guardedValue<123>()).unwrap() == 456 / 123);
-  KJ_EXPECT((guardedValue<456>() % guardedValue<123>()).unwrap() == 456 % 123);
+  KJ_EXPECT((boundedValue<456>() + boundedValue<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT(boundedValue<456>().subtractChecked(boundedValue<123>(), [](){}).unwrap() == 456 - 123);
+  KJ_EXPECT((boundedValue<456>() * boundedValue<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((boundedValue<456>() / boundedValue<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((boundedValue<456>() % boundedValue<123>()).unwrap() == 456 % 123);
 
 
   {
-    Guarded<123, uint8_t> succ KJ_UNUSED;
-    // COMPILE ERROR: Guarded<1234, uint8_t> err KJ_UNUSED;
-    // COMPILE ERROR: auto err KJ_UNUSED = guardedValue<0xffffffffull>() + guardedValue<1>();
+    Bounded<123, uint8_t> succ KJ_UNUSED;
+    // COMPILE ERROR: Bounded<1234, uint8_t> err KJ_UNUSED;
+    // COMPILE ERROR: auto err KJ_UNUSED = boundedValue<0xffffffffull>() + boundedValue<1>();
   }
 
   {
-    Guarded<123, uint8_t> succ1 KJ_UNUSED = guardedValue<123>();
-    Guarded<123, uint8_t> succ2 KJ_UNUSED = guardedValue<122>();
-    Guarded<123, uint8_t> succ3 KJ_UNUSED = guardedValue<0>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<124>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<125>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<123456>();
+    Bounded<123, uint8_t> succ1 KJ_UNUSED = boundedValue<123>();
+    Bounded<123, uint8_t> succ2 KJ_UNUSED = boundedValue<122>();
+    Bounded<123, uint8_t> succ3 KJ_UNUSED = boundedValue<0>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = boundedValue<124>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = boundedValue<125>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = boundedValue<123456>();
   }
 
-  Guarded<123, uint8_t> foo;
-  foo = guardedValue<123>();
-  foo = guardedValue<122>();
-  foo = guardedValue<0>();
-  // COMPILE ERROR: foo = guardedValue<124>();
-  // COMPILE ERROR: foo = guardedValue<125>();
-  // COMPILE ERROR: foo = guardedValue<123456>();
+  Bounded<123, uint8_t> foo;
+  foo = boundedValue<123>();
+  foo = boundedValue<122>();
+  foo = boundedValue<0>();
+  // COMPILE ERROR: foo = boundedValue<124>();
+  // COMPILE ERROR: foo = boundedValue<125>();
+  // COMPILE ERROR: foo = boundedValue<123456>();
 
   assertMax<122>(foo, []() {});
   // COMPILE ERROR: assertMax<123>(foo, []() {});
@@ -191,29 +191,29 @@ TEST(UnitMeasure, Guarded) {
   // COMPILE ERROR: assertMaxBits<7>(foo, []() {});
   // COMPILE ERROR: assertMaxBits<8>(foo, []() {});
 
-  Guarded<12, uint8_t> bar;
+  Bounded<12, uint8_t> bar;
   // COMPILE ERROR: bar = foo;
   // COMPILE ERROR: bar = foo.assertMax<13>([]() {});
   bool caught = false;
-  foo = guardedValue<13>();
+  foo = boundedValue<13>();
   bar = foo.assertMax<12>([&]() { caught = true; });
   KJ_EXPECT(caught);
 
-  foo = guardedValue<100>() + guardedValue<23>();
-  // COMPILE ERROR: foo = guardedValue<100>() + guardedValue<24>();
+  foo = boundedValue<100>() + boundedValue<23>();
+  // COMPILE ERROR: foo = boundedValue<100>() + boundedValue<24>();
 
-  bar = guardedValue<3>() * guardedValue<4>();
-  // COMPILE ERROR: bar = guardedValue<2>() * guardedValue<7>();
+  bar = boundedValue<3>() * boundedValue<4>();
+  // COMPILE ERROR: bar = boundedValue<2>() * boundedValue<7>();
 
-  foo.subtractChecked(guardedValue<122>(), []() { KJ_FAIL_EXPECT(""); });
-  foo.subtractChecked(guardedValue<123>(), []() { KJ_FAIL_EXPECT(""); });
+  foo.subtractChecked(boundedValue<122>(), []() { KJ_FAIL_EXPECT(""); });
+  foo.subtractChecked(boundedValue<123>(), []() { KJ_FAIL_EXPECT(""); });
   caught = false;
-  foo.subtractChecked(guardedValue<124>(), [&]() { caught = true; });
+  foo.subtractChecked(boundedValue<124>(), [&]() { caught = true; });
   KJ_EXPECT(caught);
 
   {
-    Guarded<65535, uint16_t> succ1 KJ_UNUSED = guarded((uint16_t)123);
-    // COMPILE ERROR: Guarded<65534, uint16_t> err KJ_UNUSED = guarded((uint16_t)123);
+    Bounded<65535, uint16_t> succ1 KJ_UNUSED = bounded((uint16_t)123);
+    // COMPILE ERROR: Bounded<65534, uint16_t> err KJ_UNUSED = bounded((uint16_t)123);
   }
 
   uint old = foo.unwrap();
@@ -221,93 +221,93 @@ TEST(UnitMeasure, Guarded) {
   KJ_EXPECT(foo.unwrap() == old);
 
   {
-    Guarded<1234, uint16_t> x = guarded<123>();
-    uint16_t succ = unguard(x);
+    Bounded<1234, uint16_t> x = bounded<123>();
+    uint16_t succ = unbound(x);
     KJ_EXPECT(succ == 123);
 
-    // COMPILE ERROR: uint8_t err KJ_UNUSED = unguard(x);
+    // COMPILE ERROR: uint8_t err KJ_UNUSED = unbound(x);
   }
 }
 
-TEST(UnitMeasure, GuardedVsGuardedConst) {
+TEST(UnitMeasure, BoundedVsGuardedConst) {
   // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
   //   line restored to verify that they actually error out.
 
-  KJ_EXPECT((guardedValue<456>() + guarded<123>()).unwrap() == 456 + 123);
-  KJ_EXPECT(guardedValue<456>().subtractChecked(guarded<123>(), [](){}).unwrap() == 456 - 123);
-  KJ_EXPECT((guardedValue<456>() * guarded<123>()).unwrap() == 456 * 123);
-  KJ_EXPECT((guardedValue<456>() / guarded<123>()).unwrap() == 456 / 123);
-  KJ_EXPECT((guardedValue<456>() % guarded<123>()).unwrap() == 456 % 123);
+  KJ_EXPECT((boundedValue<456>() + bounded<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT(boundedValue<456>().subtractChecked(bounded<123>(), [](){}).unwrap() == 456 - 123);
+  KJ_EXPECT((boundedValue<456>() * bounded<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((boundedValue<456>() / bounded<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((boundedValue<456>() % bounded<123>()).unwrap() == 456 % 123);
 
   {
-    Guarded<123, uint8_t> succ1 KJ_UNUSED = guarded<123>();
-    Guarded<123, uint8_t> succ2 KJ_UNUSED = guarded<122>();
-    Guarded<123, uint8_t> succ3 KJ_UNUSED = guarded<0>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<124>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<125>();
-    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<123456>();
+    Bounded<123, uint8_t> succ1 KJ_UNUSED = bounded<123>();
+    Bounded<123, uint8_t> succ2 KJ_UNUSED = bounded<122>();
+    Bounded<123, uint8_t> succ3 KJ_UNUSED = bounded<0>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = bounded<124>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = bounded<125>();
+    // COMPILE ERROR: Bounded<123, uint8_t> err KJ_UNUSED = bounded<123456>();
   }
 
-  Guarded<123, uint8_t> foo;
-  foo = guarded<123>();
-  foo = guarded<122>();
-  foo = guarded<0>();
-  // COMPILE ERROR: foo = guarded<124>();
-  // COMPILE ERROR: foo = guarded<125>();
-  // COMPILE ERROR: foo = guarded<123456>();
+  Bounded<123, uint8_t> foo;
+  foo = bounded<123>();
+  foo = bounded<122>();
+  foo = bounded<0>();
+  // COMPILE ERROR: foo = bounded<124>();
+  // COMPILE ERROR: foo = bounded<125>();
+  // COMPILE ERROR: foo = bounded<123456>();
 
-  Guarded<16, uint8_t> bar;
-  // COMPILE ERROR: bar = foo >> guarded<2>();
-  bar = foo >> guarded<3>();
+  Bounded<16, uint8_t> bar;
+  // COMPILE ERROR: bar = foo >> bounded<2>();
+  bar = foo >> bounded<3>();
 
-  // COMPILE ERROR: foo = bar << guarded<3>();
-  foo = bar << guarded<2>();
+  // COMPILE ERROR: foo = bar << bounded<3>();
+  foo = bar << bounded<2>();
 }
 
-TEST(UnitMeasure, GuardedRange) {
+TEST(UnitMeasure, BoundedRange) {
   uint expected = 0;
-  for (auto i: zeroTo(guarded<10>())) {
-    Guarded<10, uint8_t> value = i;
-    KJ_EXPECT(unguard(value) == expected++);
+  for (auto i: zeroTo(bounded<10>())) {
+    Bounded<10, uint8_t> value = i;
+    KJ_EXPECT(unbound(value) == expected++);
   }
   KJ_EXPECT(expected == 10);
 
   expected = 0;
-  for (auto i: zeroTo(guarded((uint8_t)10))) {
-    Guarded<255, uint8_t> value = i;
-    KJ_EXPECT(unguard(value) == expected++);
+  for (auto i: zeroTo(bounded((uint8_t)10))) {
+    Bounded<255, uint8_t> value = i;
+    KJ_EXPECT(unbound(value) == expected++);
   }
   KJ_EXPECT(expected == 10);
 
   expected = 3;
-  for (auto i: range(guarded((uint8_t)3), guarded((uint8_t)10))) {
-    Guarded<255, uint8_t> value = i;
-    KJ_EXPECT(unguard(value) == expected++);
+  for (auto i: range(bounded((uint8_t)3), bounded((uint8_t)10))) {
+    Bounded<255, uint8_t> value = i;
+    KJ_EXPECT(unbound(value) == expected++);
   }
   KJ_EXPECT(expected == 10);
 }
 
-TEST(UnitMeasure, GuardedQuantity) {
-  auto BYTES = unit<Quantity<Guarded<12345, uint16_t>, byte>>();
+TEST(UnitMeasure, BoundedQuantity) {
+  auto BYTES = unit<Quantity<Bounded<12345, uint16_t>, byte>>();
 
   uint expected = 0;
-  for (auto i: zeroTo(guarded<10>() * BYTES)) {
-    Quantity<Guarded<10, uint8_t>, byte> value = i;
-    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  for (auto i: zeroTo(bounded<10>() * BYTES)) {
+    Quantity<Bounded<10, uint8_t>, byte> value = i;
+    KJ_EXPECT(unbound(value / BYTES) == expected++);
   }
   KJ_EXPECT(expected == 10);
 
   expected = 0;
-  for (auto i: zeroTo(guarded((uint8_t)10) * BYTES)) {
-    Quantity<Guarded<255, uint8_t>, byte> value = i;
-    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  for (auto i: zeroTo(bounded((uint8_t)10) * BYTES)) {
+    Quantity<Bounded<255, uint8_t>, byte> value = i;
+    KJ_EXPECT(unbound(value / BYTES) == expected++);
   }
   KJ_EXPECT(expected == 10);
 
   expected = 3;
-  for (auto i: range(guarded((uint8_t)3) * BYTES, guarded((uint8_t)10) * BYTES)) {
-    Quantity<Guarded<255, uint8_t>, byte> value = i;
-    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  for (auto i: range(bounded((uint8_t)3) * BYTES, bounded((uint8_t)10) * BYTES)) {
+    Quantity<Bounded<255, uint8_t>, byte> value = i;
+    KJ_EXPECT(unbound(value / BYTES) == expected++);
   }
   KJ_EXPECT(expected == 10);
 }
@@ -315,38 +315,38 @@ TEST(UnitMeasure, GuardedQuantity) {
 template <typename T>
 void assertTypeAndValue(T a, T b) { KJ_EXPECT(a == b); }
 
-TEST(UnitMeasure, GuardedMinMax) {
-  assertTypeAndValue(guarded<5>(), kj::max(guarded<4>(), guarded<5>()));
-  assertTypeAndValue(guarded<5>(), kj::max(guarded<5>(), guarded<4>()));
-  assertTypeAndValue(guarded<4>(), kj::max(guarded<4>(), guarded<4>()));
+TEST(UnitMeasure, BoundedMinMax) {
+  assertTypeAndValue(bounded<5>(), kj::max(bounded<4>(), bounded<5>()));
+  assertTypeAndValue(bounded<5>(), kj::max(bounded<5>(), bounded<4>()));
+  assertTypeAndValue(bounded<4>(), kj::max(bounded<4>(), bounded<4>()));
 
-  assertTypeAndValue(guarded<4>(), kj::min(guarded<4>(), guarded<5>()));
-  assertTypeAndValue(guarded<4>(), kj::min(guarded<5>(), guarded<4>()));
-  assertTypeAndValue(guarded<4>(), kj::min(guarded<4>(), guarded<4>()));
+  assertTypeAndValue(bounded<4>(), kj::min(bounded<4>(), bounded<5>()));
+  assertTypeAndValue(bounded<4>(), kj::min(bounded<5>(), bounded<4>()));
+  assertTypeAndValue(bounded<4>(), kj::min(bounded<4>(), bounded<4>()));
 
   typedef uint8_t t1;
   typedef uint16_t t2;
 
-  assertTypeAndValue(guardedValue<5,t2>(3), kj::max(guardedValue<4,t2>(3), guardedValue<5,t1>(2)));
-  assertTypeAndValue(guardedValue<5,t2>(3), kj::max(guardedValue<5,t1>(2), guardedValue<4,t2>(3)));
-  assertTypeAndValue(guardedValue<4,t2>(3), kj::max(guardedValue<4,t2>(3), guardedValue<4,t2>(3)));
+  assertTypeAndValue(boundedValue<5,t2>(3), kj::max(boundedValue<4,t2>(3), boundedValue<5,t1>(2)));
+  assertTypeAndValue(boundedValue<5,t2>(3), kj::max(boundedValue<5,t1>(2), boundedValue<4,t2>(3)));
+  assertTypeAndValue(boundedValue<4,t2>(3), kj::max(boundedValue<4,t2>(3), boundedValue<4,t2>(3)));
 
-  assertTypeAndValue(guardedValue<4,t2>(2), kj::min(guardedValue<4,t2>(3), guardedValue<5,t1>(2)));
-  assertTypeAndValue(guardedValue<4,t2>(2), kj::min(guardedValue<5,t1>(2), guardedValue<4,t2>(3)));
-  assertTypeAndValue(guardedValue<4,t2>(3), kj::min(guardedValue<4,t2>(3), guardedValue<4,t2>(3)));
+  assertTypeAndValue(boundedValue<4,t2>(2), kj::min(boundedValue<4,t2>(3), boundedValue<5,t1>(2)));
+  assertTypeAndValue(boundedValue<4,t2>(2), kj::min(boundedValue<5,t1>(2), boundedValue<4,t2>(3)));
+  assertTypeAndValue(boundedValue<4,t2>(3), kj::min(boundedValue<4,t2>(3), boundedValue<4,t2>(3)));
 
-  assertTypeAndValue(guardedValue<5,t1>(4), kj::max(guarded<4>(), guardedValue<5,t1>(2)));
-  assertTypeAndValue(guardedValue<5,t1>(4), kj::max(guardedValue<5,t1>(2), guarded<4>()));
+  assertTypeAndValue(boundedValue<5,t1>(4), kj::max(bounded<4>(), boundedValue<5,t1>(2)));
+  assertTypeAndValue(boundedValue<5,t1>(4), kj::max(boundedValue<5,t1>(2), bounded<4>()));
 
-  assertTypeAndValue(guardedValue<4,t1>(2), kj::min(guarded<4>(), guardedValue<5,t1>(2)));
-  assertTypeAndValue(guardedValue<4,t1>(2), kj::min(guardedValue<5,t1>(2), guarded<4>()));
+  assertTypeAndValue(boundedValue<4,t1>(2), kj::min(bounded<4>(), boundedValue<5,t1>(2)));
+  assertTypeAndValue(boundedValue<4,t1>(2), kj::min(boundedValue<5,t1>(2), bounded<4>()));
 
   // These two are degenerate cases. Currently they fail to compile but meybe they shouldn't?
-//  assertTypeAndValue(guarded<5>(), kj::max(guardedValue<4,t2>(3), guarded<5>()));
-//  assertTypeAndValue(guarded<5>(), kj::max(guarded<5>(), guardedValue<4,t2>(3)));
+//  assertTypeAndValue(bounded<5>(), kj::max(boundedValue<4,t2>(3), bounded<5>()));
+//  assertTypeAndValue(bounded<5>(), kj::max(bounded<5>(), boundedValue<4,t2>(3)));
 
-  assertTypeAndValue(guardedValue<4,t2>(3), kj::min(guardedValue<4,t2>(3), guarded<5>()));
-  assertTypeAndValue(guardedValue<4,t2>(3), kj::min(guarded<5>(), guardedValue<4,t2>(3)));
+  assertTypeAndValue(boundedValue<4,t2>(3), kj::min(boundedValue<4,t2>(3), bounded<5>()));
+  assertTypeAndValue(boundedValue<4,t2>(3), kj::min(bounded<5>(), boundedValue<4,t2>(3)));
 }
 
 }  // namespace

--- a/c++/src/kj/units-test.c++
+++ b/c++/src/kj/units-test.c++
@@ -61,5 +61,256 @@ TEST(UnitMeasure, Basics) {
   EXPECT_FALSE(8 * KIB < 4 * KIB);
 }
 
+template <typename T, typename U>
+static void assertSameType() {
+  U u;
+  T* t = &u;
+  *t = 0;
+}
+
+TEST(UnitMeasure, AtLeastUInt) {
+  assertSameType<uint8_t , AtLeastUInt< 2>>();
+  assertSameType<uint8_t , AtLeastUInt< 3>>();
+  assertSameType<uint8_t , AtLeastUInt< 4>>();
+  assertSameType<uint8_t , AtLeastUInt< 5>>();
+  assertSameType<uint8_t , AtLeastUInt< 6>>();
+  assertSameType<uint8_t , AtLeastUInt< 7>>();
+  assertSameType<uint8_t , AtLeastUInt< 8>>();
+  assertSameType<uint16_t, AtLeastUInt< 9>>();
+  assertSameType<uint16_t, AtLeastUInt<10>>();
+  assertSameType<uint16_t, AtLeastUInt<13>>();
+  assertSameType<uint16_t, AtLeastUInt<16>>();
+  assertSameType<uint32_t, AtLeastUInt<17>>();
+  assertSameType<uint32_t, AtLeastUInt<23>>();
+  assertSameType<uint32_t, AtLeastUInt<24>>();
+  assertSameType<uint32_t, AtLeastUInt<25>>();
+  assertSameType<uint32_t, AtLeastUInt<32>>();
+  assertSameType<uint64_t, AtLeastUInt<33>>();
+  assertSameType<uint64_t, AtLeastUInt<40>>();
+  assertSameType<uint64_t, AtLeastUInt<41>>();
+  assertSameType<uint64_t, AtLeastUInt<47>>();
+  assertSameType<uint64_t, AtLeastUInt<48>>();
+  assertSameType<uint64_t, AtLeastUInt<52>>();
+  assertSameType<uint64_t, AtLeastUInt<64>>();
+
+  // COMPILE ERROR: assertSameType<uint64_t, AtLeastUInt<65>>();
+}
+
+TEST(UnitMeasure, GuardedConst) {
+  // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
+  //   line restored to verify that they actually error out.
+
+  KJ_EXPECT((guarded<456>() + guarded<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT((guarded<456>() - guarded<123>()).unwrap() == 456 - 123);
+  KJ_EXPECT((guarded<456>() * guarded<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((guarded<456>() / guarded<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((guarded<456>() % guarded<123>()).unwrap() == 456 % 123);
+  KJ_EXPECT((guarded<456>() << guarded<5>()).unwrap() == 456 << 5);
+  KJ_EXPECT((guarded<456>() >> guarded<2>()).unwrap() == 456 >> 2);
+
+  KJ_EXPECT(guarded<123>() == guarded<123>());
+  KJ_EXPECT(guarded<123>() != guarded<456>());
+  KJ_EXPECT(guarded<123>() <  guarded<456>());
+  KJ_EXPECT(guarded<456>() >  guarded<123>());
+  KJ_EXPECT(guarded<123>() <= guarded<456>());
+  KJ_EXPECT(guarded<456>() >= guarded<123>());
+
+  KJ_EXPECT(!(guarded<123>() == guarded<456>()));
+  KJ_EXPECT(!(guarded<123>() != guarded<123>()));
+  KJ_EXPECT(!(guarded<456>() <  guarded<123>()));
+  KJ_EXPECT(!(guarded<123>() >  guarded<456>()));
+  KJ_EXPECT(!(guarded<456>() <= guarded<123>()));
+  KJ_EXPECT(!(guarded<123>() >= guarded<456>()));
+
+  {
+    uint16_t succ = unguard(guarded<12345>());
+    KJ_EXPECT(succ == 12345);
+
+    // COMPILE ERROR: uint8_t err KJ_UNUSED = unguard(guarded<12345>());
+  }
+
+  // COMPILE ERROR: auto err1 KJ_UNUSED = guarded<(0xffffffffffffffffull)>() + guarded<1>();
+  // COMPILE ERROR: auto err2 KJ_UNUSED = guarded<1>() - guarded<2>();
+  // COMPILE ERROR: auto err3 KJ_UNUSED = guarded<(1ull << 60)>() * guarded<(1ull << 60)>();
+  // COMPILE ERROR: auto err4 KJ_UNUSED = guarded<1>() / guarded<0>();
+  // COMPILE ERROR: auto err5 KJ_UNUSED = guarded<1>() % guarded<0>();
+  // COMPILE ERROR: auto err6 KJ_UNUSED = guarded<1>() << guarded<64>();
+  // COMPILE ERROR: auto err7 KJ_UNUSED = guarded<(1ull << 60)>() << guarded<4>();
+  // COMPILE ERROR: auto err8 KJ_UNUSED = guarded<1>() >> guarded<64>();
+
+  // COMPILE ERROR: guardedAdd<0xffffffffffffffffull, 1>();
+  // COMPILE ERROR: guardedSub<1, 2>();
+  // COMPILE ERROR: guardedMul<0x100000000, 0x100000000>();
+  // COMPILE ERROR: guardedLShift<0x10, 60>();
+}
+
+template <uint value>
+constexpr Guarded<value, uint> guardedValue() {
+  return Guarded<value, uint>(value, unsafe);
+}
+
+TEST(UnitMeasure, Guarded) {
+  // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
+  //   line restored to verify that they actually error out.
+
+  KJ_EXPECT((guardedValue<456>() + guardedValue<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT(guardedValue<456>().subtractChecked(guardedValue<123>(), [](){}).unwrap() == 456 - 123);
+  KJ_EXPECT((guardedValue<456>() * guardedValue<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((guardedValue<456>() / guardedValue<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((guardedValue<456>() % guardedValue<123>()).unwrap() == 456 % 123);
+
+
+  {
+    Guarded<123, uint8_t> succ KJ_UNUSED;
+    // COMPILE ERROR: Guarded<1234, uint8_t> err KJ_UNUSED;
+    // COMPILE ERROR: auto err KJ_UNUSED = guardedValue<0xffffffffull>() + guardedValue<1>();
+  }
+
+  {
+    Guarded<123, uint8_t> succ1 KJ_UNUSED = guardedValue<123>();
+    Guarded<123, uint8_t> succ2 KJ_UNUSED = guardedValue<122>();
+    Guarded<123, uint8_t> succ3 KJ_UNUSED = guardedValue<0>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<124>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<125>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guardedValue<123456>();
+  }
+
+  Guarded<123, uint8_t> foo;
+  foo = guardedValue<123>();
+  foo = guardedValue<122>();
+  foo = guardedValue<0>();
+  // COMPILE ERROR: foo = guardedValue<124>();
+  // COMPILE ERROR: foo = guardedValue<125>();
+  // COMPILE ERROR: foo = guardedValue<123456>();
+
+  assertMax<122>(foo, []() {});
+  // COMPILE ERROR: assertMax<123>(foo, []() {});
+  // COMPILE ERROR: assertMax<124>(foo, []() {});
+
+  assertMaxBits<6>(foo, []() {});
+  // COMPILE ERROR: assertMaxBits<7>(foo, []() {});
+  // COMPILE ERROR: assertMaxBits<8>(foo, []() {});
+
+  Guarded<12, uint8_t> bar;
+  // COMPILE ERROR: bar = foo;
+  // COMPILE ERROR: bar = foo.assertMax<13>([]() {});
+  bool caught = false;
+  foo = guardedValue<13>();
+  bar = foo.assertMax<12>([&]() { caught = true; });
+  KJ_EXPECT(caught);
+
+  foo = guardedValue<100>() + guardedValue<23>();
+  // COMPILE ERROR: foo = guardedValue<100>() + guardedValue<24>();
+
+  bar = guardedValue<3>() * guardedValue<4>();
+  // COMPILE ERROR: bar = guardedValue<2>() * guardedValue<7>();
+
+  foo.subtractChecked(guardedValue<122>(), []() { KJ_FAIL_EXPECT(); });
+  foo.subtractChecked(guardedValue<123>(), []() { KJ_FAIL_EXPECT(); });
+  caught = false;
+  foo.subtractChecked(guardedValue<124>(), [&]() { caught = true; });
+  KJ_EXPECT(caught);
+
+  {
+    Guarded<65535, uint16_t> succ1 KJ_UNUSED = guarded((uint16_t)123);
+    // COMPILE ERROR: Guarded<65534, uint16_t> err KJ_UNUSED = guarded((uint16_t)123);
+  }
+
+  uint old = foo.unwrap();
+  foo = foo * unit<decltype(foo)>();
+  KJ_EXPECT(foo.unwrap() == old);
+
+  {
+    Guarded<1234, uint16_t> x = guarded<123>();
+    uint16_t succ = unguard(x);
+    KJ_EXPECT(succ == 123);
+
+    // COMPILE ERROR: uint8_t err KJ_UNUSED = unguard(x);
+  }
+}
+
+TEST(UnitMeasure, GuardedVsGuardedConst) {
+  // TODO(someday): Some script should attempt to compile this test once with each "COMPILE ERROR"
+  //   line restored to verify that they actually error out.
+
+  KJ_EXPECT((guardedValue<456>() + guarded<123>()).unwrap() == 456 + 123);
+  KJ_EXPECT(guardedValue<456>().subtractChecked(guarded<123>(), [](){}).unwrap() == 456 - 123);
+  KJ_EXPECT((guardedValue<456>() * guarded<123>()).unwrap() == 456 * 123);
+  KJ_EXPECT((guardedValue<456>() / guarded<123>()).unwrap() == 456 / 123);
+  KJ_EXPECT((guardedValue<456>() % guarded<123>()).unwrap() == 456 % 123);
+
+  {
+    Guarded<123, uint8_t> succ1 KJ_UNUSED = guarded<123>();
+    Guarded<123, uint8_t> succ2 KJ_UNUSED = guarded<122>();
+    Guarded<123, uint8_t> succ3 KJ_UNUSED = guarded<0>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<124>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<125>();
+    // COMPILE ERROR: Guarded<123, uint8_t> err KJ_UNUSED = guarded<123456>();
+  }
+
+  Guarded<123, uint8_t> foo;
+  foo = guarded<123>();
+  foo = guarded<122>();
+  foo = guarded<0>();
+  // COMPILE ERROR: foo = guarded<124>();
+  // COMPILE ERROR: foo = guarded<125>();
+  // COMPILE ERROR: foo = guarded<123456>();
+
+  Guarded<16, uint8_t> bar;
+  // COMPILE ERROR: bar = foo >> guarded<2>();
+  bar = foo >> guarded<3>();
+
+  // COMPILE ERROR: foo = bar << guarded<3>();
+  foo = bar << guarded<2>();
+}
+
+TEST(UnitMeasure, GuardedRange) {
+  uint expected = 0;
+  for (auto i: zeroTo(guarded<10>())) {
+    Guarded<10, uint8_t> value = i;
+    KJ_EXPECT(unguard(value) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+
+  expected = 0;
+  for (auto i: zeroTo(guarded((uint8_t)10))) {
+    Guarded<255, uint8_t> value = i;
+    KJ_EXPECT(unguard(value) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+
+  expected = 3;
+  for (auto i: range(guarded((uint8_t)3), guarded((uint8_t)10))) {
+    Guarded<255, uint8_t> value = i;
+    KJ_EXPECT(unguard(value) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+}
+
+TEST(UnitMeasure, GuardedQuantity) {
+  auto BYTES = unit<Quantity<Guarded<12345, uint16_t>, byte>>();
+
+  uint expected = 0;
+  for (auto i: zeroTo(guarded<10>() * BYTES)) {
+    Quantity<Guarded<10, uint8_t>, byte> value = i;
+    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+
+  expected = 0;
+  for (auto i: zeroTo(guarded((uint8_t)10) * BYTES)) {
+    Quantity<Guarded<255, uint8_t>, byte> value = i;
+    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+
+  expected = 3;
+  for (auto i: range(guarded((uint8_t)3) * BYTES, guarded((uint8_t)10) * BYTES)) {
+    Quantity<Guarded<255, uint8_t>, byte> value = i;
+    KJ_EXPECT(unguard(value / BYTES) == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+}
+
 }  // namespace
 }  // namespace kj

--- a/c++/src/kj/units.c++
+++ b/c++/src/kj/units.c++
@@ -20,7 +20,12 @@
 // THE SOFTWARE.
 
 #include "units.h"
+#include "debug.h"
 
 namespace kj {
+
+void ThrowOverflow::operator()() const {
+  KJ_FAIL_REQUIRE("integer overflow");
+}
 
 }  // namespace kj

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -376,9 +376,6 @@ private:
   template <typename Number1, typename Number2, typename Unit2>
   friend inline constexpr auto operator*(Number1 a, Quantity<Number2, Unit2> b)
       -> Quantity<decltype(Number1() * Number2()), Unit2>;
-
-  template <typename T>
-  friend inline constexpr T unit();
 };
 
 template <typename T> struct Unit_ {

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -724,21 +724,6 @@ private:
 
   template <uint64_t, typename>
   friend class Bounded;
-
-  template <uint64_t aN, uint64_t bN, typename A, typename B>
-  friend constexpr Bounded<kj::min(aN, bN), WiderType<A, B>>
-  min(Bounded<aN, A> a, Bounded<bN, B> b);
-  template <uint64_t aN, uint b, typename A>
-  friend constexpr Bounded<kj::min(aN, b), A> min(Bounded<aN, A> a, BoundedConst<b>);
-  template <uint64_t aN, uint b, typename A>
-  friend constexpr Bounded<kj::min(aN, b), A> min(BoundedConst<b>, Bounded<aN, A> a);
-  template <uint64_t aN, uint64_t bN, typename A, typename B>
-  friend constexpr Bounded<kj::max(aN, bN), WiderType<A, B>>
-  max(Bounded<aN, A> a, Bounded<bN, B> b);
-  template <uint64_t aN, uint b, typename A>
-  friend constexpr Bounded<kj::max(aN, b), A> max(Bounded<aN, A> a, BoundedConst<b>);
-  template <uint64_t aN, uint b, typename A>
-  friend constexpr Bounded<kj::max(aN, b), A> max(BoundedConst<b>, Bounded<aN, A> a);
 };
 
 template <typename Number>
@@ -893,12 +878,12 @@ inline auto trySubtract(Quantity<T, Unit> value, Quantity<U, Unit> other)
 template <uint64_t aN, uint64_t bN, typename A, typename B>
 inline constexpr Bounded<kj::min(aN, bN), WiderType<A, B>>
 min(Bounded<aN, A> a, Bounded<bN, B> b) {
-  return Bounded<kj::min(aN, bN), WiderType<A, B>>(kj::min(a.value, b.value), unsafe);
+  return Bounded<kj::min(aN, bN), WiderType<A, B>>(kj::min(a.unwrap(), b.unwrap()), unsafe);
 }
 template <uint64_t aN, uint64_t bN, typename A, typename B>
 inline constexpr Bounded<kj::max(aN, bN), WiderType<A, B>>
 max(Bounded<aN, A> a, Bounded<bN, B> b) {
-  return Bounded<kj::max(aN, bN), WiderType<A, B>>(kj::max(a.value, b.value), unsafe);
+  return Bounded<kj::max(aN, bN), WiderType<A, B>>(kj::max(a.unwrap(), b.unwrap()), unsafe);
 }
 // We need to override min() and max() because:
 // 1) WiderType<> might not choose the correct bounds.
@@ -982,19 +967,19 @@ inline constexpr Bounded<cvalue, decltype(uint() - T())>
 
 template <uint64_t aN, uint b, typename A>
 inline constexpr Bounded<kj::min(aN, b), A> min(Bounded<aN, A> a, BoundedConst<b>) {
-  return Bounded<kj::min(aN, b), A>(kj::min(b, a.value), unsafe);
+  return Bounded<kj::min(aN, b), A>(kj::min(b, a.unwrap()), unsafe);
 }
 template <uint64_t aN, uint b, typename A>
 inline constexpr Bounded<kj::min(aN, b), A> min(BoundedConst<b>, Bounded<aN, A> a) {
-  return Bounded<kj::min(aN, b), A>(kj::min(a.value, b), unsafe);
+  return Bounded<kj::min(aN, b), A>(kj::min(a.unwrap(), b), unsafe);
 }
 template <uint64_t aN, uint b, typename A>
 inline constexpr Bounded<kj::max(aN, b), A> max(Bounded<aN, A> a, BoundedConst<b>) {
-  return Bounded<kj::max(aN, b), A>(kj::max(b, a.value), unsafe);
+  return Bounded<kj::max(aN, b), A>(kj::max(b, a.unwrap()), unsafe);
 }
 template <uint64_t aN, uint b, typename A>
 inline constexpr Bounded<kj::max(aN, b), A> max(BoundedConst<b>, Bounded<aN, A> a) {
-  return Bounded<kj::max(aN, b), A>(kj::max(a.value, b), unsafe);
+  return Bounded<kj::max(aN, b), A>(kj::max(a.unwrap(), b), unsafe);
 }
 // We need to override min() between a Bounded and a constant since:
 // 1) WiderType<> might choose BoundedConst over a 1-byte Bounded, which is wrong.

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -514,10 +514,6 @@ class GuardedConst {
 public:
   GuardedConst() = default;
 
-  inline constexpr GuardedConst(decltype(kj::maxValue)) {}
-  inline constexpr GuardedConst(decltype(kj::minValue)) {}
-  // These aren't directly useful but cause kj::max()/kj::min() to choose types correctly.
-
   inline constexpr uint unwrap() const { return value; }
 
 #define OP(op, check) \
@@ -608,8 +604,6 @@ public:
   static_assert(maxN <= T(kj::maxValue), "possible overflow detected");
 
   Guarded() = default;
-  inline constexpr Guarded(decltype(kj::maxValue)): value(maxN) {}
-  inline constexpr Guarded(decltype(kj::minValue)): value(0) {}
 
   Guarded(const Guarded& other) = default;
   template <typename OtherInt, typename = EnableIf<isIntegral<OtherInt>()>>

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -31,6 +31,7 @@
 #endif
 
 #include "common.h"
+#include <inttypes.h>
 
 namespace kj {
 
@@ -67,6 +68,15 @@ struct Id {
 // =======================================================================================
 // Quantity and UnitRatio -- implement unit analysis via the type system
 
+struct Unsafe_ {};
+constexpr Unsafe_ unsafe = Unsafe_();
+// Use as a parameter to constructors that are unsafe to indicate that you really do mean it.
+
+template <uint64_t maxN, typename T>
+class Guarded;
+template <uint value>
+class GuardedConst;
+
 template <typename T> constexpr bool isIntegral() { return false; }
 template <> constexpr bool isIntegral<char>() { return true; }
 template <> constexpr bool isIntegral<signed char>() { return true; }
@@ -80,6 +90,16 @@ template <> constexpr bool isIntegral<unsigned int>() { return true; }
 template <> constexpr bool isIntegral<unsigned long>() { return true; }
 template <> constexpr bool isIntegral<unsigned long long>() { return true; }
 
+template <typename T>
+struct IsIntegralOrGuarded_ { static constexpr bool value = isIntegral<T>(); };
+template <uint64_t m, typename T>
+struct IsIntegralOrGuarded_<Guarded<m, T>> { static constexpr bool value = true; };
+template <uint v>
+struct IsIntegralOrGuarded_<GuardedConst<v>> { static constexpr bool value = true; };
+
+template <typename T>
+inline constexpr bool isIntegralOrGuarded() { return IsIntegralOrGuarded_<T>::value; }
+
 template <typename Number, typename Unit1, typename Unit2>
 class UnitRatio {
   // A multiplier used to convert Quantities of one unit to Quantities of another unit.  See
@@ -88,12 +108,13 @@ class UnitRatio {
   // Construct this type by dividing one Quantity by another of a different unit.  Use this type
   // by multiplying it by a Quantity, or dividing a Quantity by it.
 
-  static_assert(isIntegral<Number>(), "Underlying type for UnitRatio must be integer.");
+  static_assert(isIntegralOrGuarded<Number>(),
+      "Underlying type for UnitRatio must be integer.");
 
 public:
   inline UnitRatio() {}
 
-  constexpr explicit UnitRatio(Number unit1PerUnit2): unit1PerUnit2(unit1PerUnit2) {}
+  constexpr UnitRatio(Number unit1PerUnit2, decltype(unsafe)): unit1PerUnit2(unit1PerUnit2) {}
   // This constructor was intended to be private, but GCC complains about it being private in a
   // bunch of places that don't appear to even call it, so I made it public.  Oh well.
 
@@ -102,50 +123,50 @@ public:
       : unit1PerUnit2(other.unit1PerUnit2) {}
 
   template <typename OtherNumber>
-  inline constexpr UnitRatio<decltype(Number(1)+OtherNumber(1)), Unit1, Unit2>
+  inline constexpr UnitRatio<decltype(Number()+OtherNumber()), Unit1, Unit2>
       operator+(UnitRatio<OtherNumber, Unit1, Unit2> other) const {
-    return UnitRatio<decltype(Number(1)+OtherNumber(1)), Unit1, Unit2>(
-        unit1PerUnit2 + other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()+OtherNumber()), Unit1, Unit2>(
+        unit1PerUnit2 + other.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber>
-  inline constexpr UnitRatio<decltype(Number(1)-OtherNumber(1)), Unit1, Unit2>
+  inline constexpr UnitRatio<decltype(Number()-OtherNumber()), Unit1, Unit2>
       operator-(UnitRatio<OtherNumber, Unit1, Unit2> other) const {
-    return UnitRatio<decltype(Number(1)-OtherNumber(1)), Unit1, Unit2>(
-        unit1PerUnit2 - other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()-OtherNumber()), Unit1, Unit2>(
+        unit1PerUnit2 - other.unit1PerUnit2, unsafe);
   }
 
   template <typename OtherNumber, typename Unit3>
-  inline constexpr UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit3, Unit2>
+  inline constexpr UnitRatio<decltype(Number()*OtherNumber()), Unit3, Unit2>
       operator*(UnitRatio<OtherNumber, Unit3, Unit1> other) const {
     // U1 / U2 * U3 / U1 = U3 / U2
-    return UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit3, Unit2>(
-        unit1PerUnit2 * other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()*OtherNumber()), Unit3, Unit2>(
+        unit1PerUnit2 * other.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber, typename Unit3>
-  inline constexpr UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit1, Unit3>
+  inline constexpr UnitRatio<decltype(Number()*OtherNumber()), Unit1, Unit3>
       operator*(UnitRatio<OtherNumber, Unit2, Unit3> other) const {
     // U1 / U2 * U2 / U3 = U1 / U3
-    return UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit1, Unit3>(
-        unit1PerUnit2 * other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()*OtherNumber()), Unit1, Unit3>(
+        unit1PerUnit2 * other.unit1PerUnit2, unsafe);
   }
 
   template <typename OtherNumber, typename Unit3>
-  inline constexpr UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit3, Unit2>
+  inline constexpr UnitRatio<decltype(Number()*OtherNumber()), Unit3, Unit2>
       operator/(UnitRatio<OtherNumber, Unit1, Unit3> other) const {
     // (U1 / U2) / (U1 / U3) = U3 / U2
-    return UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit3, Unit2>(
-        unit1PerUnit2 / other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()*OtherNumber()), Unit3, Unit2>(
+        unit1PerUnit2 / other.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber, typename Unit3>
-  inline constexpr UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit1, Unit3>
+  inline constexpr UnitRatio<decltype(Number()*OtherNumber()), Unit1, Unit3>
       operator/(UnitRatio<OtherNumber, Unit3, Unit2> other) const {
     // (U1 / U2) / (U3 / U2) = U1 / U3
-    return UnitRatio<decltype(Number(1)*OtherNumber(1)), Unit1, Unit3>(
-        unit1PerUnit2 / other.unit1PerUnit2);
+    return UnitRatio<decltype(Number()*OtherNumber()), Unit1, Unit3>(
+        unit1PerUnit2 / other.unit1PerUnit2, unsafe);
   }
 
   template <typename OtherNumber>
-  inline decltype(Number(1) / OtherNumber(1))
+  inline decltype(Number() / OtherNumber())
       operator/(UnitRatio<OtherNumber, Unit1, Unit2> other) const {
     return unit1PerUnit2 / other.unit1PerUnit2;
   }
@@ -162,14 +183,14 @@ private:
   friend class UnitRatio;
 
   template <typename N1, typename N2, typename U1, typename U2>
-  friend inline constexpr UnitRatio<decltype(N1(1) * N2(1)), U1, U2>
+  friend inline constexpr UnitRatio<decltype(N1() * N2()), U1, U2>
       operator*(N1, UnitRatio<N2, U1, U2>);
 };
 
 template <typename N1, typename N2, typename U1, typename U2>
-inline constexpr UnitRatio<decltype(N1(1) * N2(1)), U1, U2>
+inline constexpr UnitRatio<decltype(N1() * N2()), U1, U2>
     operator*(N1 n, UnitRatio<N2, U1, U2> r) {
-  return UnitRatio<decltype(N1(1) * N2(1)), U1, U2>(n * r.unit1PerUnit2);
+  return UnitRatio<decltype(N1() * N2()), U1, U2>(n * r.unit1PerUnit2, unsafe);
 }
 
 template <typename Number, typename Unit>
@@ -216,10 +237,11 @@ class Quantity {
   //     waitFor(3 * MINUTES);
   //   }
 
-  static_assert(isIntegral<Number>(), "Underlying type for Quantity must be integer.");
+  static_assert(isIntegralOrGuarded<Number>(),
+      "Underlying type for Quantity must be integer.");
 
 public:
-  inline constexpr Quantity() {}
+  inline constexpr Quantity() = default;
 
   inline constexpr Quantity(MaxValue_): value(maxValue) {}
   inline constexpr Quantity(MinValue_): value(minValue) {}
@@ -228,7 +250,7 @@ public:
   // parameters, causing the compiler to complain of a duplicate constructor definition, so we
   // specify MaxValue_ and MinValue_ types explicitly.
 
-  inline explicit constexpr Quantity(Number value): value(value) {}
+  inline constexpr Quantity(Number value, decltype(unsafe)): value(value) {}
   // This constructor was intended to be private, but GCC complains about it being private in a
   // bunch of places that don't appear to even call it, so I made it public.  Oh well.
 
@@ -237,60 +259,65 @@ public:
       : value(other.value) {}
 
   template <typename OtherNumber>
-  inline constexpr Quantity<decltype(Number(1) + OtherNumber(1)), Unit>
+  inline Quantity& operator=(const Quantity<OtherNumber, Unit>& other) {
+    value = other.value;
+    return *this;
+  }
+
+  template <typename OtherNumber>
+  inline constexpr Quantity<decltype(Number() + OtherNumber()), Unit>
       operator+(const Quantity<OtherNumber, Unit>& other) const {
-    return Quantity<decltype(Number(1) + OtherNumber(1)), Unit>(value + other.value);
+    return Quantity<decltype(Number() + OtherNumber()), Unit>(value + other.value, unsafe);
   }
   template <typename OtherNumber>
-  inline constexpr Quantity<decltype(Number(1) - OtherNumber(1)), Unit>
+  inline constexpr Quantity<decltype(Number() - OtherNumber()), Unit>
       operator-(const Quantity<OtherNumber, Unit>& other) const {
-    return Quantity<decltype(Number(1) - OtherNumber(1)), Unit>(value - other.value);
+    return Quantity<decltype(Number() - OtherNumber()), Unit>(value - other.value, unsafe);
   }
-  template <typename OtherNumber>
-  inline constexpr Quantity<decltype(Number(1) * OtherNumber(1)), Unit>
+  template <typename OtherNumber, typename = EnableIf<isIntegralOrGuarded<OtherNumber>()>>
+  inline constexpr Quantity<decltype(Number() * OtherNumber()), Unit>
       operator*(OtherNumber other) const {
-    static_assert(isIntegral<OtherNumber>(), "Multiplied Quantity by non-integer.");
-    return Quantity<decltype(Number(1) * other), Unit>(value * other);
+    return Quantity<decltype(Number() * other), Unit>(value * other, unsafe);
   }
-  template <typename OtherNumber>
-  inline constexpr Quantity<decltype(Number(1) / OtherNumber(1)), Unit>
+  template <typename OtherNumber, typename = EnableIf<isIntegralOrGuarded<OtherNumber>()>>
+  inline constexpr Quantity<decltype(Number() / OtherNumber()), Unit>
       operator/(OtherNumber other) const {
-    static_assert(isIntegral<OtherNumber>(), "Divided Quantity by non-integer.");
-    return Quantity<decltype(Number(1) / other), Unit>(value / other);
+    return Quantity<decltype(Number() / other), Unit>(value / other, unsafe);
   }
   template <typename OtherNumber>
-  inline constexpr decltype(Number(1) / OtherNumber(1))
+  inline constexpr decltype(Number() / OtherNumber())
       operator/(const Quantity<OtherNumber, Unit>& other) const {
     return value / other.value;
   }
   template <typename OtherNumber>
-  inline constexpr Quantity<decltype(Number(1) % OtherNumber(1)), Unit>
+  inline constexpr Quantity<decltype(Number() % OtherNumber()), Unit>
       operator%(const Quantity<OtherNumber, Unit>& other) const {
-    return Quantity<decltype(Number(1) % OtherNumber(1)), Unit>(value % other.value);
+    return Quantity<decltype(Number() % OtherNumber()), Unit>(value % other.value, unsafe);
   }
 
   template <typename OtherNumber, typename OtherUnit>
-  inline constexpr Quantity<decltype(Number(1) * OtherNumber(1)), OtherUnit>
+  inline constexpr Quantity<decltype(Number() * OtherNumber()), OtherUnit>
       operator*(const UnitRatio<OtherNumber, OtherUnit, Unit>& ratio) const {
-    return Quantity<decltype(Number(1) * OtherNumber(1)), OtherUnit>(
-        value * ratio.unit1PerUnit2);
+    return Quantity<decltype(Number() * OtherNumber()), OtherUnit>(
+        value * ratio.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber, typename OtherUnit>
-  inline constexpr Quantity<decltype(Number(1) / OtherNumber(1)), OtherUnit>
+  inline constexpr Quantity<decltype(Number() / OtherNumber()), OtherUnit>
       operator/(const UnitRatio<OtherNumber, Unit, OtherUnit>& ratio) const {
-    return Quantity<decltype(Number(1) / OtherNumber(1)), OtherUnit>(
-        value / ratio.unit1PerUnit2);
+    return Quantity<decltype(Number() / OtherNumber()), OtherUnit>(
+        value / ratio.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber, typename OtherUnit>
-  inline constexpr Quantity<decltype(Number(1) % OtherNumber(1)), Unit>
+  inline constexpr Quantity<decltype(Number() % OtherNumber()), Unit>
       operator%(const UnitRatio<OtherNumber, Unit, OtherUnit>& ratio) const {
-    return Quantity<decltype(Number(1) % OtherNumber(1)), Unit>(
-        value % ratio.unit1PerUnit2);
+    return Quantity<decltype(Number() % OtherNumber()), Unit>(
+        value % ratio.unit1PerUnit2, unsafe);
   }
   template <typename OtherNumber, typename OtherUnit>
-  inline constexpr UnitRatio<decltype(Number(1) / OtherNumber(1)), Unit, OtherUnit>
+  inline constexpr UnitRatio<decltype(Number() / OtherNumber()), Unit, OtherUnit>
       operator/(const Quantity<OtherNumber, OtherUnit>& other) const {
-    return UnitRatio<decltype(Number(1) / OtherNumber(1)), Unit, OtherUnit>(value / other.value);
+    return UnitRatio<decltype(Number() / OtherNumber()), Unit, OtherUnit>(
+        value / other.value, unsafe);
   }
 
   template <typename OtherNumber>
@@ -347,21 +374,31 @@ private:
 
   template <typename Number1, typename Number2, typename Unit2>
   friend inline constexpr auto operator*(Number1 a, Quantity<Number2, Unit2> b)
-      -> Quantity<decltype(Number1(1) * Number2(1)), Unit2>;
+      -> Quantity<decltype(Number1() * Number2()), Unit2>;
 
   template <typename T>
   friend inline constexpr T unit();
 };
 
+template <typename T> struct Unit_ {
+  static inline constexpr T get() { return T(1); }
+};
+template <typename T, typename U>
+struct Unit_<Quantity<T, U>> {
+  static inline constexpr Quantity<decltype(Unit_<T>::get()), U> get() {
+    return Quantity<decltype(Unit_<T>::get()), U>(Unit_<T>::get(), unsafe);
+  }
+};
+
 template <typename T>
-inline constexpr T unit() { return T(1); }
+inline constexpr auto unit() -> decltype(Unit_<T>::get()) { return Unit_<T>::get(); }
 // unit<Quantity<T, U>>() returns a Quantity of value 1.  It also, intentionally, works on basic
 // numeric types.
 
 template <typename Number1, typename Number2, typename Unit>
 inline constexpr auto operator*(Number1 a, Quantity<Number2, Unit> b)
-    -> Quantity<decltype(Number1(1) * Number2(1)), Unit> {
-  return Quantity<decltype(Number1(1) * Number2(1)), Unit>(a * b.value);
+    -> Quantity<decltype(Number1() * Number2()), Unit> {
+  return Quantity<decltype(Number1() * Number2()), Unit>(a * b.value, unsafe);
 }
 
 template <typename Number1, typename Number2, typename Unit, typename Unit2>
@@ -427,6 +464,592 @@ template <typename T>
 inline constexpr T origin() { return T(0 * unit<UnitOf<T>>()); }
 // origin<Absolute<T, U>>() returns an Absolute of value 0.  It also, intentionally, works on basic
 // numeric types.
+
+// =======================================================================================
+// Overflow avoidance
+
+template <uint64_t n, uint accum = 0>
+struct BitCount_ {
+  static constexpr uint value = BitCount_<(n >> 1), accum + 1>::value;
+};
+template <uint accum>
+struct BitCount_<0, accum> {
+  static constexpr uint value = accum;
+};
+
+template <uint64_t n>
+inline constexpr uint bitCount() { return BitCount_<n>::value; }
+// Number of bits required to represent the number `n`.
+
+template <uint bitCountBitCount> struct AtLeastUInt_ {
+  static_assert(bitCountBitCount < 7, "don't know how to represent integers over 64 bits");
+};
+template <> struct AtLeastUInt_<0> { typedef uint8_t Type; };
+template <> struct AtLeastUInt_<1> { typedef uint8_t Type; };
+template <> struct AtLeastUInt_<2> { typedef uint8_t Type; };
+template <> struct AtLeastUInt_<3> { typedef uint8_t Type; };
+template <> struct AtLeastUInt_<4> { typedef uint16_t Type; };
+template <> struct AtLeastUInt_<5> { typedef uint32_t Type; };
+template <> struct AtLeastUInt_<6> { typedef uint64_t Type; };
+
+template <uint bits>
+using AtLeastUInt = typename AtLeastUInt_<bitCount<max(bits, 1) - 1>()>::Type;
+// AtLeastUInt<n> is an unsigned integer of at least n bits. E.g. AtLeastUInt<12> is uint16_t.
+
+template <uint bits>
+inline constexpr uint64_t maxValueForBits() {
+  // Get the maximum integer representable in the given number of bits.
+
+  // 1ull << 64 is unfortunately undefined.
+  return (bits == 64 ? 0 : (1ull << bits)) - 1;
+}
+
+// -------------------------------------------------------------------
+
+template <uint value>
+class GuardedConst {
+  // A constant integer value on which we can do bit size analysis.
+
+public:
+  inline constexpr uint unwrap() const { return value; }
+
+#define OP(op, check) \
+  template <uint other> \
+  inline constexpr GuardedConst<(value op other)> \
+      operator op(GuardedConst<other>) const { \
+    static_assert(check, "overflow in GuardedConst arithmetic"); \
+    return GuardedConst<(value op other)>(); \
+  }
+#define COMPARE_OP(op) \
+  template <uint other> \
+  inline constexpr bool operator op(GuardedConst<other>) const { \
+    return value op other; \
+  }
+
+  OP(+, value + other >= value)
+  OP(-, value - other <= value)
+  OP(*, value * other / other == value)
+  OP(/, true)   // div by zero already errors out; no other division ever overflows
+  OP(%, true)   // mod by zero already errors out; no other modulus ever overflows
+  OP(<<, value << other >= value)
+  OP(>>, true)  // right shift can't overflow
+  OP(&, true)   // bitwise ops can't overflow
+  OP(|, true)   // bitwise ops can't overflow
+
+  COMPARE_OP(==)
+  COMPARE_OP(!=)
+  COMPARE_OP(< )
+  COMPARE_OP(> )
+  COMPARE_OP(<=)
+  COMPARE_OP(>=)
+#undef OP
+#undef COMPARE_OP
+};
+
+template <uint64_t m, typename T>
+struct Unit_<Guarded<m, T>> {
+  static inline constexpr GuardedConst<1> get() { return GuardedConst<1>(); }
+};
+
+template <uint value>
+struct Unit_<GuardedConst<value>> {
+  static inline constexpr GuardedConst<1> get() { return GuardedConst<1>(); }
+};
+
+template <uint value>
+inline constexpr GuardedConst<value> guarded() {
+  return GuardedConst<value>();
+}
+
+template <uint64_t a, uint64_t b>
+static constexpr uint64_t guardedAdd() {
+  static_assert(a + b >= a, "possible overflow detected");
+  return a + b;
+}
+template <uint64_t a, uint64_t b>
+static constexpr uint64_t guardedSub() {
+  static_assert(a - b <= a, "possible underflow detected");
+  return a - b;
+}
+template <uint64_t a, uint64_t b>
+static constexpr uint64_t guardedMul() {
+  static_assert(a * b / b == a, "possible overflow detected");
+  return a * b;
+}
+template <uint64_t a, uint64_t b>
+static constexpr uint64_t guardedLShift() {
+  static_assert(a << b >= a, "possible overflow detected");
+  return a << b;
+}
+
+// -------------------------------------------------------------------
+
+template <uint64_t maxN, typename T>
+class Guarded {
+public:
+  static_assert(maxN <= T(kj::maxValue), "possible overflow detected");
+
+  Guarded() = default;
+  inline constexpr Guarded(decltype(kj::maxValue)): value(maxN) {}
+  inline constexpr Guarded(decltype(kj::minValue)): value(0) {}
+
+  Guarded(const Guarded& other) = default;
+  template <typename OtherInt, typename = EnableIf<isIntegral<OtherInt>()>>
+  inline constexpr Guarded(OtherInt value): value(value) {
+    static_assert(OtherInt(maxValue) <= maxN, "possible overflow detected");
+  }
+  template <uint64_t otherMax, typename OtherT>
+  inline constexpr Guarded(const Guarded<otherMax, OtherT>& other)
+      : value(other.value) {
+    static_assert(otherMax <= maxN, "possible overflow detected");
+  }
+  template <uint otherValue>
+  inline constexpr Guarded(GuardedConst<otherValue>)
+      : value(otherValue) {
+    static_assert(otherValue <= maxN, "overflow detected");
+  }
+
+  Guarded& operator=(const Guarded& other) = default;
+  template <typename OtherInt, typename = EnableIf<isIntegral<OtherInt>()>>
+  Guarded& operator=(OtherInt other) {
+    static_assert(OtherInt(maxValue) <= maxN, "possible overflow detected");
+    value = other;
+    return *this;
+  }
+  template <uint64_t otherMax, typename OtherT>
+  inline Guarded& operator=(const Guarded<otherMax, OtherT>& other) {
+    static_assert(otherMax <= maxN, "possible overflow detected");
+    value = other.value;
+    return *this;
+  }
+  template <uint otherValue>
+  inline Guarded& operator=(GuardedConst<otherValue>) {
+    static_assert(otherValue <= maxN, "overflow detected");
+    value = otherValue;
+    return *this;
+  }
+
+  inline constexpr T unwrap() const { return value; }
+
+#define OP(op, newMax) \
+  template <uint64_t otherMax, typename otherT> \
+  inline constexpr Guarded<newMax, decltype(T() op otherT())> \
+      operator op(const Guarded<otherMax, otherT>& other) const { \
+    return Guarded<newMax, decltype(T() op otherT())>(value op other.value, unsafe); \
+  }
+#define COMPARE_OP(op) \
+  template <uint64_t otherMax, typename OtherT> \
+  inline constexpr bool operator op(const Guarded<otherMax, OtherT>& other) const { \
+    return value op other.value; \
+  }
+
+  OP(+, (guardedAdd<maxN, otherMax>()))
+  OP(*, (guardedMul<maxN, otherMax>()))
+  OP(/, maxN)
+  OP(%, otherMax - 1)
+
+  // operator- is intentionally omitted because we mostly use this with unsigned types, and
+  // subtraction requires proof that subtrahend is not greater than the minuend.
+
+  COMPARE_OP(==)
+  COMPARE_OP(!=)
+  COMPARE_OP(< )
+  COMPARE_OP(> )
+  COMPARE_OP(<=)
+  COMPARE_OP(>=)
+
+#undef OP
+#undef COMPARE_OP
+
+  template <uint64_t newMax, typename ErrorFunc>
+  inline Guarded<newMax, T> assertMax(ErrorFunc&& func) const {
+    // Assert that the number is no more than `newMax`. Otherwise, call `func`.
+    static_assert(newMax < maxN, "this guarded size assertion is redundant");
+    if (KJ_UNLIKELY(value > newMax)) func();
+    return Guarded<newMax, T>(value, unsafe);
+  }
+
+  template <uint64_t otherMax, typename OtherT, typename ErrorFunc>
+  inline Guarded<maxN, decltype(T() - OtherT())> subtractChecked(
+      const Guarded<otherMax, OtherT>& other, ErrorFunc&& func) const {
+    // Subtract a number, calling func() if the result would underflow.
+    if (KJ_UNLIKELY(value < other.value)) func();
+    return Guarded<maxN, decltype(T() - OtherT())>(value - other.value, unsafe);
+  }
+
+  template <uint otherValue, typename ErrorFunc>
+  inline Guarded<maxN - otherValue, T> subtractChecked(
+      GuardedConst<otherValue>, ErrorFunc&& func) const {
+    // Subtract a number, calling func() if the result would underflow.
+    static_assert(otherValue <= maxN, "underflow detected");
+    if (KJ_UNLIKELY(value < otherValue)) func();
+    return Guarded<maxN - otherValue, T>(value - otherValue, unsafe);
+  }
+
+  inline constexpr Guarded(T value, decltype(unsafe)): value(value) {}
+  template <uint64_t otherMax, typename OtherT>
+  inline constexpr Guarded(Guarded<otherMax, OtherT> value, decltype(unsafe))
+      : value(value.value) {}
+  // Mainly for internal use.
+  //
+  // Only use these as a last resort, with ample commentary on why you think it's safe.
+
+private:
+  T value;
+
+  template <uint64_t, typename>
+  friend class Guarded;
+};
+
+template <typename Number>
+inline constexpr Guarded<Number(kj::maxValue), Number> guarded(Number value) {
+  return Guarded<Number(kj::maxValue), Number>(value, unsafe);
+}
+
+inline constexpr Guarded<1, uint8_t> guarded(bool value) {
+  return Guarded<1, uint8_t>(value, unsafe);
+}
+
+template <uint bits, typename Number>
+inline constexpr Guarded<maxValueForBits<bits>(), Number> assumeBits(Number value) {
+  return Guarded<maxValueForBits<bits>(), Number>(value, unsafe);
+}
+
+template <uint bits, uint64_t maxN, typename T>
+inline constexpr Guarded<maxValueForBits<bits>(), T> assumeBits(Guarded<maxN, T> value) {
+  return Guarded<maxValueForBits<bits>(), T>(value, unsafe);
+}
+
+template <uint bits, typename Number, typename Unit>
+inline constexpr auto assumeBits(Quantity<Number, Unit> value)
+    -> Quantity<decltype(assumeBits<bits>(value / unit<Quantity<Number, Unit>>())), Unit> {
+  return Quantity<decltype(assumeBits<bits>(value / unit<Quantity<Number, Unit>>())), Unit>(
+      assumeBits<bits>(value / unit<Quantity<Number, Unit>>()), unsafe);
+}
+
+struct ThrowOverflow {
+  void operator()() const;
+};
+
+template <uint64_t newMax, uint64_t maxN, typename T, typename ErrorFunc>
+inline constexpr Guarded<newMax, T> assertMax(Guarded<maxN, T> value, ErrorFunc&& errorFunc) {
+  // Assert that the guarded value is less than or equal to the given maximum, calling errorFunc()
+  // if not.
+  static_assert(newMax < maxN, "this guarded size assertion is redundant");
+  return value.template assertMax<newMax>(kj::fwd<ErrorFunc>(errorFunc));
+}
+
+template <uint64_t newMax, uint64_t maxN, typename T, typename Unit, typename ErrorFunc>
+inline constexpr Quantity<Guarded<newMax, T>, Unit> assertMax(
+    Quantity<Guarded<maxN, T>, Unit> value, ErrorFunc&& errorFunc) {
+  // Assert that the guarded value is less than or equal to the given maximum, calling errorFunc()
+  // if not.
+  static_assert(newMax < maxN, "this guarded size assertion is redundant");
+  return (value / unit<decltype(value)>()).template assertMax<newMax>(
+      kj::fwd<ErrorFunc>(errorFunc)) * unit<decltype(value)>();
+}
+
+template <uint64_t newBits, uint64_t maxN, typename T, typename ErrorFunc = ThrowOverflow>
+inline constexpr Guarded<maxValueForBits<newBits>(), T> assertMaxBits(
+    Guarded<maxN, T> value, ErrorFunc&& errorFunc = ErrorFunc()) {
+  // Assert that the guarded value requires no more than the given number of bits, calling
+  // errorFunc() if not.
+  return assertMax<maxValueForBits<newBits>()>(value, kj::fwd<ErrorFunc>(errorFunc));
+}
+
+template <uint64_t newBits, uint64_t maxN, typename T, typename Unit,
+          typename ErrorFunc = ThrowOverflow>
+inline constexpr Quantity<Guarded<maxValueForBits<newBits>(), T>, Unit> assertMaxBits(
+    Quantity<Guarded<maxN, T>, Unit> value, ErrorFunc&& errorFunc = ErrorFunc()) {
+  // Assert that the guarded value requires no more than the given number of bits, calling
+  // errorFunc() if not.
+  return assertMax<maxValueForBits<newBits>()>(value, kj::fwd<ErrorFunc>(errorFunc));
+}
+
+template <typename newT, uint64_t maxN, typename T>
+inline constexpr Guarded<maxN, newT> upgradeGuard(Guarded<maxN, T> value) {
+  return value;
+}
+
+template <typename newT, uint64_t maxN, typename T, typename Unit>
+inline constexpr Quantity<Guarded<maxN, newT>, Unit> upgradeGuard(
+    Quantity<Guarded<maxN, T>, Unit> value) {
+  return value;
+}
+
+template <uint64_t maxN, typename T, typename Other, typename ErrorFunc>
+inline auto subtractChecked(Guarded<maxN, T> value, Other other, ErrorFunc&& errorFunc)
+    -> decltype(value.subtractChecked(other, kj::fwd<ErrorFunc>(errorFunc))) {
+  return value.subtractChecked(other, kj::fwd<ErrorFunc>(errorFunc));
+}
+
+template <typename T, typename U, typename Unit, typename ErrorFunc>
+inline auto subtractChecked(Quantity<T, Unit> value, Quantity<U, Unit> other, ErrorFunc&& errorFunc)
+    -> Quantity<decltype(subtractChecked(T(), U(), kj::fwd<ErrorFunc>(errorFunc))), Unit> {
+  return subtractChecked(value / unit<Quantity<T, Unit>>(),
+                         other / unit<Quantity<U, Unit>>(),
+                         kj::fwd<ErrorFunc>(errorFunc))
+      * unit<Quantity<T, Unit>>();
+}
+
+// -------------------------------------------------------------------
+// Operators between Guarded and GuardedConst
+
+#define OP(op, newMax) \
+template <uint64_t maxN, uint cvalue, typename T> \
+inline constexpr Guarded<(newMax), decltype(T() op uint())> operator op( \
+    Guarded<maxN, T> value, GuardedConst<cvalue>) { \
+  return Guarded<(newMax), decltype(T() op uint())>(value.unwrap() op cvalue, unsafe); \
+}
+
+#define REVERSE_OP(op, newMax) \
+template <uint64_t maxN, uint cvalue, typename T> \
+inline constexpr Guarded<(newMax), decltype(uint() op T())> operator op( \
+    GuardedConst<cvalue>, Guarded<maxN, T> value) { \
+  return Guarded<(newMax), decltype(uint() op T())>(cvalue op value.unwrap(), unsafe); \
+}
+
+#define COMPARE_OP(op) \
+template <uint64_t maxN, uint cvalue, typename T> \
+inline constexpr bool operator op(Guarded<maxN, T> value, GuardedConst<cvalue>) { \
+  return value.unwrap() op cvalue; \
+} \
+template <uint64_t maxN, uint cvalue, typename T> \
+inline constexpr bool operator op(GuardedConst<cvalue>, Guarded<maxN, T> value) { \
+  return cvalue op value.unwrap(); \
+}
+
+OP(+, (guardedAdd<maxN, cvalue>()))
+REVERSE_OP(+, (guardedAdd<maxN, cvalue>()))
+
+OP(*, (guardedMul<maxN, cvalue>()))
+REVERSE_OP(*, (guardedAdd<maxN, cvalue>()))
+
+OP(/, maxN / cvalue)
+REVERSE_OP(/, cvalue)  // denominator could be 1
+
+OP(%, cvalue - 1)
+REVERSE_OP(%, maxN - 1)
+
+OP(<<, (guardedLShift<maxN, cvalue>()))
+REVERSE_OP(<<, (guardedLShift<cvalue, maxN>()))
+
+OP(>>, maxN >> cvalue)
+REVERSE_OP(>>, cvalue >> maxN)
+
+OP(&, maxValueForBits<bitCount<maxN>()>() & cvalue)
+REVERSE_OP(&, maxValueForBits<bitCount<maxN>()>() & cvalue)
+
+OP(|, maxN | cvalue)
+REVERSE_OP(|, maxN | cvalue)
+
+COMPARE_OP(==)
+COMPARE_OP(!=)
+COMPARE_OP(< )
+COMPARE_OP(> )
+COMPARE_OP(<=)
+COMPARE_OP(>=)
+
+#undef OP
+#undef REVERSE_OP
+#undef COMPARE_OP
+
+template <uint64_t maxN, uint cvalue, typename T>
+inline constexpr Guarded<cvalue, decltype(uint() - T())>
+    operator-(GuardedConst<cvalue>, Guarded<maxN, T> value) {
+  // We allow subtraction of a variable from a constant only if the constant is greater than or
+  // equal to the maximum possible value of the variable. Since the variable could be zero, the
+  // result can be as large as the constant.
+  //
+  // We do not allow subtraction of a constant from a variable because there's never a guarantee it
+  // won't underflow (unless the constant is zero, which is silly).
+  static_assert(cvalue >= maxN, "possible underflow detected");
+  return Guarded<cvalue, decltype(uint() - T())>(cvalue - value.unwrap(), unsafe);
+}
+
+// -------------------------------------------------------------------
+
+template <uint64_t maxN, typename T>
+class SafeUnwrapper {
+public:
+  inline explicit constexpr SafeUnwrapper(Guarded<maxN, T> value): value(value.unwrap()) {}
+
+  template <typename U, typename = EnableIf<isIntegral<U>()>>
+  inline constexpr operator U() {
+    static_assert(maxN <= U(maxValue), "possible truncation detected");
+    return value;
+  }
+
+  inline constexpr operator bool() {
+    static_assert(maxN <= 1, "possible truncation detected");
+    return value;
+  }
+
+private:
+  T value;
+};
+
+template <uint64_t maxN, typename T>
+inline constexpr SafeUnwrapper<maxN, T> unguard(Guarded<maxN, T> guarded) {
+  // Unwraps the guarded value, returning a value that can be implicitly cast to any integer type.
+  // If this implicit cast could truncate, a compile-time error will be raised.
+  return SafeUnwrapper<maxN, T>(guarded);
+}
+
+template <uint64_t value>
+class SafeConstUnwrapper {
+public:
+  template <typename T, typename = EnableIf<isIntegral<T>()>>
+  inline constexpr operator T() {
+    static_assert(value <= T(maxValue), "this operation will truncate");
+    return value;
+  }
+
+  inline constexpr operator bool() {
+    static_assert(value <= 1, "this operation will truncate");
+    return value;
+  }
+};
+
+template <uint value>
+inline constexpr SafeConstUnwrapper<value> unguard(GuardedConst<value>) {
+  return SafeConstUnwrapper<value>();
+}
+
+template <typename T, typename U>
+inline constexpr T unguardAs(U value) {
+  return unguard(value);
+}
+
+template <uint64_t requestedMax, uint64_t maxN, typename T>
+inline constexpr T unguardMax(Guarded<maxN, T> value) {
+  // Explicitly ungaurd expecting a value that is at most `maxN`.
+  static_assert(maxN <= requestedMax, "possible overflow detected");
+  return value.unwrap();
+}
+
+template <uint64_t requestedMax, uint value>
+inline constexpr uint unguardMax(GuardedConst<value>) {
+  // Explicitly ungaurd expecting a value that is at most `maxN`.
+  static_assert(value <= requestedMax, "overflow detected");
+  return value;
+}
+
+template <uint bits, typename T>
+inline constexpr auto unguardMaxBits(T value) ->
+    decltype(unguardMax<maxValueForBits<bits>()>(value)) {
+  // Explicitly ungaurd expecting a value that fits into `bits` bits.
+  return unguardMax<maxValueForBits<bits>()>(value);
+}
+
+#define OP(op) \
+template <uint64_t maxN, typename T, typename U> \
+inline constexpr auto operator op(T a, SafeUnwrapper<maxN, U> b) -> decltype(a op (T)b) { \
+  return a op (AtLeastUInt<sizeof(T)*8>)b; \
+} \
+template <uint64_t maxN, typename T, typename U> \
+inline constexpr auto operator op(SafeUnwrapper<maxN, U> b, T a) -> decltype((T)b op a) { \
+  return (AtLeastUInt<sizeof(T)*8>)b op a; \
+} \
+template <uint64_t value, typename T> \
+inline constexpr auto operator op(T a, SafeConstUnwrapper<value> b) -> decltype(a op (T)b) { \
+  return a op (AtLeastUInt<sizeof(T)*8>)b; \
+} \
+template <uint64_t value, typename T> \
+inline constexpr auto operator op(SafeConstUnwrapper<value> b, T a) -> decltype((T)b op a) { \
+  return (AtLeastUInt<sizeof(T)*8>)b op a; \
+}
+
+OP(+)
+OP(-)
+OP(*)
+OP(/)
+OP(%)
+OP(<<)
+OP(>>)
+OP(&)
+OP(|)
+OP(==)
+OP(!=)
+OP(<=)
+OP(>=)
+OP(<)
+OP(>)
+
+#undef OP
+
+// -------------------------------------------------------------------
+
+template <uint64_t maxN, typename T>
+class Range<Guarded<maxN, T>> {
+public:
+  inline constexpr Range(Guarded<maxN, T> begin, Guarded<maxN, T> end)
+      : inner(unguard(begin), unguard(end)) {}
+  inline explicit constexpr Range(Guarded<maxN, T> end)
+      : inner(unguard(end)) {}
+
+  class Iterator {
+  public:
+    Iterator() = default;
+    inline explicit Iterator(typename Range<T>::Iterator inner): inner(inner) {}
+
+    inline Guarded<maxN, T> operator* () const { return Guarded<maxN, T>(*inner, unsafe); }
+    inline Iterator& operator++() { ++inner; return *this; }
+
+    inline bool operator==(const Iterator& other) const { return inner == other.inner; }
+    inline bool operator!=(const Iterator& other) const { return inner != other.inner; }
+
+  private:
+    typename Range<T>::Iterator inner;
+  };
+
+  inline Iterator begin() const { return Iterator(inner.begin()); }
+  inline Iterator end() const { return Iterator(inner.end()); }
+
+private:
+  Range<T> inner;
+};
+
+template <typename T, typename U>
+class Range<Quantity<T, U>> {
+public:
+  inline constexpr Range(Quantity<T, U> begin, Quantity<T, U> end)
+      : inner(begin / unit<Quantity<T, U>>(), end / unit<Quantity<T, U>>()) {}
+  inline explicit constexpr Range(Quantity<T, U> end)
+      : inner(end / unit<Quantity<T, U>>()) {}
+
+  class Iterator {
+  public:
+    Iterator() = default;
+    inline explicit Iterator(typename Range<T>::Iterator inner): inner(inner) {}
+
+    inline Quantity<T, U> operator* () const { return *inner * unit<Quantity<T, U>>(); }
+    inline Iterator& operator++() { ++inner; return *this; }
+
+    inline bool operator==(const Iterator& other) const { return inner == other.inner; }
+    inline bool operator!=(const Iterator& other) const { return inner != other.inner; }
+
+  private:
+    typename Range<T>::Iterator inner;
+  };
+
+  inline Iterator begin() const { return Iterator(inner.begin()); }
+  inline Iterator end() const { return Iterator(inner.end()); }
+
+private:
+  Range<T> inner;
+};
+
+template <uint value>
+inline constexpr Range<Guarded<value, uint>> zeroTo(GuardedConst<value> end) {
+  return Range<Guarded<value, uint>>(end);
+}
+
+template <uint value, typename Unit>
+inline constexpr Range<Quantity<Guarded<value, uint>, Unit>>
+    zeroTo(Quantity<GuardedConst<value>, Unit> end) {
+  return Range<Quantity<Guarded<value, uint>, Unit>>(end);
+}
 
 }  // namespace kj
 

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -497,14 +497,6 @@ template <uint bits>
 using AtLeastUInt = typename AtLeastUInt_<bitCount<max(bits, 1) - 1>()>::Type;
 // AtLeastUInt<n> is an unsigned integer of at least n bits. E.g. AtLeastUInt<12> is uint16_t.
 
-template <uint bits>
-inline constexpr uint64_t maxValueForBits() {
-  // Get the maximum integer representable in the given number of bits.
-
-  // 1ull << 64 is unfortunately undefined.
-  return (bits == 64 ? 0 : (1ull << bits)) - 1;
-}
-
 // -------------------------------------------------------------------
 
 template <uint value>
@@ -807,10 +799,6 @@ inline constexpr auto assumeMax(Quantity<BoundedConst<maxN>, Unit>, Quantity<Num
     -> decltype(assumeMax<maxN>(value)) {
   return assumeMax<maxN>(value);
 }
-
-struct ThrowOverflow {
-  void operator()() const;
-};
 
 template <uint64_t newMax, uint64_t maxN, typename T, typename ErrorFunc>
 inline constexpr Bounded<newMax, T> assertMax(Bounded<maxN, T> value, ErrorFunc&& errorFunc) {

--- a/c++/src/kj/units.h
+++ b/c++/src/kj/units.h
@@ -786,7 +786,7 @@ inline constexpr auto assumeMax(Quantity<BoundedConst<maxN>, Unit>, Quantity<Num
 }
 
 template <uint64_t newMax, uint64_t maxN, typename T, typename ErrorFunc>
-inline constexpr Bounded<newMax, T> assertMax(Bounded<maxN, T> value, ErrorFunc&& errorFunc) {
+inline Bounded<newMax, T> assertMax(Bounded<maxN, T> value, ErrorFunc&& errorFunc) {
   // Assert that the bounded value is less than or equal to the given maximum, calling errorFunc()
   // if not.
   static_assert(newMax < maxN, "this bounded size assertion is redundant");
@@ -794,7 +794,7 @@ inline constexpr Bounded<newMax, T> assertMax(Bounded<maxN, T> value, ErrorFunc&
 }
 
 template <uint64_t newMax, uint64_t maxN, typename T, typename Unit, typename ErrorFunc>
-inline constexpr Quantity<Bounded<newMax, T>, Unit> assertMax(
+inline Quantity<Bounded<newMax, T>, Unit> assertMax(
     Quantity<Bounded<maxN, T>, Unit> value, ErrorFunc&& errorFunc) {
   // Assert that the bounded value is less than or equal to the given maximum, calling errorFunc()
   // if not.
@@ -804,20 +804,20 @@ inline constexpr Quantity<Bounded<newMax, T>, Unit> assertMax(
 }
 
 template <uint newMax, uint64_t maxN, typename T, typename ErrorFunc>
-inline constexpr Bounded<newMax, T> assertMax(
+inline Bounded<newMax, T> assertMax(
     BoundedConst<newMax>, Bounded<maxN, T> value, ErrorFunc&& errorFunc) {
   return assertMax<newMax>(value, kj::mv(errorFunc));
 }
 
 template <uint newMax, uint64_t maxN, typename T, typename Unit, typename ErrorFunc>
-inline constexpr Quantity<Bounded<newMax, T>, Unit> assertMax(
+inline Quantity<Bounded<newMax, T>, Unit> assertMax(
     Quantity<BoundedConst<newMax>, Unit>,
     Quantity<Bounded<maxN, T>, Unit> value, ErrorFunc&& errorFunc) {
   return assertMax<newMax>(value, kj::mv(errorFunc));
 }
 
 template <uint64_t newBits, uint64_t maxN, typename T, typename ErrorFunc = ThrowOverflow>
-inline constexpr Bounded<maxValueForBits<newBits>(), T> assertMaxBits(
+inline Bounded<maxValueForBits<newBits>(), T> assertMaxBits(
     Bounded<maxN, T> value, ErrorFunc&& errorFunc = ErrorFunc()) {
   // Assert that the bounded value requires no more than the given number of bits, calling
   // errorFunc() if not.
@@ -826,7 +826,7 @@ inline constexpr Bounded<maxValueForBits<newBits>(), T> assertMaxBits(
 
 template <uint64_t newBits, uint64_t maxN, typename T, typename Unit,
           typename ErrorFunc = ThrowOverflow>
-inline constexpr Quantity<Bounded<maxValueForBits<newBits>(), T>, Unit> assertMaxBits(
+inline Quantity<Bounded<maxValueForBits<newBits>(), T>, Unit> assertMaxBits(
     Quantity<Bounded<maxN, T>, Unit> value, ErrorFunc&& errorFunc = ErrorFunc()) {
   // Assert that the bounded value requires no more than the given number of bits, calling
   // errorFunc() if not.
@@ -994,12 +994,12 @@ public:
   inline explicit constexpr SafeUnwrapper(Bounded<maxN, T> value): value(value.unwrap()) {}
 
   template <typename U, typename = EnableIf<isIntegral<U>()>>
-  inline constexpr operator U() {
+  inline constexpr operator U() const {
     static_assert(maxN <= U(maxValue), "possible truncation detected");
     return value;
   }
 
-  inline constexpr operator bool() {
+  inline constexpr operator bool() const {
     static_assert(maxN <= 1, "possible truncation detected");
     return value;
   }
@@ -1019,12 +1019,12 @@ template <uint64_t value>
 class SafeConstUnwrapper {
 public:
   template <typename T, typename = EnableIf<isIntegral<T>()>>
-  inline constexpr operator T() {
+  inline constexpr operator T() const {
     static_assert(value <= T(maxValue), "this operation will truncate");
     return value;
   }
 
-  inline constexpr operator bool() {
+  inline constexpr operator bool() const {
     static_assert(value <= 1, "this operation will truncate");
     return value;
   }


### PR DESCRIPTION
Way back in this blog post, I described how I used template metaprogramming to detect integer overflows in Cap'n Proto:

https://capnproto.org/news/2015-03-02-security-advisory-and-integer-overflow-protection.html

Unfortunately, at the time I only got that code up to the point of being able to compile layout.c++ without errors. I didn't ever get it _running_, much less did I merge it. And over the years, it of course got out-of-date.

This PR updates the code to the current master and actually runs, with all tests passing.

I ran all the benchmarks and determined that if there is any performance impact, it is within the noise.

Code size has increased by 5%-ish. Remarkably, though, there is little difference between CAPNP_DEBUG_TYPES vs. not, so this increase seems to be coming from some structural changes rather than from any failure to elide the extra checks.