### PR TITLE
MallocMessageBuilder: don't allocate segments above the max serializable size

### DIFF
--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -242,6 +242,8 @@ MallocMessageBuilder::~MallocMessageBuilder() noexcept(false) {
 }
 
 kj::ArrayPtr<word> MallocMessageBuilder::allocateSegment(uint minimumSize) {
+  KJ_REQUIRE(minimumSize <= MAX_SEGMENT_WORDS, "MallocMessageBuilder asked to allocate segment above maximum serializable size.");
+
   if (!returnedFirstSegment && !ownFirstSegment) {
     kj::ArrayPtr<word> result = kj::arrayPtr(reinterpret_cast<word*>(firstSegment), nextSize);
     if (result.size() >= minimumSize) {
@@ -254,7 +256,7 @@ kj::ArrayPtr<word> MallocMessageBuilder::allocateSegment(uint minimumSize) {
     ownFirstSegment = true;
   }
 
-  uint size = kj::max(minimumSize, nextSize);
+  uint size = kj::max(minimumSize, kj::min(MAX_SEGMENT_WORDS, nextSize));
 
   void* result = calloc(size, sizeof(word));
   if (result == nullptr) {

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -243,6 +243,7 @@ MallocMessageBuilder::~MallocMessageBuilder() noexcept(false) {
 
 kj::ArrayPtr<word> MallocMessageBuilder::allocateSegment(uint minimumSize) {
   KJ_REQUIRE(minimumSize <= MAX_SEGMENT_WORDS, "MallocMessageBuilder asked to allocate segment above maximum serializable size.");
+  KJ_ASSERT(nextSize <= MAX_SEGMENT_WORDS, "MallocMessageBuilder nextSize out of bounds.");
 
   if (!returnedFirstSegment && !ownFirstSegment) {
     kj::ArrayPtr<word> result = kj::arrayPtr(reinterpret_cast<word*>(firstSegment), nextSize);
@@ -256,7 +257,7 @@ kj::ArrayPtr<word> MallocMessageBuilder::allocateSegment(uint minimumSize) {
     ownFirstSegment = true;
   }
 
-  uint size = kj::max(minimumSize, kj::min(MAX_SEGMENT_WORDS, nextSize));
+  uint size = kj::max(minimumSize, nextSize);
 
   void* result = calloc(size, sizeof(word));
   if (result == nullptr) {
@@ -279,7 +280,11 @@ kj::ArrayPtr<word> MallocMessageBuilder::allocateSegment(uint minimumSize) {
       moreSegments = mv(newSegments);
     }
     segments->segments.push_back(result);
-    if (allocationStrategy == AllocationStrategy::GROW_HEURISTICALLY) nextSize += size;
+    if (allocationStrategy == AllocationStrategy::GROW_HEURISTICALLY) {
+      // set nextSize = min(nextSize+size, MAX_SEGMENT_WORDS)
+      // while protecting against possible overflow of (nextSize+size)
+      nextSize = (size <= MAX_SEGMENT_WORDS-nextSize) ? nextSize+size : MAX_SEGMENT_WORDS;
+    }
   }
 
   return kj::arrayPtr(reinterpret_cast<word*>(result), size);


### PR DESCRIPTION
MallocMessageBuilder::allocateSegment increases the segment size on each sequential invocation, irrespective of the size actually requested by the caller. After enough invocations, it allocates more than MAX_SEGMENT_WORDS even if the caller didn't request so much. Then BuilderArena rejects the returned segment (verifySegmentSize) leading to breakage.

This would only affect multi-gigabyte messages where we also (foolishly) raise the traversal limit to accommodate. By capping excess segment allocation to MAX_SEGMENT_WORDS, @orodeh and I buy ourselves more headroom before we have to fix our application to not depend on such huge messages. (cc @ekg who had a related question on #245)

Thank you for this awesome tool!