### PR TITLE
Fix autotools build on MacOS

### DIFF
--- a/c++/Makefile.am
+++ b/c++/Makefile.am
@@ -244,7 +244,7 @@ libkj_async_la_SOURCES=                                        \
   src/kj/async-io-win32.c++                                    \
   src/kj/time.c++
 
-libkj_http_la_LIBADD = libkj.la $(ASYNC_LIBS) $(PTHREAD_LIBS)
+libkj_http_la_LIBADD = libkj-async.la libkj.la $(ASYNC_LIBS) $(PTHREAD_LIBS)
 libkj_http_la_LDFLAGS = -release $(SO_VERSION) -no-undefined
 libkj_http_la_SOURCES=                                         \
   src/kj/compat/http.c++

--- a/c++/src/kj/compat/http.c++
+++ b/c++/src/kj/compat/http.c++
@@ -23,6 +23,7 @@
 #include <kj/debug.h>
 #include <kj/parse/char.h>
 #include <unordered_map>
+#include <stdlib.h>
 
 namespace kj {
 
@@ -1458,7 +1459,7 @@ public:
       inner.writeBodyData(kj::str(*length, "\r\n"));
       auto lengthValue = *length;
       return inner.pumpBodyFrom(input, *length)
-          .then([this,lengthValue](size_t actual) {
+          .then([this,lengthValue](uint64_t actual) {
         if (actual < lengthValue) {
           inner.abortBody();
           KJ_FAIL_REQUIRE(


### PR DESCRIPTION
After https://github.com/sandstorm-io/capnproto/commit/df2c7ec2e17b01c79dff2dc213fe77b367f77a10, the build fails for me on MacOS 10.12.4.

```
$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/c++/4.2.1
Apple LLVM version 8.1.0 (clang-802.0.41)
Target: x86_64-apple-darwin16.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

These changes get things working again.