### PR TITLE
canonicalization: make sure that pad bits of primitive lists are zeroed

### DIFF
--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1818,7 +1818,7 @@ struct WireHelpers {
           (upgradeBound<uint64_t>(value.elementCount) * value.step) % (BYTES * BITS_PER_BYTE);
         if (leftoverBits > ZERO * BITS) {
           // We need to copy a partial byte.
-          uint8_t mask = (1 << leftoverBits / BITS) - 1;
+          uint8_t mask = (1 << unboundAs<uint8_t>(leftoverBits / BITS)) - 1;
           *((reinterpret_cast<byte*>(ptr)) + wholeByteSize) = mask & *(value.ptr + wholeByteSize);
         }
       }
@@ -3165,7 +3165,7 @@ bool ListReader::isCanonical(const word **readHead, const WirePointer *ref) {
 
       auto leftoverBits = bitSize % (BYTES * BITS_PER_BYTE);
       if (leftoverBits > ZERO * BITS) {
-        auto mask = ~((1 << (leftoverBits / BITS)) - 1);
+        auto mask = ~((1 << unboundAs<uint8_t>(leftoverBits / BITS)) - 1);
 
         if (mask & *byteReadHead) {
           return false;

--- a/c++/src/capnp/layout.c++
+++ b/c++/src/capnp/layout.c++
@@ -1812,7 +1812,10 @@ struct WireHelpers {
         // List of data.
         ref->listRef.set(value.elementSize, value.elementCount);
 
-        auto wholeByteSize = upgradeBound<uint64_t>(value.elementCount) * value.step / BITS_PER_BYTE;
+        auto wholeByteSize =
+          assertMax<kj::maxValueForBits<SEGMENT_WORD_COUNT_BITS + 3>() - 1>(
+            upgradeBound<uint64_t>(value.elementCount) * value.step / BITS_PER_BYTE,
+            []() { KJ_FAIL_ASSERT("encountered impossibly long data ListReader"); });
         copyMemory(reinterpret_cast<byte*>(ptr), value.ptr, wholeByteSize);
         auto leftoverBits =
           (upgradeBound<uint64_t>(value.elementCount) * value.step) % (BYTES * BITS_PER_BYTE);


### PR DESCRIPTION
Fixes #429.

I've not yet been able to figure out how to get this to pass the `-DCAPNP_DEBUG_TYPES` analysis. @kentonv, maybe you can help me with that?