### PR TITLE
adjust AnyList::equals(): a list of pointers cannot be equal to a struct list

### DIFF
--- a/c++/src/capnp/any-test.c++
+++ b/c++/src/capnp/any-test.c++
@@ -377,6 +377,31 @@ KJ_TEST("Bit list with nonzero pad bits") {
   KJ_ASSERT(message1.getRoot<AnyList>() == message2.getRoot<AnyList>());
 }
 
+KJ_TEST("Pointer list unequal to struct list") {
+  AlignedData<2> segment1 = {{
+      // list with zero pointer-sized elements
+      0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  }};
+  kj::ArrayPtr<const word> segments1[1] = {
+    kj::arrayPtr(segment1.words, 2)
+  };
+  SegmentArrayMessageReader message1(kj::arrayPtr(segments1, 1));
+
+  AlignedData<2> segment2 = {{
+      // struct list of length zero
+      0x01, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+
+      // struct list tag, zero elements
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  }};
+  kj::ArrayPtr<const word> segments2[1] = {
+    kj::arrayPtr(segment2.words, 2)
+  };
+  SegmentArrayMessageReader message2(kj::arrayPtr(segments2, 1));
+
+  EXPECT_EQ(Equality::NOT_EQUAL, message1.getRoot<AnyList>().equals(message2.getRoot<AnyList>()));
+}
+
 }  // namespace
 }  // namespace _ (private)
 }  // namespace capnp

--- a/c++/src/capnp/any.c++
+++ b/c++/src/capnp/any.c++
@@ -141,6 +141,11 @@ Equality AnyList::Reader::equals(AnyList::Reader right) {
   if(size() != right.size()) {
     return Equality::NOT_EQUAL;
   }
+
+  if (getElementSize() != right.getElementSize()) {
+    return Equality::NOT_EQUAL;
+  }
+
   auto eqResult = Equality::EQUAL;
   switch(getElementSize()) {
     case ElementSize::VOID:
@@ -149,10 +154,6 @@ Equality AnyList::Reader::equals(AnyList::Reader right) {
     case ElementSize::TWO_BYTES:
     case ElementSize::FOUR_BYTES:
     case ElementSize::EIGHT_BYTES: {
-      if (getElementSize() != right.getElementSize()) {
-        return Equality::NOT_EQUAL;
-      }
-
       size_t cmpSize = getRawBytes().size();
 
       if (getElementSize() == ElementSize::BIT && size() % 8 != 0) {


### PR DESCRIPTION
I think the most sensible definition of equality is: two values are equal if and only if they canonicalize to exactly the same bytes.

This patch fixes a case where are current implementation of equality does not match that definition.