### PR TITLE
Allow MSVC to build capnp command line tools

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,8 @@
 #     support for.
 #   - Use CMake to ...
 #       build Cap'n Proto with MinGW.
-#       build Cap'n Proto with VS2015 and the MinGW-built capnp tools.
-#       build the Cap'n Proto samples with VS2015 and the MinGW-built capnp tools.
-#   - Archive both Cap'n Proto builds in capnproto-c++-{mingw,vs2015}.zip artifacts.
+#       build Cap'n Proto with VS2015.
+#       build Cap'n Proto samples with VS2015.
 
 version: "{build}"
 
@@ -52,21 +51,20 @@ build_script:
       -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
       -DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX_MINGW%
   - cmake --build build-mingw --target install -- -j%NUMBER_OF_PROCESSORS%
-  - set PATH=%INSTALL_PREFIX_MINGW%\bin;%PATH%
+
   - echo "Building Cap'n Proto with Visual Studio 2015"
   - >-
       cmake -Hc++ -Bbuild-vs2015 -G "Visual Studio 14 2015" -A x64
-      -DEXTERNAL_CAPNP=ON
       -DCMAKE_INSTALL_PREFIX=%INSTALL_PREFIX_VS2015%
   - cmake --build build-vs2015 --config %BUILD_TYPE% --target install
   # TODO(someday): pass `-- /maxcpucount` for a parallel build. Right now it occasionally expresses
   # a filesystem-related race: capnp-capnpc++ complains that it can't create test.capnp.h.
+
+  - echo "Building Cap'n Proto samples with Visual Studio 2015"
   - >-
-      cmake -Hc++/samples -Bbuild-samples -G "Visual Studio 14 2015" -A x64
+      cmake -Hc++/samples -Bbuild-vs2015-samples -G "Visual Studio 14 2015" -A x64
       -DCMAKE_PREFIX_PATH=%INSTALL_PREFIX_VS2015%
-      -DCAPNP_EXECUTABLE=%INSTALL_PREFIX_MINGW%\bin\capnp.exe
-      -DCAPNPC_CXX_EXECUTABLE=%INSTALL_PREFIX_MINGW%\bin\capnpc-c++.exe
-  - cmake --build build-samples --config %BUILD_TYPE%
+  - cmake --build build-vs2015-samples --config %BUILD_TYPE%
 
 # TODO(soon): Fix tests on Windows.
 #

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -29,29 +29,9 @@ option(BUILD_TESTING "Build unit tests and enable CTest 'check' target." ON)
 option(EXTERNAL_CAPNP "Use the system capnp binary, or the one specified in $CAPNP, instead of using the compiled one." OFF)
 option(CAPNP_LITE "Compile Cap'n Proto in 'lite mode', in which all reflection APIs (schema.h, dynamic.h, etc.) are not included. Produces a smaller library at the cost of features. All programs built against the library must be compiled with -DCAPNP_LITE. Requires EXTERNAL_CAPNP." OFF)
 
-if(MSVC)
-  option(CAPNP_BUILD_TOOLS "Build Cap'n Proto tools" OFF)
-else()
-  option(CAPNP_BUILD_TOOLS "Build Cap'n Proto tools" ON)
-endif()
-mark_as_advanced(CAPNP_BUILD_TOOLS)
-# TODO(msvc):  This option exists purely to ease the MSVC port. As of this writing, the latest
-# stable version of Visual C++ (VS2015U3) cannot build the Cap'n Proto tools, so this option
-# defaults to OFF in that case. In all other cases it defaults to ON.
-
 # Check for invalid combinations of build options
 if(CAPNP_LITE AND BUILD_TESTING AND NOT EXTERNAL_CAPNP)
   message(SEND_ERROR "You must set EXTERNAL_CAPNP when using CAPNP_LITE and BUILD_TESTING.")
-endif()
-
-if(NOT CAPNP_BUILD_TOOLS AND BUILD_TESTING AND NOT EXTERNAL_CAPNP)
-  message(SEND_ERROR "You must set EXTERNAL_CAPNP when using BUILD_TESTING but not CAPNP_BUILD_TOOLS")
-  if(MSVC)
-    message(SEND_ERROR "Note: CAPNP_BUILD_TOOLS is off because you are using MSVC, which cannot build the tools")
-    # If we're using MSVC, then we know the reason why CAPNP_BUILD_TOOLS is off and should help the
-    # user out. If we're NOT using MSVC, then the user must have explicitly set CAPNP_BUILD_TOOLS
-    # off, so they're on their own.
-  endif()
 endif()
 
 if(CAPNP_LITE)

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -44,6 +44,14 @@ endif()
 if(MSVC)
   # TODO(cleanup): Enable higher warning level in MSVC, but make sure to test
   #   build with that warning level and clean out false positives.
+
+  add_compile_options(/wo4503)
+  # Only warn once on truncated decorated names. The maximum symbol length MSVC
+  # supports is 4k characters, which the parser framework regularly blows. The
+  # compiler likes to print out the entire type that went over the limit along
+  # with this warning, which gets unbearably spammy. That said, we don't want to
+  # just ignore it, so I'm letting it trigger once until we find some places to
+  # inject ParserRefs.
 else()
   # Note that it's important to add new CXXFLAGS before ones specified by the
   # user, so that the user's flags override them. This is particularly

--- a/c++/cmake/CapnProtoConfig.cmake.in
+++ b/c++/cmake/CapnProtoConfig.cmake.in
@@ -12,10 +12,8 @@
 
 set(CapnProto_VERSION @VERSION@)
 
-if(@CAPNP_BUILD_TOOLS@)
-  set(CAPNP_EXECUTABLE $<TARGET_FILE:CapnProto::capnp_tool>)
-  set(CAPNPC_CXX_EXECUTABLE $<TARGET_FILE:CapnProto::capnpc_cpp>)
-endif()
+set(CAPNP_EXECUTABLE $<TARGET_FILE:CapnProto::capnp_tool>)
+set(CAPNPC_CXX_EXECUTABLE $<TARGET_FILE:CapnProto::capnpc_cpp>)
 set(CAPNP_INCLUDE_DIRECTORY "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@")
 
 # work around http://public.kitware.com/Bug/view.php?id=15258

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -124,60 +124,58 @@ endif()
 
 # Tools/Compilers ==============================================================
 
-if(CAPNP_BUILD_TOOLS)
-  set(capnpc_sources
-    compiler/md5.c++
-    compiler/error-reporter.c++
-    compiler/lexer.capnp.c++
-    compiler/lexer.c++
-    compiler/grammar.capnp.c++
-    compiler/parser.c++
-    compiler/node-translator.c++
-    compiler/compiler.c++
-    schema-parser.c++
-    serialize-text.c++
+set(capnpc_sources
+  compiler/md5.c++
+  compiler/error-reporter.c++
+  compiler/lexer.capnp.c++
+  compiler/lexer.c++
+  compiler/grammar.capnp.c++
+  compiler/parser.c++
+  compiler/node-translator.c++
+  compiler/compiler.c++
+  schema-parser.c++
+  serialize-text.c++
+)
+if(NOT CAPNP_LITE)
+  add_library(capnpc ${capnpc_sources})
+  target_link_libraries(capnpc capnp kj)
+  install(TARGETS capnpc ${INSTALL_TARGETS_DEFAULT_ARGS})
+  install(FILES ${capnpc_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
+endif()
+
+if(NOT CAPNP_LITE)
+  add_executable(capnp_tool
+    compiler/module-loader.c++
+    compiler/capnp.c++
   )
-  if(NOT CAPNP_LITE)
-    add_library(capnpc ${capnpc_sources})
-    target_link_libraries(capnpc capnp kj)
-    install(TARGETS capnpc ${INSTALL_TARGETS_DEFAULT_ARGS})
-    install(FILES ${capnpc_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/capnp")
-  endif()
+  target_link_libraries(capnp_tool capnpc capnp kj)
+  set_target_properties(capnp_tool PROPERTIES OUTPUT_NAME capnp)
+  set_target_properties(capnp_tool PROPERTIES CAPNP_INCLUDE_DIRECTORY
+    $<JOIN:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>,$<INSTALL_INTERFACE:${CMAKE_INSTALL_BINDIR}/..>>
+  )
 
-  if(NOT CAPNP_LITE)
-    add_executable(capnp_tool
-      compiler/module-loader.c++
-      compiler/capnp.c++
-    )
-    target_link_libraries(capnp_tool capnpc capnp kj)
-    set_target_properties(capnp_tool PROPERTIES OUTPUT_NAME capnp)
-    set_target_properties(capnp_tool PROPERTIES CAPNP_INCLUDE_DIRECTORY
-      $<JOIN:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>,$<INSTALL_INTERFACE:${CMAKE_INSTALL_BINDIR}/..>>
-    )
+  add_executable(capnpc_cpp
+    compiler/capnpc-c++.c++
+  )
+  target_link_libraries(capnpc_cpp capnp kj)
+  set_target_properties(capnpc_cpp PROPERTIES OUTPUT_NAME capnpc-c++)
+  #Capnp tool needs capnpc_cpp location. But cmake deprecated LOCATION property.
+  #So we use custom property to pass location
+  set_target_properties(capnpc_cpp PROPERTIES CAPNPC_CXX_EXECUTABLE
+    $<TARGET_FILE:capnpc_cpp>
+  )
 
-    add_executable(capnpc_cpp
-      compiler/capnpc-c++.c++
-    )
-    target_link_libraries(capnpc_cpp capnp kj)
-    set_target_properties(capnpc_cpp PROPERTIES OUTPUT_NAME capnpc-c++)
-    #Capnp tool needs capnpc_cpp location. But cmake deprecated LOCATION property.
-    #So we use custom property to pass location
-    set_target_properties(capnpc_cpp PROPERTIES CAPNPC_CXX_EXECUTABLE
-      $<TARGET_FILE:capnpc_cpp>
-    )
+  add_executable(capnpc_capnp
+    compiler/capnpc-capnp.c++
+  )
+  target_link_libraries(capnpc_capnp capnp kj)
+  set_target_properties(capnpc_capnp PROPERTIES OUTPUT_NAME capnpc-capnp)
 
-    add_executable(capnpc_capnp
-      compiler/capnpc-capnp.c++
-    )
-    target_link_libraries(capnpc_capnp capnp kj)
-    set_target_properties(capnpc_capnp PROPERTIES OUTPUT_NAME capnpc-capnp)
+  install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 
-    install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
-
-    # Symlink capnpc -> capnp
-    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc\")")
-  endif()  # NOT CAPNP_LITE
-endif()  # CAPNP_BUILD_TOOLS
+  # Symlink capnpc -> capnp
+  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc\")")
+endif()  # NOT CAPNP_LITE
 
 # Tests ========================================================================
 
@@ -195,12 +193,10 @@ if(BUILD_TESTING)
 
   capnp_generate_cpp(test_capnp_cpp_files test_capnp_h_files ${test_capnp_files})
 
-  set(test_libraries capnp kj-test kj)
-  if(NOT CAPNP_LITE)
-    list(APPEND test_libraries capnp-json capnp-rpc kj-async)
-  endif()
-  if(CAPNP_BUILD_TOOLS)
-    list(APPEND test_libraries capnpc)
+  if(CAPNP_LITE)
+    set(test_libraries capnp kj-test kj)
+  else()
+    set(test_libraries capnp-json capnp-rpc capnp capnpc kj-async kj-test kj)
   endif()
 
   add_executable(capnp-tests
@@ -232,12 +228,16 @@ if(BUILD_TESTING)
       membrane-test.c++
       schema-test.c++
       schema-loader-test.c++
+      schema-parser-test.c++
       dynamic-test.c++
       stringify-test.c++
       serialize-async-test.c++
+      serialize-text-test.c++
       rpc-test.c++
       rpc-twoparty-test.c++
       ez-rpc-test.c++
+      compiler/lexer-test.c++
+      compiler/md5-test.c++
       test-util.c++
       compat/json-test.c++
       ${test_capnp_cpp_files}
@@ -253,29 +253,9 @@ if(BUILD_TESTING)
     add_dependencies(check capnp-heavy-tests)
     add_test(NAME capnp-heavy-tests-run COMMAND capnp-heavy-tests)
 
-    if(CAPNP_BUILD_TOOLS)
-      add_executable(capnp-parse-tests
-        schema-parser-test.c++
-        serialize-text-test.c++
-        compiler/md5-test.c++
-        compiler/lexer-test.c++
-        test-util.c++
-        ${test_capnp_cpp_files}
-        ${test_capnp_h_files}
-      )
-      target_link_libraries(capnp-parse-tests ${test_libraries})
-      if(NOT MSVC)
-        set_target_properties(capnp-parse-tests
-          PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations"
-        )
-      endif()
-      add_dependencies(check capnp-parse-tests)
-      add_test(NAME capnp-parse-tests-run COMMAND capnp-parse-tests)
-
-      add_executable(capnp-evolution-tests compiler/evolution-test.c++)
-      target_link_libraries(capnp-evolution-tests capnpc capnp kj)
-      add_dependencies(check capnp-evolution-tests)
-      add_test(NAME capnp-evolution-tests-run COMMAND capnp-evolution-tests)
-    endif()  # CAPNP_BUILD_TOOLS
+    add_executable(capnp-evolution-tests compiler/evolution-test.c++)
+    target_link_libraries(capnp-evolution-tests capnpc capnp kj)
+    add_dependencies(check capnp-evolution-tests)
+    add_test(NAME capnp-evolution-tests-run COMMAND capnp-evolution-tests)
   endif()  # NOT CAPNP_LITE
 endif()  # BUILD_TESTING

--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -163,7 +163,7 @@ if(CAPNP_BUILD_TOOLS)
     #Capnp tool needs capnpc_cpp location. But cmake deprecated LOCATION property.
     #So we use custom property to pass location
     set_target_properties(capnpc_cpp PROPERTIES CAPNPC_CXX_EXECUTABLE
-      $<JOIN:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/capnpc-c++>,$<INSTALL_INTERFACE:${CMAKE_INSTALL_BINDIR}/capnpc-c++>>
+      $<TARGET_FILE:capnpc_cpp>
     )
 
     add_executable(capnpc_capnp

--- a/c++/src/capnp/compiler/module-loader.c++
+++ b/c++/src/capnp/compiler/module-loader.c++
@@ -57,7 +57,7 @@ protected:
   }
 };
 
-constexpr MmapDisposer mmapDisposer = MmapDisposer();
+KJ_CONSTEXPR(static const) MmapDisposer mmapDisposer = MmapDisposer();
 
 kj::Array<const byte> mmapForRead(kj::StringPtr filename) {
   int fd;

--- a/c++/src/capnp/message.c++
+++ b/c++/src/capnp/message.c++
@@ -42,7 +42,7 @@ public:
   }
 #endif
 };
-static constexpr DummyCapTableReader dummyCapTableReader = DummyCapTableReader();
+static KJ_CONSTEXPR(const) DummyCapTableReader dummyCapTableReader = DummyCapTableReader();
 
 }  // namespace
 

--- a/c++/src/capnp/schema-parser.c++
+++ b/c++/src/capnp/schema-parser.c++
@@ -242,7 +242,7 @@ protected:
   }
 };
 
-constexpr MmapDisposer mmapDisposer = MmapDisposer();
+KJ_CONSTEXPR(static const) MmapDisposer mmapDisposer = MmapDisposer();
 
 static char* canonicalizePath(char* path) {
   // Taken from some old C code of mine.

--- a/c++/src/kj/CMakeLists.txt
+++ b/c++/src/kj/CMakeLists.txt
@@ -19,16 +19,12 @@ set(kj_sources_heavy
   units.c++
   refcount.c++
   string-tree.c++
-)
-set(kj-parse_sources
   parse/char.c++
 )
-set(kj_sources ${kj_sources_lite})
 if(NOT CAPNP_LITE)
-  list(APPEND kj_sources ${kj_sources_heavy})
-endif()
-if(CAPNP_BUILD_TOOLS)
-  list(APPEND kj_sources ${kj-parse_sources})
+  set(kj_sources ${kj_sources_lite} ${kj_sources_heavy})
+else()
+  set(kj_sources ${kj_sources_lite})
 endif()
 
 set(kj_headers
@@ -177,20 +173,12 @@ if(BUILD_TESTING)
       one-of-test.c++
       function-test.c++
       threadlocal-pthread-test.c++
+      parse/common-test.c++
+      parse/char-test.c++
       compat/http-test.c++
     )
     target_link_libraries(kj-heavy-tests kj-http kj-async kj-test kj)
     add_dependencies(check kj-heavy-tests)
     add_test(NAME kj-heavy-tests-run COMMAND kj-heavy-tests)
-
-    if(CAPNP_BUILD_TOOLS)
-      add_executable(kj-parse-tests
-        parse/common-test.c++
-        parse/char-test.c++
-      )
-      target_link_libraries(kj-parse-tests kj-test kj)
-      add_dependencies(check kj-parse-tests)
-      add_test(NAME kj-parse-tests-run COMMAND kj-parse-tests)
-    endif()  # CAPNP_BUILD_TOOLS
   endif()  # NOT CAPNP_LITE
 endif()  # BUILD_TESTING

--- a/c++/src/kj/array.c++
+++ b/c++/src/kj/array.c++
@@ -103,7 +103,5 @@ void HeapArrayDisposer::disposeImpl(
   }
 }
 
-const HeapArrayDisposer HeapArrayDisposer::instance = HeapArrayDisposer();
-
 }  // namespace _ (private)
 }  // namespace kj

--- a/c++/src/kj/array.h
+++ b/c++/src/kj/array.h
@@ -261,8 +261,12 @@ public:
   static T* allocate(size_t count);
   template <typename T>
   static T* allocateUninitialized(size_t count);
-
-  static const HeapArrayDisposer instance;
+  static const HeapArrayDisposer& instance() {
+    // TODO(msvc): Replace this function with just a constexpr variable when MSVC initializes
+    //   constexpr vtable pointers correctly.
+    static HeapArrayDisposer disposer;
+    return disposer;
+  }
 
 private:
   static void* allocateImpl(size_t elementSize, size_t elementCount, size_t capacity,
@@ -285,7 +289,7 @@ inline Array<T> heapArray(size_t size) {
   // Much like `heap<T>()` from memory.h, allocates a new array on the heap.
 
   return Array<T>(_::HeapArrayDisposer::allocate<T>(size), size,
-                  _::HeapArrayDisposer::instance);
+                  _::HeapArrayDisposer::instance());
 }
 
 template <typename T> Array<T> heapArray(const T* content, size_t size);
@@ -474,7 +478,7 @@ inline ArrayBuilder<T> heapArrayBuilder(size_t size) {
   // manually by calling `add()`.
 
   return ArrayBuilder<T>(_::HeapArrayDisposer::allocateUninitialized<RemoveConst<T>>(size),
-                         size, _::HeapArrayDisposer::instance);
+                         size, _::HeapArrayDisposer::instance());
 }
 
 // =======================================================================================

--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -133,12 +133,12 @@ public:
   template <typename Other>
   constexpr ParserRef(Other&& other)
       : parser(&other), wrapper(&wrapperImplInstance<Decay<Other>>()) {
-    static_assert(kj::isReference<Other>(), "ParseRef should not be assigned to a temporary.");
+    static_assert(kj::isReference<Other>(), "ParserRef should not be assigned to a temporary.");
   }
 
   template <typename Other>
   inline ParserRef& operator=(Other&& other) {
-    static_assert(kj::isReference<Other>(), "ParseRef should not be assigned to a temporary.");
+    static_assert(kj::isReference<Other>(), "ParserRef should not be assigned to a temporary.");
     parser = &other;
     wrapper = &wrapperImplInstance<Decay<Other>>();
     return *this;

--- a/c++/src/kj/parse/common.h
+++ b/c++/src/kj/parse/common.h
@@ -45,6 +45,9 @@
 #include "../array.h"
 #include "../tuple.h"
 #include "../vector.h"
+#if _MSC_VER
+#include <type_traits>  // result_of_t
+#endif
 
 namespace kj {
 namespace parse {
@@ -100,7 +103,15 @@ private:
 template <typename T> struct OutputType_;
 template <typename T> struct OutputType_<Maybe<T>> { typedef T Type; };
 template <typename Parser, typename Input>
-using OutputType = typename OutputType_<decltype(instance<Parser&>()(instance<Input&>()))>::Type;
+using OutputType = typename OutputType_<
+#if _MSC_VER
+    std::result_of_t<Parser(Input)>
+    // The instance<T&>() based version below results in:
+    //   C2064: term does not evaluate to a function taking 1 arguments
+#else
+    decltype(instance<Parser&>()(instance<Input&>()))
+#endif
+    >::Type;
 // Synonym for the output type of a parser, given the parser type and the input type.
 
 // =======================================================================================

--- a/c++/src/kj/string.c++
+++ b/c++/src/kj/string.c++
@@ -106,14 +106,14 @@ template <> float StringPtr::parseAs<float>() const { return parseDouble(*this);
 String heapString(size_t size) {
   char* buffer = _::HeapArrayDisposer::allocate<char>(size + 1);
   buffer[size] = '\0';
-  return String(buffer, size, _::HeapArrayDisposer::instance);
+  return String(buffer, size, _::HeapArrayDisposer::instance());
 }
 
 String heapString(const char* value, size_t size) {
   char* buffer = _::HeapArrayDisposer::allocate<char>(size + 1);
   memcpy(buffer, value, size);
   buffer[size] = '\0';
-  return String(buffer, size, _::HeapArrayDisposer::instance);
+  return String(buffer, size, _::HeapArrayDisposer::instance());
 }
 
 #define HEXIFY_INT(type, format) \


### PR DESCRIPTION
This PR:

- Works around a couple run-of-the-mill MSVC bugs.
- Fixes a static initialization order issue that caused `kj-heavy-tests.exe` to crash (87b7d79).
- Works around the MSVC-doesn't-initialize-constexpr-vtable-pointers bug. For the `ParserRef` workaround, I also had to take some care to avoid the static initialization order fiasco.
- Fixes an error that prevented `capnpc-c++` from being located correctly by CMake.
- Removes the CAPNP_BUILD_TOOLS CMake option.

@kentonv, the static initialization order issues are unfortunate here. :( In general, any use of the `Disposer::instance`-style idiom risks a crash, unless they can be made constexpr. Since all of the variables in question in this PR have vtables, they cannot be made constexpr lest MSVC generate incomplete code. If you worry about dynamic initializers bleeding performance, we could add some `#ifdef` logic to allow constexpr variables to be used by compilers which compile correctly.