### PR TITLE
Add CMakeLists.txt to top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(c++)


### PR DESCRIPTION
This makes it easy to use capnproto using in source builds using git submodules. Currently once you checkout capnproto as a submodule and want to integrate it into an existing CMake build, the missing CMakeLists.txt in the base capnproto directory causes things to not work. If you would like to address this usecase via other means please let me know and I would be happy to rework the commit. For instance we could pull out the project definition in the CMakeLists.txt under c++ directory to the top level.