### PR TITLE
Fix MSVC build error when using List<T> with generic T

### DIFF
--- a/c++/src/capnp/common.h
+++ b/c++/src/capnp/common.h
@@ -161,15 +161,19 @@ inline constexpr Kind kind() {
   return k;
 }
 
-#if CAPNP_LITE
+#if _MSC_VER
 
 #define CAPNP_KIND(T) ::capnp::_::Kind_<T>::kind
-// Avoid constexpr methods in lite mode (MSVC is bad at constexpr).
+// Avoid constexpr methods in MSVC (it remains buggy in many situations).
 
-#else  // CAPNP_LITE
+#else  // _MSC_VER
 
 #define CAPNP_KIND(T) ::capnp::kind<T>()
-// Use this macro rather than kind<T>() in any code which must work in lite mode.
+// Use this macro rather than kind<T>() in any code which must work in MSVC.
+
+#endif  // _MSC_VER, else
+
+#if !CAPNP_LITE
 
 template <typename T, Kind k = kind<T>()>
 inline constexpr Style style() {
@@ -178,7 +182,7 @@ inline constexpr Style style() {
        : k == Kind::INTERFACE ? Style::CAPABILITY : Style::POINTER;
 }
 
-#endif  // CAPNP_LITE, else
+#endif  // !CAPNP_LITE
 
 template <typename T, Kind k = CAPNP_KIND(T)>
 struct List;

--- a/c++/src/capnp/compiler/capnpc-c++.c++
+++ b/c++/src/capnp/compiler/capnpc-c++.c++
@@ -494,7 +494,7 @@ private:
             case schema::Type::AnyPointer::Unconstrained::LIST:
               return CppTypeName::makePrimitive(" ::capnp::AnyList");
             case schema::Type::AnyPointer::Unconstrained::CAPABILITY:
-              hasInterfaces = true;  // Probably need to #inculde <capnp/capability.h>.
+              hasInterfaces = true;  // Probably need to #include <capnp/capability.h>.
               return CppTypeName::makePrimitive(" ::capnp::Capability");
           }
           KJ_UNREACHABLE;
@@ -682,12 +682,12 @@ private:
     kj::StringTree dependencies;
     size_t dependencyCount;
     // TODO(msvc):  `dependencyCount` is the number of individual dependency definitions in
-    // `dependencies`. It's a hack to allow makeGenericDefinitions to hard-code the size of the
-    // `_capnpPrivate::brandDependencies` array into the definition of
-    // `_capnpPrivate::specificBrand::dependencyCount`. This is necessary because MSVC cannot deduce
-    // the size of `brandDependencies` if it is nested under a class template. It's probably this
-    // demoralizingly deferred bug:
-    // https://connect.microsoft.com/VisualStudio/feedback/details/759407/can-not-get-size-of-static-array-defined-in-class-template
+    //   `dependencies`. It's a hack to allow makeGenericDefinitions to hard-code the size of the
+    //   `_capnpPrivate::brandDependencies` array into the definition of
+    //   `_capnpPrivate::specificBrand::dependencyCount`. This is necessary because MSVC cannot
+    //   deduce the size of `brandDependencies` if it is nested under a class template. It's
+    //   probably this demoralizingly deferred bug:
+    //   https://connect.microsoft.com/VisualStudio/feedback/details/759407/can-not-get-size-of-static-array-defined-in-class-template
   };
 
   BrandInitializerText makeBrandInitializers(

--- a/c++/src/capnp/test.capnp
+++ b/c++/src/capnp/test.capnp
@@ -537,6 +537,9 @@ struct TestGenerics(Foo, Bar) {
     }
   }
 
+  list @4 :List(Inner);
+  # At one time this failed to compile with MSVC due to poor expression SFINAE support.
+
   struct Inner {
     foo @0 :Foo;
     bar @1 :Bar;


### PR DESCRIPTION
Issue #479 turns out to be a run-of-the-mill expression SFINAE / constexpr problem in MSVC. This PR:

- Adds the offending case to `test.capnp`.
- Fixes it by reverting the definition of `CAPNP_KIND(T)` back to the lite mode way of doing it.
- Sneaks in a couple comment improvements in `capnpc++.c++`, unrelated to the problem at hand.